### PR TITLE
feat(stdlib): add Unleash feature flag management module

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,147 +1,316 @@
 # AGENTS.md
 
-## Proposal-First Rule (CRITICAL)
+## Skills & Rules
 
-NEVER create or modify project files without explicit approval. Always:
+For coding practices, commit hygiene, and workflow rules, install from
+[agent-skills](https://github.com/developerinlondon/agent-skills):
 
-1. PROPOSE the change (what, why, which files)
-2. WAIT for approval
-3. IMPLEMENT only after approval
+```bash
+npx skills add developerinlondon/agent-skills
+```
 
-Exceptions: bug fixes in already-approved work, read-only research, formatting.
+Key skills that apply to this project:
 
-## Team
+- **autonomous-workflow** — Proposal-first development, decision authority, commit hygiene
+- **code-quality** — Warnings-as-errors, no underscore prefixes, test coverage, type safety
 
-- **Nayeem Syed** - Project owner
-- **AI Agent** - Primary developer (Claude Opus, via OpenCode)
+## What is Assay
 
-## Project
-
-**Assay** - A lightweight, open-source deployment verification runner. Rust runtime + Lua 5.4
-scripting. Runs as an ArgoCD PostSync hook Job to verify deployments actually work.
+Lightweight Lua runtime for Kubernetes. Single ~9 MB static binary that replaces 50–250 MB
+Python/Node/kubectl containers in K8s Jobs.
 
 - **Repo**: [github.com/developerinlondon/assay](https://github.com/developerinlondon/assay)
-- **Image**: `ghcr.io/developerinlondon/assay` (scratch, target ~6MB)
-- **Landing**: assay.sbs (planned)
-- **Parent project**: [jeebon](https://github.com/jarvisai-run/jeebon) (B2B2C AI knowledge base)
+- **Image**: `ghcr.io/developerinlondon/assay:latest` (~6 MB compressed)
+- **Crate**: [crates.io/crates/assay-lua](https://crates.io/crates/assay-lua)
+- **Stack**: Rust (2024 edition), Tokio, Lua 5.5 (mlua), reqwest, clap, axum
 
-## Stack
+## Two Modes
 
-| Layer     | Component                                                           |
-| --------- | ------------------------------------------------------------------- |
-| Language  | Rust (2024 edition)                                                 |
-| Runtime   | Tokio (async)                                                       |
-| Scripting | Lua 5.4 via mlua 0.11.6 (`lua54`, `vendored`, `async`, `serialize`) |
-| HTTP      | reqwest 0.13.x (`json`, `rustls`, `query`)                          |
-| CLI       | clap 4.x (derive)                                                   |
-| Config    | serde_yml (YAML) + serde_json                                       |
-| Logging   | tracing + tracing-subscriber (stderr, env-filter)                   |
-| Errors    | anyhow                                                              |
-| CI/CD     | GitHub Actions -> ghcr.io                                           |
-| Container | Multi-stage Rust builder -> scratch                                 |
-
-## Architecture
-
+```bash
+assay script.lua     # Lua mode — run script with all builtins
+assay checks.yaml    # YAML mode — structured checks with retry/backoff/parallel
 ```
-+------------------------------------------------------------------+
-| assay binary (~5MB, statically linked, scratch image)            |
-|                                                                  |
-|  +------------------------------------------------------------+  |
-|  | Rust Core (tokio async runtime)                            |  |
-|  |                                                            |  |
-|  |  +-- Config parser (serde_yml) -- reads checks.yaml        |  |
-|  |  +-- CLI (clap) -- `assay checks.yaml` / `assay script.lua` |  |
-|  |  +-- Runner -- orchestrates checks, retries, timeouts      |  |
-|  |  +-- HTTP client (reqwest) -- async GET/POST               |  |
-|  |  +-- JSON engine (serde_json) -- parse + encode            |  |
-|  |  +-- Structured output -- JSON results to stdout           |  |
-|  |  +-- Exit code -- 0 (all pass) or 1 (any fail)             |  |
-|  +---------------------------+--------------------------------+  |
-|                              | exposed as Lua builtins           |
-|  +---------------------------v--------------------------------+  |
-|  | Lua 5.4 VM (mlua, sandboxed -- os/io/debug/load removed)  |  |
-|  |                                                            |  |
-|  |  http.get/post, json.parse/encode, prometheus.query        |  |
-|  |  assert.{eq,gt,lt,contains,not_nil,matches}                |  |
-|  |  log.{info,warn,error}, env.get, sleep                     |  |
-|  +------------------------------------------------------------+  |
-+------------------------------------------------------------------+
+
+## Using Assay in Kubernetes
+
+```yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: configure-service
+  annotations:
+    argocd.argoproj.io/hook: PostSync
+spec:
+  template:
+    spec:
+      containers:
+        - name: configure
+          image: ghcr.io/developerinlondon/assay:latest
+          command: ["assay", "/scripts/configure.lua"]
+          volumeMounts:
+            - name: scripts
+              mountPath: /scripts
+          env:
+            - name: SERVICE_URL
+              value: "http://my-service:8080"
+            - name: API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: my-service-credentials
+                  key: admin_api_token
+      volumes:
+        - name: scripts
+          configMap:
+            name: postsync-scripts
+      restartPolicy: Never
+```
+
+## Built-in Globals
+
+Available in all `.lua` scripts — no `require` needed:
+
+| Category | Functions |
+|----------|-----------|
+| HTTP | `http.get(url, opts?)`, `http.post(url, body, opts?)`, `http.put(url, body, opts?)`, `http.patch(url, body, opts?)`, `http.delete(url, opts?)`, `http.serve(port, routes)` |
+| JSON/YAML/TOML | `json.parse(str)`, `json.encode(tbl)`, `yaml.parse(str)`, `yaml.encode(tbl)`, `toml.parse(str)`, `toml.encode(tbl)` |
+| Filesystem | `fs.read(path)`, `fs.write(path, str)` |
+| Crypto | `crypto.jwt_sign(claims, key, alg, opts?)`, `crypto.hash(str, alg)`, `crypto.hmac(key, data, alg?, raw?)`, `crypto.random(len)` |
+| Base64 | `base64.encode(str)`, `base64.decode(str)` |
+| Regex | `regex.match(pat, str)`, `regex.find(pat, str)`, `regex.find_all(pat, str)`, `regex.replace(pat, str, repl)` |
+| Database | `db.connect(url)`, `db.query(conn, sql, params?)`, `db.execute(conn, sql, params?)`, `db.close(conn)` |
+| WebSocket | `ws.connect(url)`, `ws.send(conn, msg)`, `ws.recv(conn)`, `ws.close(conn)` |
+| Templates | `template.render(path, vars)`, `template.render_string(tmpl, vars)` |
+| Async | `async.spawn(fn)`, `async.spawn_interval(fn, ms)`, `handle:await()`, `handle:cancel()` |
+| Assert | `assert.eq(a, b, msg?)`, `assert.gt(a, b, msg?)`, `assert.lt(a, b, msg?)`, `assert.contains(str, sub, msg?)`, `assert.not_nil(val, msg?)`, `assert.matches(str, pat, msg?)` |
+| Logging | `log.info(msg)`, `log.warn(msg)`, `log.error(msg)` |
+| Utilities | `env.get(key)`, `sleep(secs)`, `time()` |
+
+HTTP responses: `{status, body, headers}`. Options: `{headers = {["X-Key"] = "val"}}`.
+
+## Stdlib Modules
+
+23 embedded Lua modules loaded via `require("assay.<name>")`:
+
+| Module | Description |
+|--------|-------------|
+| `assay.prometheus` | Query metrics, alerts, targets, rules, label values, series |
+| `assay.alertmanager` | Manage alerts, silences, receivers, config |
+| `assay.loki` | Push logs, query, labels, series |
+| `assay.grafana` | Health, dashboards, datasources, annotations |
+| `assay.k8s` | 30+ resource types, CRDs, readiness checks |
+| `assay.argocd` | Apps, sync, health, projects, repositories |
+| `assay.kargo` | Stages, freight, promotions, verification |
+| `assay.flux` | GitRepositories, Kustomizations, HelmReleases |
+| `assay.traefik` | Routers, services, middlewares, entrypoints |
+| `assay.vault` | KV secrets, policies, auth, transit, PKI |
+| `assay.openbao` | Alias for vault (API-compatible) |
+| `assay.certmanager` | Certificates, issuers, ACME challenges |
+| `assay.eso` | ExternalSecrets, SecretStores, ClusterSecretStores |
+| `assay.dex` | OIDC discovery, JWKS, health |
+| `assay.crossplane` | Providers, XRDs, compositions, managed resources |
+| `assay.velero` | Backups, restores, schedules, storage locations |
+| `assay.temporal` | Workflows, task queues, schedules |
+| `assay.harbor` | Projects, repositories, artifacts, vulnerability scanning |
+| `assay.healthcheck` | HTTP checks, JSON path, body matching, latency, multi-check |
+| `assay.s3` | S3-compatible storage (AWS, R2, MinIO) with Sig V4 |
+| `assay.postgres` | Postgres-specific helpers |
+| `assay.zitadel` | OIDC identity management with JWT machine auth |
+| `assay.unleash` | Feature flags: projects, environments, features, strategies, API tokens |
+
+### Client Pattern
+
+Every stdlib module follows the same structure:
+
+```lua
+local grafana = require("assay.grafana")
+local c = grafana.client("http://grafana:3000", { api_key = "glsa_..." })
+local h = c:health()
+assert.eq(h.database, "ok")
+```
+
+1. `require("assay.<name>")` returns module table `M`
+2. `M.client(url, opts?)` creates a client with auth config
+3. Client methods use `c:method()` (colon = implicit self)
+4. Errors raised via `error()` — use `pcall()` to catch
+
+Auth varies by service: `{ token = "..." }`, `{ api_key = "..." }`, `{ username = "...", password = "..." }`.
+
+## Adding a New Stdlib Module
+
+No Rust changes needed. Modules are auto-discovered via `include_dir!("$CARGO_MANIFEST_DIR/stdlib")`
+in `src/lua/mod.rs`.
+
+### 1. Create `stdlib/<name>.lua`
+
+Follow the client pattern. Reference `grafana.lua` (simple, 110 lines) or `vault.lua` (comprehensive,
+330 lines):
+
+```lua
+local M = {}
+
+function M.client(url, opts)
+  opts = opts or {}
+  local c = {
+    url = url:gsub("/+$", ""),
+    token = opts.token,
+  }
+
+  local function headers(self)
+    local h = { ["Content-Type"] = "application/json" }
+    if self.token then h["Authorization"] = "Bearer " .. self.token end
+    return h
+  end
+
+  local function api_get(self, path_str)
+    local resp = http.get(self.url .. path_str, { headers = headers(self) })
+    if resp.status ~= 200 then
+      error("<name>: GET " .. path_str .. " HTTP " .. resp.status .. ": " .. resp.body)
+    end
+    return json.parse(resp.body)
+  end
+
+  local function api_post(self, path_str, payload)
+    local resp = http.post(self.url .. path_str, payload, { headers = headers(self) })
+    if resp.status ~= 200 and resp.status ~= 201 then
+      error("<name>: POST " .. path_str .. " HTTP " .. resp.status .. ": " .. resp.body)
+    end
+    return json.parse(resp.body)
+  end
+
+  function c:health()
+    return api_get(self, "/api/health")
+  end
+
+  return c
+end
+
+return M
+```
+
+Conventions:
+
+- `api_get/api_post/api_put/api_delete` are local helpers, not exported
+- Error format: `"<module>: <METHOD> <path> HTTP <status>: <body>"`
+- Strip trailing slashes: `url:gsub("/+$", "")`
+- All HTTP uses builtins (`http.get`, `json.parse`) — no external requires
+- 404 = nil pattern: check `resp.status == 404`, return `nil`
+- Idempotent helpers go on `M` (module level), not on the client
+
+### 2. Create `tests/stdlib_<name>.rs`
+
+Wiremock-based tests. One test per client method:
+
+```rust
+mod common;
+
+use common::run_lua;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[tokio::test]
+async fn test_require_<name>() {
+    let script = r#"
+        local mod = require("assay.<name>")
+        assert.not_nil(mod)
+        assert.not_nil(mod.client)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_<name>_health() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/health"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "status": "OK"
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local mod = require("assay.<name>")
+        local c = mod.client("{}", {{ token = "test-token" }})
+        local h = c:health()
+        assert.eq(h.status, "OK")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+```
+
+Note: Lua tables in `format!` strings need doubled braces: `{{ key = "value" }}`.
+
+### 3. Update `README.md`
+
+Add the module to the stdlib table.
+
+### 4. Verify
+
+```bash
+cargo check && cargo clippy -- -D warnings && cargo test
 ```
 
 ## Directory Structure
 
 ```
 assay/
-+-- Cargo.toml
-+-- Cargo.lock
-+-- AGENTS.md              # This file
-+-- Dockerfile             # Multi-stage: rust builder -> scratch
-+-- src/
-|   +-- main.rs            # CLI entry point (clap)
-|   +-- config.rs          # YAML config parser (checks.yaml)
-|   +-- runner.rs          # Orchestrator: retries, backoff, timeout
-|   +-- output.rs          # Structured JSON results + exit code
-|   +-- checks/
-|   |   +-- mod.rs         # Check dispatcher
-|   |   +-- http.rs        # HTTP check type (YAML mode)
-|   |   +-- prometheus.rs  # Prometheus check type (YAML mode)
-|   |   +-- script.rs      # Lua script check type
-|   +-- lua/
-|       +-- mod.rs         # Lua 5.4 VM setup + sandbox
-|       +-- builtins.rs    # All builtin functions
-|       +-- async_bridge.rs# Async Lua execution
-+-- examples/              # Example check configs and Lua scripts
-+-- tests/                 # Integration test configs
-+-- .github/workflows/     # CI (release.yml)
-+-- .opencode/
-    +-- plans/             # Implementation plans
+├── Cargo.toml
+├── Cargo.lock
+├── AGENTS.md                 # This file
+├── Dockerfile                # Multi-stage: rust builder -> scratch
+├── src/
+│   ├── main.rs               # CLI entry point (clap)
+│   ├── lib.rs                # Library root (pub mod lua)
+│   ├── config.rs             # YAML config parser (checks.yaml)
+│   ├── runner.rs             # Orchestrator: retries, backoff, timeout
+│   ├── output.rs             # Structured JSON results + exit code
+│   ├── checks/
+│   │   ├── mod.rs            # Check dispatcher
+│   │   ├── http.rs           # HTTP check type (YAML mode)
+│   │   ├── prometheus.rs     # Prometheus check type (YAML mode)
+│   │   └── script.rs         # Lua script check type
+│   └── lua/
+│       ├── mod.rs            # VM setup, sandbox, stdlib loader (include_dir!)
+│       ├── async_bridge.rs   # Async Lua execution, shebang stripping
+│       └── builtins/
+│           ├── mod.rs        # register_all() — wires builtins into Lua globals
+│           ├── http.rs       # http.{get,post,put,patch,delete,serve}
+│           ├── json.rs       # json.{parse,encode}
+│           ├── serialization.rs  # yaml + toml parse/encode
+│           ├── core.rs       # env, sleep, time, fs, base64, regex, log, async
+│           ├── assert.rs     # assert.{eq,gt,lt,contains,not_nil,matches}
+│           ├── crypto.rs     # crypto.{jwt_sign,hash,hmac,random}
+│           ├── db.rs         # db.{connect,query,execute,close}
+│           ├── ws.rs         # ws.{connect,send,recv,close}
+│           └── template.rs   # template.{render,render_string}
+├── stdlib/                   # Embedded Lua modules (auto-discovered)
+│   ├── vault.lua             # Comprehensive reference (330 lines)
+│   ├── grafana.lua           # Simple reference (110 lines)
+│   └── ... (22 modules total)
+├── tests/
+│   ├── common/mod.rs         # Test helpers: run_lua(), create_vm(), eval_lua()
+│   ├── stdlib_vault.rs       # One test file per stdlib module
+│   └── ...
+└── examples/                 # Example scripts and check configs
 ```
+
+## Design Decisions (FINAL)
+
+| Decision | Choice | Reason |
+|----------|--------|--------|
+| Language runtime | Lua 5.5 | ArgoCD compatible, 30yr ecosystem, native int64, perf irrelevant for I/O |
+| Not Luau | Rejected | Lua 5.1 base, Roblox ecosystem, no int64 |
+| Not Rhai | Rejected | 6x slower, no async, no coroutines |
+| Not Wasmtime | Rejected | Requires compile step, bad for script iteration |
 
 ## Commands
 
 ```bash
 cargo check                        # Type check
 cargo clippy -- -D warnings        # Lint (warnings = errors)
-cargo test                         # Run tests
-cargo build --release              # Release build (~5MB)
-cargo build --release --target x86_64-unknown-linux-musl  # Static binary for Docker
+cargo test                         # Run all tests
+cargo build --release              # Release build (~9 MB)
 ```
-
-## Coding Practices
-
-1. **Proposal-First**: Analyze -> propose -> get approval -> implement
-2. **Warnings Are Errors**: `cargo clippy -- -D warnings` must pass. Fix ALL warnings.
-3. **No Underscore Prefix**: Never use `_variable` to silence linters -- use or remove it.
-4. **No Suppression**: No `#[allow(...)]`, `as any`, `@ts-ignore` equivalents.
-5. **Real Error Messages**: Use `anyhow::Context` for all fallible operations. No empty catch.
-6. **Test After Change**: Run `cargo check && cargo clippy -- -D warnings && cargo test` after
-   edits.
-7. **Latest Versions**: Check `cargo search <crate> --limit 1` before adding dependencies.
-8. **No Attribution Lines**: Never add `Co-authored-by`, `Ultraworked with`, or any AI agent
-   attribution to commits, PRs/MRs, comments, or changelogs. Keep commit messages clean.
-9. **Performance-Aware**: Every code change must consider performance impact. Avoid unnecessary
-   allocations, cloning, and copies. Prefer zero-cost abstractions. When adding new builtins or
-   modifying hot paths: reuse existing clients/connections (don't create per-request), use lazy
-   initialization for expensive resources, extract shared logic into helpers instead of duplicating
-   code. Profile before optimizing, but never introduce obviously wasteful patterns. The Rust core
-   must stay lean -- assay runs as short-lived K8s Jobs where startup time and memory matter.
-
-## Design Decisions (FINAL -- do not change)
-
-| Decision         | Choice   | Reason                                                                   |
-| ---------------- | -------- | ------------------------------------------------------------------------ |
-| Language runtime | Lua 5.4  | ArgoCD compatible, 30yr ecosystem, native int64, perf irrelevant for I/O |
-| Not Luau         | Rejected | Benchmark used JIT (unfair), Lua 5.1 base, Roblox ecosystem, no int64    |
-| Not Rhai         | Rejected | 6x slower, no async, no coroutines                                       |
-| Not Wasmtime     | Rejected | Fastest but requires compile step, bad for script iteration              |
-
-## Autonomous Operation
-
-### Deviation Rules
-
-- Rule 1: AUTO-FIX bugs -- wrong logic, type errors, null pointers, broken tests
-- Rule 2: AUTO-ADD missing safety -- error handling, input validation
-- Rule 3: AUTO-FIX blockers -- missing deps, broken imports
-- Rule 4: ASK about architecture -- new dependencies, changing APIs, new features
-
-Priority: Rule 4 (stop and ask) > Rules 1-3 (fix silently and note what you did).

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ Supported URLs:
 
 ## Stdlib Modules
 
-Assay embeds 22 Lua modules for Kubernetes-native operations. Use `require("assay.<module>")`:
+Assay embeds 23 Lua modules for Kubernetes-native operations. Use `require("assay.<module>")`:
 
 | Module               | Description                                                 |
 | -------------------- | ----------------------------------------------------------- |
@@ -322,6 +322,7 @@ Assay embeds 22 Lua modules for Kubernetes-native operations. Use `require("assa
 | `assay.harbor`       | Projects, repositories, artifacts, vulnerability scanning   |
 | `assay.healthcheck`  | HTTP checks, JSON path, body matching, latency, multi-check |
 | `assay.s3`           | S3-compatible storage (AWS, iDrive e2, R2, MinIO) — Sig V4  |
+| `assay.unleash`      | Feature flags: projects, environments, features, strategies, API tokens |
 
 Example:
 

--- a/stdlib/unleash.lua
+++ b/stdlib/unleash.lua
@@ -1,0 +1,262 @@
+local M = {}
+
+function M.client(url, opts)
+  opts = opts or {}
+  local c = {
+    url = url:gsub("/+$", ""),
+    token = opts.token,
+  }
+
+  local function headers(self)
+    local h = { ["Content-Type"] = "application/json" }
+    if self.token then h["Authorization"] = self.token end
+    return h
+  end
+
+  local function api_get(self, path_str)
+    local resp = http.get(self.url .. path_str, { headers = headers(self) })
+    if resp.status == 404 then return nil end
+    if resp.status ~= 200 then
+      error("unleash: GET " .. path_str .. " HTTP " .. resp.status .. ": " .. resp.body)
+    end
+    return json.parse(resp.body)
+  end
+
+  local function api_post(self, path_str, payload)
+    local resp = http.post(self.url .. path_str, payload, { headers = headers(self) })
+    if resp.status ~= 200 and resp.status ~= 201 then
+      error("unleash: POST " .. path_str .. " HTTP " .. resp.status .. ": " .. resp.body)
+    end
+    if resp.body and #resp.body > 0 then
+      return json.parse(resp.body)
+    end
+    return nil
+  end
+
+  local function api_put(self, path_str, payload)
+    local resp = http.put(self.url .. path_str, payload, { headers = headers(self) })
+    if resp.status ~= 200 then
+      error("unleash: PUT " .. path_str .. " HTTP " .. resp.status .. ": " .. resp.body)
+    end
+    if resp.body and #resp.body > 0 then
+      return json.parse(resp.body)
+    end
+    return nil
+  end
+
+  local function api_delete(self, path_str)
+    local resp = http.delete(self.url .. path_str, { headers = headers(self) })
+    if resp.status ~= 200 then
+      error("unleash: DELETE " .. path_str .. " HTTP " .. resp.status .. ": " .. resp.body)
+    end
+    if resp.body and #resp.body > 0 then
+      return json.parse(resp.body)
+    end
+    return nil
+  end
+
+  -- Health
+
+  function c:health()
+    local resp = http.get(self.url .. "/health", { headers = headers(self) })
+    if resp.status ~= 200 then
+      error("unleash: GET /health HTTP " .. resp.status .. ": " .. resp.body)
+    end
+    return json.parse(resp.body)
+  end
+
+  -- Projects
+
+  function c:projects()
+    local data = api_get(self, "/api/admin/projects")
+    if not data then return {} end
+    return data.projects or {}
+  end
+
+  function c:project(id)
+    return api_get(self, "/api/admin/projects/" .. id)
+  end
+
+  function c:create_project(project)
+    return api_post(self, "/api/admin/projects", project)
+  end
+
+  function c:update_project(id, project)
+    return api_put(self, "/api/admin/projects/" .. id, project)
+  end
+
+  function c:delete_project(id)
+    return api_delete(self, "/api/admin/projects/" .. id)
+  end
+
+  -- Environments
+
+  function c:environments()
+    local data = api_get(self, "/api/admin/environments")
+    if not data then return {} end
+    return data.environments or {}
+  end
+
+  function c:enable_environment(project_id, env_name)
+    return api_post(self, "/api/admin/projects/" .. project_id .. "/environments", {
+      environment = env_name,
+    })
+  end
+
+  function c:disable_environment(project_id, env_name)
+    return api_delete(self, "/api/admin/projects/" .. project_id .. "/environments/" .. env_name)
+  end
+
+  -- Features
+
+  function c:features(project_id)
+    local data = api_get(self, "/api/admin/projects/" .. project_id .. "/features")
+    if not data then return {} end
+    return data.features or {}
+  end
+
+  function c:feature(project_id, name)
+    return api_get(self, "/api/admin/projects/" .. project_id .. "/features/" .. name)
+  end
+
+  function c:create_feature(project_id, feature)
+    return api_post(self, "/api/admin/projects/" .. project_id .. "/features", feature)
+  end
+
+  function c:update_feature(project_id, name, feature)
+    return api_put(self, "/api/admin/projects/" .. project_id .. "/features/" .. name, feature)
+  end
+
+  function c:archive_feature(project_id, name)
+    return api_delete(self, "/api/admin/projects/" .. project_id .. "/features/" .. name)
+  end
+
+  function c:toggle_on(project_id, name, env)
+    return api_post(self, "/api/admin/projects/" .. project_id .. "/features/" .. name .. "/environments/" .. env .. "/on", {})
+  end
+
+  function c:toggle_off(project_id, name, env)
+    return api_post(self, "/api/admin/projects/" .. project_id .. "/features/" .. name .. "/environments/" .. env .. "/off", {})
+  end
+
+  -- Strategies
+
+  function c:strategies(project_id, feature_name, env)
+    local data = api_get(self, "/api/admin/projects/" .. project_id .. "/features/" .. feature_name .. "/environments/" .. env .. "/strategies")
+    if not data then return {} end
+    if type(data) == "table" and data[1] then return data end
+    return data.strategies or data
+  end
+
+  function c:add_strategy(project_id, feature_name, env, strategy)
+    return api_post(self, "/api/admin/projects/" .. project_id .. "/features/" .. feature_name .. "/environments/" .. env .. "/strategies", strategy)
+  end
+
+  -- API Tokens
+
+  function c:tokens()
+    local data = api_get(self, "/api/admin/api-tokens")
+    if not data then return {} end
+    return data.tokens or {}
+  end
+
+  function c:create_token(token_config)
+    return api_post(self, "/api/admin/api-tokens", token_config)
+  end
+
+  function c:delete_token(secret)
+    return api_delete(self, "/api/admin/api-tokens/" .. secret)
+  end
+
+  return c
+end
+
+function M.wait(url, opts)
+  opts = opts or {}
+  local timeout = opts.timeout or 60
+  local interval = opts.interval or 2
+  local max_attempts = math.ceil(timeout / interval)
+
+  for i = 1, max_attempts do
+    local ok, resp = pcall(http.get, url .. "/health")
+    if ok and resp.status == 200 then
+      log.info("Unleash healthy after " .. tostring(i * interval) .. "s")
+      return true
+    end
+    if i == max_attempts then
+      error("unleash.wait: not reachable at " .. url .. " after " .. tostring(timeout) .. "s")
+    end
+    log.info("Waiting for Unleash... (" .. tostring(i) .. "/" .. tostring(max_attempts) .. ")")
+    sleep(interval)
+  end
+end
+
+function M.ensure_project(client, project_id, opts)
+  opts = opts or {}
+  local existing = client:project(project_id)
+  if existing then
+    log.info("Project already exists: " .. project_id)
+    return existing
+  end
+
+  local project = {
+    id = project_id,
+    name = opts.name or project_id,
+  }
+  if opts.description then
+    project.description = opts.description
+  end
+
+  local created = client:create_project(project)
+  log.info("Created project: " .. project_id)
+  return created
+end
+
+function M.ensure_environment(client, project_id, env_name)
+  local ok, err = pcall(client.enable_environment, client, project_id, env_name)
+  if ok then
+    log.info("Enabled environment " .. env_name .. " on project " .. project_id)
+    return true
+  end
+
+  if type(err) == "string" and (err:find("409") or err:find("already")) then
+    log.info("Environment " .. env_name .. " already enabled on project " .. project_id)
+    return true
+  end
+
+  error("unleash.ensure_environment: " .. tostring(err))
+end
+
+function M.ensure_token(client, opts)
+  assert.not_nil(opts.username, "unleash.ensure_token: opts.username is required")
+  assert.not_nil(opts.type, "unleash.ensure_token: opts.type is required")
+
+  local existing = client:tokens()
+  for _, t in ipairs(existing) do
+    local match = t.username == opts.username and t.type == opts.type
+    if match and opts.environment then
+      match = t.environment == opts.environment
+    end
+    if match then
+      log.info("Token already exists for " .. opts.username .. " (" .. opts.type .. ")")
+      return t
+    end
+  end
+
+  local token_config = {
+    username = opts.username,
+    type = opts.type,
+  }
+  if opts.environment then
+    token_config.environment = opts.environment
+  end
+  if opts.projects then
+    token_config.projects = opts.projects
+  end
+
+  local created = client:create_token(token_config)
+  log.info("Created token for " .. opts.username .. " (" .. opts.type .. ")")
+  return created
+end
+
+return M

--- a/tests/stdlib_unleash.rs
+++ b/tests/stdlib_unleash.rs
@@ -1,0 +1,808 @@
+mod common;
+
+use common::run_lua;
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[tokio::test]
+async fn test_require_unleash() {
+    let script = r#"
+        local unleash = require("assay.unleash")
+        assert.not_nil(unleash)
+        assert.not_nil(unleash.client)
+        assert.not_nil(unleash.wait)
+        assert.not_nil(unleash.ensure_project)
+        assert.not_nil(unleash.ensure_environment)
+        assert.not_nil(unleash.ensure_token)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_unleash_health() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/health"))
+        .and(header("Authorization", "*:*.test-admin-token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "health": "GOOD"
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local unleash = require("assay.unleash")
+        local c = unleash.client("{}", {{ token = "*:*.test-admin-token" }})
+        local h = c:health()
+        assert.eq(h.health, "GOOD")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_unleash_projects() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/admin/projects"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "version": 1,
+            "projects": [
+                {"id": "default", "name": "Default", "description": "Default project", "memberCount": 1, "featureCount": 5},
+                {"id": "simons", "name": "Simons", "description": "Golden Image Factory", "memberCount": 2, "featureCount": 3}
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local unleash = require("assay.unleash")
+        local c = unleash.client("{}", {{ token = "test-token" }})
+        local projects = c:projects()
+        assert.eq(#projects, 2)
+        assert.eq(projects[1].id, "default")
+        assert.eq(projects[2].id, "simons")
+        assert.eq(projects[2].name, "Simons")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_unleash_project() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/admin/projects/simons"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "simons",
+            "name": "Simons",
+            "description": "Golden Image Factory",
+            "environments": [
+                {"environment": "development", "enabled": true},
+                {"environment": "production", "enabled": true}
+            ],
+            "features": []
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local unleash = require("assay.unleash")
+        local c = unleash.client("{}", {{ token = "test-token" }})
+        local p = c:project("simons")
+        assert.eq(p.id, "simons")
+        assert.eq(p.name, "Simons")
+        assert.eq(#p.environments, 2)
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_unleash_project_not_found() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/admin/projects/nonexistent"))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local unleash = require("assay.unleash")
+        local c = unleash.client("{}", {{ token = "test-token" }})
+        local p = c:project("nonexistent")
+        assert.eq(p, nil)
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_unleash_create_project() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/admin/projects"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+            "id": "simons",
+            "name": "Simons",
+            "description": "Golden Image Factory"
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local unleash = require("assay.unleash")
+        local c = unleash.client("{}", {{ token = "test-token" }})
+        local p = c:create_project({{ id = "simons", name = "Simons", description = "Golden Image Factory" }})
+        assert.eq(p.id, "simons")
+        assert.eq(p.name, "Simons")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_unleash_update_project() {
+    let server = MockServer::start().await;
+    Mock::given(method("PUT"))
+        .and(path("/api/admin/projects/simons"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "simons",
+            "name": "Simons Updated",
+            "description": "Updated description"
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local unleash = require("assay.unleash")
+        local c = unleash.client("{}", {{ token = "test-token" }})
+        local p = c:update_project("simons", {{ name = "Simons Updated", description = "Updated description" }})
+        assert.eq(p.name, "Simons Updated")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_unleash_delete_project() {
+    let server = MockServer::start().await;
+    Mock::given(method("DELETE"))
+        .and(path("/api/admin/projects/simons"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local unleash = require("assay.unleash")
+        local c = unleash.client("{}", {{ token = "test-token" }})
+        c:delete_project("simons")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_unleash_environments() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/admin/environments"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "version": 1,
+            "environments": [
+                {"name": "development", "type": "development", "enabled": true, "sortOrder": 1},
+                {"name": "production", "type": "production", "enabled": true, "sortOrder": 2}
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local unleash = require("assay.unleash")
+        local c = unleash.client("{}", {{ token = "test-token" }})
+        local envs = c:environments()
+        assert.eq(#envs, 2)
+        assert.eq(envs[1].name, "development")
+        assert.eq(envs[2].name, "production")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_unleash_enable_environment() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/admin/projects/simons/environments"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local unleash = require("assay.unleash")
+        local c = unleash.client("{}", {{ token = "test-token" }})
+        c:enable_environment("simons", "production")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_unleash_disable_environment() {
+    let server = MockServer::start().await;
+    Mock::given(method("DELETE"))
+        .and(path("/api/admin/projects/simons/environments/staging"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local unleash = require("assay.unleash")
+        local c = unleash.client("{}", {{ token = "test-token" }})
+        c:disable_environment("simons", "staging")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_unleash_features() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/admin/projects/simons/features"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "version": 2,
+            "features": [
+                {"name": "dark-mode", "type": "release", "enabled": false, "project": "simons"},
+                {"name": "new-dashboard", "type": "experiment", "enabled": true, "project": "simons"}
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local unleash = require("assay.unleash")
+        local c = unleash.client("{}", {{ token = "test-token" }})
+        local features = c:features("simons")
+        assert.eq(#features, 2)
+        assert.eq(features[1].name, "dark-mode")
+        assert.eq(features[2].name, "new-dashboard")
+        assert.eq(features[2].enabled, true)
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_unleash_feature() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/admin/projects/simons/features/dark-mode"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "name": "dark-mode",
+            "type": "release",
+            "project": "simons",
+            "enabled": false,
+            "environments": [
+                {"name": "development", "enabled": true},
+                {"name": "production", "enabled": false}
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local unleash = require("assay.unleash")
+        local c = unleash.client("{}", {{ token = "test-token" }})
+        local f = c:feature("simons", "dark-mode")
+        assert.eq(f.name, "dark-mode")
+        assert.eq(f.type, "release")
+        assert.eq(#f.environments, 2)
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_unleash_feature_not_found() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/admin/projects/simons/features/nonexistent"))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local unleash = require("assay.unleash")
+        local c = unleash.client("{}", {{ token = "test-token" }})
+        local f = c:feature("simons", "nonexistent")
+        assert.eq(f, nil)
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_unleash_create_feature() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/admin/projects/simons/features"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+            "name": "dark-mode",
+            "type": "release",
+            "project": "simons",
+            "description": "Enable dark mode UI"
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local unleash = require("assay.unleash")
+        local c = unleash.client("{}", {{ token = "test-token" }})
+        local f = c:create_feature("simons", {{ name = "dark-mode", type = "release", description = "Enable dark mode UI" }})
+        assert.eq(f.name, "dark-mode")
+        assert.eq(f.type, "release")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_unleash_update_feature() {
+    let server = MockServer::start().await;
+    Mock::given(method("PUT"))
+        .and(path("/api/admin/projects/simons/features/dark-mode"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "name": "dark-mode",
+            "type": "release",
+            "description": "Updated dark mode"
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local unleash = require("assay.unleash")
+        local c = unleash.client("{}", {{ token = "test-token" }})
+        local f = c:update_feature("simons", "dark-mode", {{ description = "Updated dark mode" }})
+        assert.eq(f.description, "Updated dark mode")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_unleash_archive_feature() {
+    let server = MockServer::start().await;
+    Mock::given(method("DELETE"))
+        .and(path("/api/admin/projects/simons/features/dark-mode"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local unleash = require("assay.unleash")
+        local c = unleash.client("{}", {{ token = "test-token" }})
+        c:archive_feature("simons", "dark-mode")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_unleash_toggle_on() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/admin/projects/simons/features/dark-mode/environments/development/on"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local unleash = require("assay.unleash")
+        local c = unleash.client("{}", {{ token = "test-token" }})
+        c:toggle_on("simons", "dark-mode", "development")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_unleash_toggle_off() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/admin/projects/simons/features/dark-mode/environments/production/off"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local unleash = require("assay.unleash")
+        local c = unleash.client("{}", {{ token = "test-token" }})
+        c:toggle_off("simons", "dark-mode", "production")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_unleash_strategies() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/admin/projects/simons/features/dark-mode/environments/development/strategies"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+            {"id": "strategy-1", "name": "default", "parameters": {}},
+            {"id": "strategy-2", "name": "userWithId", "parameters": {"userIds": "user1,user2"}}
+        ])))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local unleash = require("assay.unleash")
+        local c = unleash.client("{}", {{ token = "test-token" }})
+        local strats = c:strategies("simons", "dark-mode", "development")
+        assert.eq(#strats, 2)
+        assert.eq(strats[1].name, "default")
+        assert.eq(strats[2].name, "userWithId")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_unleash_add_strategy() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/admin/projects/simons/features/dark-mode/environments/development/strategies"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "strategy-3",
+            "name": "flexibleRollout",
+            "parameters": {"rollout": "50", "stickiness": "default"}
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local unleash = require("assay.unleash")
+        local c = unleash.client("{}", {{ token = "test-token" }})
+        local s = c:add_strategy("simons", "dark-mode", "development", {{
+            name = "flexibleRollout",
+            parameters = {{ rollout = "50", stickiness = "default" }}
+        }})
+        assert.eq(s.name, "flexibleRollout")
+        assert.eq(s.id, "strategy-3")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_unleash_tokens() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/admin/api-tokens"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "tokens": [
+                {"secret": "*:development.abc123", "username": "simons-dev", "type": "client", "environment": "development", "projects": ["simons"]},
+                {"secret": "*:*.admin456", "username": "admin", "type": "admin", "projects": ["*"]}
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local unleash = require("assay.unleash")
+        local c = unleash.client("{}", {{ token = "test-token" }})
+        local tokens = c:tokens()
+        assert.eq(#tokens, 2)
+        assert.eq(tokens[1].username, "simons-dev")
+        assert.eq(tokens[1].type, "client")
+        assert.eq(tokens[2].type, "admin")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_unleash_create_token() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/admin/api-tokens"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+            "secret": "simons:development.newtoken789",
+            "username": "simons-client",
+            "type": "client",
+            "environment": "development",
+            "projects": ["simons"],
+            "createdAt": "2026-02-20T00:00:00Z"
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local unleash = require("assay.unleash")
+        local c = unleash.client("{}", {{ token = "test-token" }})
+        local t = c:create_token({{
+            username = "simons-client",
+            type = "client",
+            environment = "development",
+            projects = {{ "simons" }}
+        }})
+        assert.eq(t.secret, "simons:development.newtoken789")
+        assert.eq(t.username, "simons-client")
+        assert.eq(t.type, "client")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_unleash_delete_token() {
+    let server = MockServer::start().await;
+    Mock::given(method("DELETE"))
+        .and(path("/api/admin/api-tokens/old-token-secret"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local unleash = require("assay.unleash")
+        local c = unleash.client("{}", {{ token = "test-token" }})
+        c:delete_token("old-token-secret")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_unleash_wait_success() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/health"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"health": "GOOD"})))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local unleash = require("assay.unleash")
+        local result = unleash.wait("{}", {{ timeout = 5, interval = 0.1 }})
+        assert.eq(result, true)
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_unleash_wait_timeout() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/health"))
+        .respond_with(ResponseTemplate::new(503))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local unleash = require("assay.unleash")
+        unleash.wait("{}", {{ timeout = 1, interval = 0.5 }})
+        "#,
+        server.uri()
+    );
+    let result = run_lua(&script).await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_unleash_ensure_project_existing() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/admin/projects/simons"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "simons",
+            "name": "Simons",
+            "description": "Existing project"
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local unleash = require("assay.unleash")
+        local c = unleash.client("{}", {{ token = "test-token" }})
+        local p = unleash.ensure_project(c, "simons")
+        assert.eq(p.id, "simons")
+        assert.eq(p.name, "Simons")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_unleash_ensure_project_new() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/admin/projects/new-project"))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/api/admin/projects"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+            "id": "new-project",
+            "name": "New Project",
+            "description": "A new project"
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local unleash = require("assay.unleash")
+        local c = unleash.client("{}", {{ token = "test-token" }})
+        local p = unleash.ensure_project(c, "new-project", {{ name = "New Project", description = "A new project" }})
+        assert.not_nil(p)
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_unleash_ensure_environment_new() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/admin/projects/simons/environments"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local unleash = require("assay.unleash")
+        local c = unleash.client("{}", {{ token = "test-token" }})
+        local result = unleash.ensure_environment(c, "simons", "qa")
+        assert.eq(result, true)
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_unleash_ensure_environment_already_exists() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/api/admin/projects/simons/environments"))
+        .respond_with(ResponseTemplate::new(409).set_body_string("Environment already enabled"))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local unleash = require("assay.unleash")
+        local c = unleash.client("{}", {{ token = "test-token" }})
+        local result = unleash.ensure_environment(c, "simons", "development")
+        assert.eq(result, true)
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_unleash_ensure_token_existing() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/admin/api-tokens"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "tokens": [
+                {"secret": "hidden", "username": "simons-dev", "type": "client", "environment": "development", "projects": ["simons"]}
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local unleash = require("assay.unleash")
+        local c = unleash.client("{}", {{ token = "test-token" }})
+        local t = unleash.ensure_token(c, {{
+            username = "simons-dev",
+            type = "client",
+            environment = "development"
+        }})
+        assert.eq(t.username, "simons-dev")
+        assert.eq(t.type, "client")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_unleash_ensure_token_new() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/admin/api-tokens"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "tokens": []
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/api/admin/api-tokens"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+            "secret": "simons:production.newtoken",
+            "username": "simons-prod",
+            "type": "client",
+            "environment": "production",
+            "projects": ["simons"]
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local unleash = require("assay.unleash")
+        local c = unleash.client("{}", {{ token = "test-token" }})
+        local t = unleash.ensure_token(c, {{
+            username = "simons-prod",
+            type = "client",
+            environment = "production",
+            projects = {{ "simons" }}
+        }})
+        assert.eq(t.secret, "simons:production.newtoken")
+        assert.eq(t.username, "simons-prod")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}


### PR DESCRIPTION
## Summary

- Add `assay.unleash` stdlib module covering the full Unleash admin API: health, projects, environments, features, strategies, and API tokens
- Include idempotent module-level helpers (`ensure_project`, `ensure_environment`, `ensure_token`, `wait`) for safe repeated execution in ArgoCD PostSync jobs
- Add 32 wiremock-based tests covering all client methods and ensure helpers
- Update README.md and AGENTS.md with the new module (23 stdlib modules total)

## API Coverage

| Area | Methods |
|------|---------|
| Health | `health()` |
| Projects | `projects()`, `project()`, `create_project()`, `update_project()`, `delete_project()` |
| Environments | `environments()`, `enable_environment()`, `disable_environment()` |
| Features | `features()`, `feature()`, `create_feature()`, `update_feature()`, `archive_feature()`, `toggle_on()`, `toggle_off()` |
| Strategies | `strategies()`, `add_strategy()` |
| API Tokens | `tokens()`, `create_token()`, `delete_token()` |
| Helpers | `M.wait()`, `M.ensure_project()`, `M.ensure_environment()`, `M.ensure_token()` |

## Testing

```
cargo check          ✅
cargo clippy         ✅ (0 warnings)
cargo test           ✅ (523 total, 32 new unleash tests)
```