### PR TITLE
feat: assay v0.5.2 — general-purpose builtins (fs, shell, process)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,8 +16,16 @@ Key skills that apply to this project:
 
 ## What is Assay
 
-Lightweight Lua runtime for Kubernetes. Single ~9 MB static binary that replaces 50–250 MB
-Python/Node/kubectl containers in K8s Jobs.
+General-purpose enhanced Lua runtime. Single ~9 MB static binary with batteries
+included: HTTP client/server, JSON/YAML/TOML, crypto, database, WebSocket,
+filesystem, shell execution, process management, async, and 23 embedded stdlib
+modules for infrastructure services (Kubernetes, Prometheus, Vault, ArgoCD, etc.).
+
+Use cases:
+- **Standalone scripting** — system automation, CI/CD tasks, file processing
+- **Embedded runtime** — other Rust services embed assay as a library (`pub mod lua`)
+- **Kubernetes Jobs** — replaces 50–250 MB Python/Node/kubectl containers (~6 MB image)
+- **Infrastructure automation** — GitOps hooks, health checks, service configuration
 
 - **Repo**: [github.com/developerinlondon/assay](https://github.com/developerinlondon/assay)
 - **Image**: `ghcr.io/developerinlondon/assay:latest` (~6 MB compressed)
@@ -31,7 +39,7 @@ assay script.lua     # Lua mode — run script with all builtins
 assay checks.yaml    # YAML mode — structured checks with retry/backoff/parallel
 ```
 
-## Using Assay in Kubernetes
+### Example: Kubernetes Job
 
 ```yaml
 apiVersion: batch/v1
@@ -73,7 +81,7 @@ Available in all `.lua` scripts — no `require` needed:
 |----------|-----------|
 | HTTP | `http.get(url, opts?)`, `http.post(url, body, opts?)`, `http.put(url, body, opts?)`, `http.patch(url, body, opts?)`, `http.delete(url, opts?)`, `http.serve(port, routes)` |
 | JSON/YAML/TOML | `json.parse(str)`, `json.encode(tbl)`, `yaml.parse(str)`, `yaml.encode(tbl)`, `toml.parse(str)`, `toml.encode(tbl)` |
-| Filesystem | `fs.read(path)`, `fs.write(path, str)` |
+| Filesystem | `fs.read(path)`, `fs.write(path, str)`, `fs.remove(path)`, `fs.list(path)`, `fs.stat(path)`, `fs.mkdir(path)`, `fs.exists(path)` |
 | Crypto | `crypto.jwt_sign(claims, key, alg, opts?)`, `crypto.hash(str, alg)`, `crypto.hmac(key, data, alg?, raw?)`, `crypto.random(len)` |
 | Base64 | `base64.encode(str)`, `base64.decode(str)` |
 | Regex | `regex.match(pat, str)`, `regex.find(pat, str)`, `regex.find_all(pat, str)`, `regex.replace(pat, str, repl)` |
@@ -84,6 +92,8 @@ Available in all `.lua` scripts — no `require` needed:
 | Assert | `assert.eq(a, b, msg?)`, `assert.gt(a, b, msg?)`, `assert.lt(a, b, msg?)`, `assert.contains(str, sub, msg?)`, `assert.not_nil(val, msg?)`, `assert.matches(str, pat, msg?)` |
 | Logging | `log.info(msg)`, `log.warn(msg)`, `log.error(msg)` |
 | Utilities | `env.get(key)`, `sleep(secs)`, `time()` |
+| Shell | `shell.exec(cmd, opts?)` — execute commands with timeout, working dir, env |
+| Process | `process.list()`, `process.is_running(name)`, `process.kill(pid, signal?)` |
 
 HTTP responses: `{status, body, headers}`. Options: `{headers = {["X-Key"] = "val"}}`.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "assay-lua"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -88,6 +88,7 @@ dependencies = [
  "hyper-util",
  "include_dir",
  "jsonwebtoken",
+ "libc",
  "minijinja",
  "mlua",
  "rand 0.10.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "assay-lua"
-version = "0.5.1"
+version = "0.5.2"
 categories = ["command-line-utilities", "development-tools::testing"]
 edition = "2024"
 homepage = "https://assay.rs"
-keywords = ["verification", "testing", "lua", "kubernetes", "validation"]
+keywords = ["lua", "scripting", "automation", "runtime", "kubernetes"]
 license = "MIT"
 repository = "https://github.com/developerinlondon/assay"
-description = "Lightweight Lua runtime for Kubernetes. Verification, scripting, and web services."
+description = "General-purpose enhanced Lua runtime. Batteries-included scripting, automation, and web services."
 
 [[bin]]
 name = "assay"
@@ -69,6 +69,9 @@ rand = "0.10.0"
 
 # Lightweight regex
 regex-lite = "0.1.9"
+
+# Process signals (kill)
+libc = "0.2"
 
 # TOML parsing/encoding
 toml = "0.9.12"

--- a/src/lua/builtins/core.rs
+++ b/src/lua/builtins/core.rs
@@ -99,6 +99,80 @@ pub fn register_fs(lua: &Lua) -> mlua::Result<()> {
     })?;
     fs_table.set("write", write_fn)?;
 
+    let remove_fn = lua.create_function(|_, path: String| {
+        let p = std::path::Path::new(&path);
+        if p.is_dir() {
+            std::fs::remove_dir_all(&path).map_err(|e| {
+                mlua::Error::runtime(format!("fs.remove: failed to remove directory {path:?}: {e}"))
+            })
+        } else {
+            std::fs::remove_file(&path).map_err(|e| {
+                mlua::Error::runtime(format!("fs.remove: failed to remove {path:?}: {e}"))
+            })
+        }
+    })?;
+    fs_table.set("remove", remove_fn)?;
+
+    let list_fn = lua.create_function(|lua, path: String| {
+        let entries = lua.create_table()?;
+        for (i, entry) in (1..).zip(std::fs::read_dir(&path).map_err(|e| {
+            mlua::Error::runtime(format!("fs.list: failed to list {path:?}: {e}"))
+        })?) {
+            let entry = entry.map_err(|e| {
+                mlua::Error::runtime(format!("fs.list: error reading entry in {path:?}: {e}"))
+            })?;
+            let info = lua.create_table()?;
+            let name = entry.file_name().to_string_lossy().to_string();
+            info.set("name", name)?;
+            let file_type = entry.file_type().map_err(|e| {
+                mlua::Error::runtime(format!("fs.list: failed to get file type: {e}"))
+            })?;
+            if file_type.is_dir() {
+                info.set("type", "directory")?;
+            } else if file_type.is_symlink() {
+                info.set("type", "symlink")?;
+            } else {
+                info.set("type", "file")?;
+            }
+            entries.set(i, info)?;
+        }
+        Ok(entries)
+    })?;
+    fs_table.set("list", list_fn)?;
+
+    let stat_fn = lua.create_function(|lua, path: String| {
+        let metadata = std::fs::metadata(&path).map_err(|e| {
+            mlua::Error::runtime(format!("fs.stat: failed to stat {path:?}: {e}"))
+        })?;
+        let info = lua.create_table()?;
+        info.set("size", metadata.len())?;
+        info.set("is_file", metadata.is_file())?;
+        info.set("is_dir", metadata.is_dir())?;
+        info.set("is_symlink", metadata.is_symlink())?;
+        if let Ok(modified) = metadata.modified()
+            && let Ok(duration) = modified.duration_since(std::time::UNIX_EPOCH)
+        {
+            info.set("modified", duration.as_secs_f64())?;
+        }
+        if let Ok(created) = metadata.created()
+            && let Ok(duration) = created.duration_since(std::time::UNIX_EPOCH)
+        {
+            info.set("created", duration.as_secs_f64())?;
+        }
+        Ok(info)
+    })?;
+    fs_table.set("stat", stat_fn)?;
+
+    let mkdir_fn = lua.create_function(|_, path: String| {
+        std::fs::create_dir_all(&path).map_err(|e| {
+            mlua::Error::runtime(format!("fs.mkdir: failed to create {path:?}: {e}"))
+        })
+    })?;
+    fs_table.set("mkdir", mkdir_fn)?;
+
+    let exists_fn = lua.create_function(|_, path: String| Ok(std::path::Path::new(&path).exists()))?;
+    fs_table.set("exists", exists_fn)?;
+
     lua.globals().set("fs", fs_table)?;
     Ok(())
 }

--- a/src/lua/builtins/core.rs
+++ b/src/lua/builtins/core.rs
@@ -101,7 +101,14 @@ pub fn register_fs(lua: &Lua) -> mlua::Result<()> {
 
     let remove_fn = lua.create_function(|_, path: String| {
         let p = std::path::Path::new(&path);
-        if p.is_dir() {
+        // Use symlink_metadata to detect symlinks without following them.
+        // A symlink to a directory should be removed as a file (unlink),
+        // not recursively delete the target directory.
+        let is_dir = match std::fs::symlink_metadata(&path) {
+            Ok(m) => m.file_type().is_dir(),
+            Err(_) => p.is_dir(),
+        };
+        if is_dir {
             std::fs::remove_dir_all(&path).map_err(|e| {
                 mlua::Error::runtime(format!("fs.remove: failed to remove directory {path:?}: {e}"))
             })
@@ -144,11 +151,16 @@ pub fn register_fs(lua: &Lua) -> mlua::Result<()> {
         let metadata = std::fs::metadata(&path).map_err(|e| {
             mlua::Error::runtime(format!("fs.stat: failed to stat {path:?}: {e}"))
         })?;
+        // Use symlink_metadata separately to correctly detect symlinks,
+        // since std::fs::metadata follows symlinks (is_symlink always false).
+        let is_symlink = std::fs::symlink_metadata(&path)
+            .map(|m| m.file_type().is_symlink())
+            .unwrap_or(false);
         let info = lua.create_table()?;
         info.set("size", metadata.len())?;
         info.set("is_file", metadata.is_file())?;
         info.set("is_dir", metadata.is_dir())?;
-        info.set("is_symlink", metadata.is_symlink())?;
+        info.set("is_symlink", is_symlink)?;
         if let Ok(modified) = metadata.modified()
             && let Ok(duration) = modified.duration_since(std::time::UNIX_EPOCH)
         {

--- a/src/lua/builtins/http.rs
+++ b/src/lua/builtins/http.rs
@@ -173,6 +173,12 @@ pub fn register_http(lua: &Lua, client: reqwest::Client) -> mlua::Result<()> {
             .await
             .map_err(|e| mlua::Error::runtime(format!("http.serve: bind failed: {e}")))?;
 
+        // Expose the actual bound port so callers using port 0 can discover it
+        let actual_port = listener.local_addr()
+            .map_err(|e| mlua::Error::runtime(format!("http.serve: failed to get local addr: {e}")))?
+            .port();
+        lua.globals().set("_SERVER_PORT", actual_port)?;
+
         loop {
             let (stream, _addr) = listener
                 .accept()

--- a/src/lua/builtins/mod.rs
+++ b/src/lua/builtins/mod.rs
@@ -5,7 +5,9 @@ mod crypto;
 mod db;
 mod http;
 mod json;
+mod process;
 mod serialization;
+mod shell;
 mod template;
 mod ws;
 
@@ -28,5 +30,7 @@ pub fn register_all(lua: &mlua::Lua, client: reqwest::Client) -> mlua::Result<()
     db::register_db(lua)?;
     ws::register_ws(lua)?;
     template::register_template(lua)?;
+    shell::register_shell(lua)?;
+    process::register_process(lua)?;
     Ok(())
 }

--- a/src/lua/builtins/process.rs
+++ b/src/lua/builtins/process.rs
@@ -1,56 +1,117 @@
 use mlua::Lua;
 
+/// Parse process list from /proc (Linux)
+#[cfg(target_os = "linux")]
+fn list_processes() -> Result<Vec<(i64, String, Option<String>)>, String> {
+    let entries = std::fs::read_dir("/proc")
+        .map_err(|e| format!("process.list: failed to read /proc: {e}"))?;
+
+    let mut result = Vec::new();
+    for entry in entries {
+        let entry = match entry {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+
+        let pid: i64 = match name_str.parse() {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+
+        let comm_path = entry.path().join("comm");
+        let comm = std::fs::read_to_string(&comm_path)
+            .unwrap_or_default()
+            .trim()
+            .to_string();
+
+        if comm.is_empty() {
+            continue;
+        }
+
+        let cmdline_path = entry.path().join("cmdline");
+        let cmdline = std::fs::read_to_string(&cmdline_path)
+            .ok()
+            .map(|s| s.replace('\0', " ").trim().to_string())
+            .filter(|s| !s.is_empty());
+
+        result.push((pid, comm, cmdline));
+    }
+    Ok(result)
+}
+
+/// Parse process list from `ps -eo pid,comm` (macOS / fallback)
+#[cfg(not(target_os = "linux"))]
+fn list_processes() -> Result<Vec<(i64, String, Option<String>)>, String> {
+    let output = std::process::Command::new("ps")
+        .args(["-eo", "pid,comm"])
+        .output()
+        .map_err(|e| format!("process.list: failed to run ps: {e}"))?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "process.list: ps failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut result = Vec::new();
+    for line in stdout.lines().skip(1) {
+        // skip header
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let mut parts = line.splitn(2, char::is_whitespace);
+        let pid: i64 = match parts.next().and_then(|s| s.trim().parse().ok()) {
+            Some(p) => p,
+            None => continue,
+        };
+        let comm = match parts.next() {
+            Some(s) => s.trim().to_string(),
+            None => continue,
+        };
+        if comm.is_empty() {
+            continue;
+        }
+        // Extract just the binary name from the full path (e.g. /usr/sbin/syslogd -> syslogd)
+        let name = comm
+            .rsplit('/')
+            .next()
+            .unwrap_or(&comm)
+            .to_string();
+        result.push((pid, name, Some(comm)));
+    }
+    Ok(result)
+}
+
+/// Check if a process with the given name is running
+fn is_process_running(name: &str) -> bool {
+    match list_processes() {
+        Ok(procs) => procs.iter().any(|(_, comm, _)| comm == name),
+        Err(_) => false,
+    }
+}
+
 pub fn register_process(lua: &Lua) -> mlua::Result<()> {
     let process_table = lua.create_table()?;
 
-    // process.list() — returns table of {pid, name, ...} from /proc
+    // process.list() — returns table of {pid, name, cmdline?}
     let list_fn = lua.create_function(|lua, ()| {
+        let proc_list =
+            list_processes().map_err(mlua::Error::runtime)?;
+
         let procs = lua.create_table()?;
-        let mut i = 1;
-
-        let entries = std::fs::read_dir("/proc").map_err(|e| {
-            mlua::Error::runtime(format!("process.list: failed to read /proc: {e}"))
-        })?;
-
-        for entry in entries {
-            let entry = match entry {
-                Ok(e) => e,
-                Err(_) => continue,
-            };
-            let name = entry.file_name();
-            let name_str = name.to_string_lossy();
-
-            // Only numeric directories (PIDs)
-            let pid: i64 = match name_str.parse() {
-                Ok(p) => p,
-                Err(_) => continue,
-            };
-
-            let comm_path = entry.path().join("comm");
-            let comm = std::fs::read_to_string(&comm_path)
-                .unwrap_or_default()
-                .trim()
-                .to_string();
-
-            if comm.is_empty() {
-                continue;
-            }
-
+        for (i, (pid, name, cmdline)) in proc_list.into_iter().enumerate() {
             let info = lua.create_table()?;
             info.set("pid", pid)?;
-            info.set("name", comm)?;
-
-            // Try to read cmdline for full command
-            let cmdline_path = entry.path().join("cmdline");
-            if let Ok(cmdline) = std::fs::read_to_string(&cmdline_path) {
-                let cmdline = cmdline.replace('\0', " ").trim().to_string();
-                if !cmdline.is_empty() {
-                    info.set("cmdline", cmdline)?;
-                }
+            info.set("name", name)?;
+            if let Some(cmd) = cmdline {
+                info.set("cmdline", cmd)?;
             }
-
-            procs.set(i, info)?;
-            i += 1;
+            procs.set(i + 1, info)?;
         }
 
         Ok(procs)
@@ -59,32 +120,7 @@ pub fn register_process(lua: &Lua) -> mlua::Result<()> {
 
     // process.is_running(name) — check if a process with given name exists
     let is_running_fn = lua.create_function(|_, name: String| {
-        let entries = match std::fs::read_dir("/proc") {
-            Ok(e) => e,
-            Err(_) => return Ok(false),
-        };
-
-        for entry in entries {
-            let entry = match entry {
-                Ok(e) => e,
-                Err(_) => continue,
-            };
-
-            let dir_name = entry.file_name();
-            // Only numeric directories
-            if dir_name.to_string_lossy().parse::<u32>().is_err() {
-                continue;
-            }
-
-            let comm_path = entry.path().join("comm");
-            if let Ok(comm) = std::fs::read_to_string(&comm_path)
-                && comm.trim() == name
-            {
-                return Ok(true);
-            }
-        }
-
-        Ok(false)
+        Ok(is_process_running(&name))
     })?;
     process_table.set("is_running", is_running_fn)?;
 
@@ -113,7 +149,7 @@ pub fn register_process(lua: &Lua) -> mlua::Result<()> {
             })
             .unwrap_or(Ok(15))?;
 
-        // Use libc::kill directly — no extra dependency needed
+        // Use libc::kill directly — works on both Linux and macOS
         let result = unsafe { libc::kill(pid, signal) };
         if result == 0 {
             Ok(true)

--- a/src/lua/builtins/process.rs
+++ b/src/lua/builtins/process.rs
@@ -1,0 +1,131 @@
+use mlua::Lua;
+
+pub fn register_process(lua: &Lua) -> mlua::Result<()> {
+    let process_table = lua.create_table()?;
+
+    // process.list() — returns table of {pid, name, ...} from /proc
+    let list_fn = lua.create_function(|lua, ()| {
+        let procs = lua.create_table()?;
+        let mut i = 1;
+
+        let entries = std::fs::read_dir("/proc").map_err(|e| {
+            mlua::Error::runtime(format!("process.list: failed to read /proc: {e}"))
+        })?;
+
+        for entry in entries {
+            let entry = match entry {
+                Ok(e) => e,
+                Err(_) => continue,
+            };
+            let name = entry.file_name();
+            let name_str = name.to_string_lossy();
+
+            // Only numeric directories (PIDs)
+            let pid: i64 = match name_str.parse() {
+                Ok(p) => p,
+                Err(_) => continue,
+            };
+
+            let comm_path = entry.path().join("comm");
+            let comm = std::fs::read_to_string(&comm_path)
+                .unwrap_or_default()
+                .trim()
+                .to_string();
+
+            if comm.is_empty() {
+                continue;
+            }
+
+            let info = lua.create_table()?;
+            info.set("pid", pid)?;
+            info.set("name", comm)?;
+
+            // Try to read cmdline for full command
+            let cmdline_path = entry.path().join("cmdline");
+            if let Ok(cmdline) = std::fs::read_to_string(&cmdline_path) {
+                let cmdline = cmdline.replace('\0', " ").trim().to_string();
+                if !cmdline.is_empty() {
+                    info.set("cmdline", cmdline)?;
+                }
+            }
+
+            procs.set(i, info)?;
+            i += 1;
+        }
+
+        Ok(procs)
+    })?;
+    process_table.set("list", list_fn)?;
+
+    // process.is_running(name) — check if a process with given name exists
+    let is_running_fn = lua.create_function(|_, name: String| {
+        let entries = match std::fs::read_dir("/proc") {
+            Ok(e) => e,
+            Err(_) => return Ok(false),
+        };
+
+        for entry in entries {
+            let entry = match entry {
+                Ok(e) => e,
+                Err(_) => continue,
+            };
+
+            let dir_name = entry.file_name();
+            // Only numeric directories
+            if dir_name.to_string_lossy().parse::<u32>().is_err() {
+                continue;
+            }
+
+            let comm_path = entry.path().join("comm");
+            if let Ok(comm) = std::fs::read_to_string(&comm_path)
+                && comm.trim() == name
+            {
+                return Ok(true);
+            }
+        }
+
+        Ok(false)
+    })?;
+    process_table.set("is_running", is_running_fn)?;
+
+    // process.kill(pid, signal?) — send signal to process (default SIGTERM = 15)
+    let kill_fn = lua.create_function(|_, args: mlua::MultiValue| {
+        let mut args_iter = args.into_iter();
+
+        let pid: i32 = args_iter
+            .next()
+            .ok_or_else(|| mlua::Error::runtime("process.kill: pid required"))
+            .and_then(|v| match v {
+                mlua::Value::Integer(n) => Ok(n as i32),
+                mlua::Value::Number(n) => Ok(n as i32),
+                _ => Err(mlua::Error::runtime("process.kill: pid must be a number")),
+            })?;
+
+        let signal: i32 = args_iter
+            .next()
+            .map(|v| match v {
+                mlua::Value::Integer(n) => Ok(n as i32),
+                mlua::Value::Number(n) => Ok(n as i32),
+                mlua::Value::Nil => Ok(15), // SIGTERM
+                _ => Err(mlua::Error::runtime(
+                    "process.kill: signal must be a number",
+                )),
+            })
+            .unwrap_or(Ok(15))?;
+
+        // Use libc::kill directly — no extra dependency needed
+        let result = unsafe { libc::kill(pid, signal) };
+        if result == 0 {
+            Ok(true)
+        } else {
+            let err = std::io::Error::last_os_error();
+            Err(mlua::Error::runtime(format!(
+                "process.kill: failed to send signal {signal} to pid {pid}: {err}"
+            )))
+        }
+    })?;
+    process_table.set("kill", kill_fn)?;
+
+    lua.globals().set("process", process_table)?;
+    Ok(())
+}

--- a/src/lua/builtins/process.rs
+++ b/src/lua/builtins/process.rs
@@ -137,6 +137,14 @@ pub fn register_process(lua: &Lua) -> mlua::Result<()> {
                 _ => Err(mlua::Error::runtime("process.kill: pid must be a number")),
             })?;
 
+        // Validate pid > 0 to prevent dangerous signals:
+        // pid 0 = caller's process group, pid -1 = all permitted processes
+        if pid <= 0 {
+            return Err(mlua::Error::runtime(format!(
+                "process.kill: pid must be > 0, got {pid}"
+            )));
+        }
+
         let signal: i32 = args_iter
             .next()
             .map(|v| match v {
@@ -149,7 +157,13 @@ pub fn register_process(lua: &Lua) -> mlua::Result<()> {
             })
             .unwrap_or(Ok(15))?;
 
-        // Use libc::kill directly — works on both Linux and macOS
+        if signal < 0 {
+            return Err(mlua::Error::runtime(format!(
+                "process.kill: signal must be >= 0, got {signal}"
+            )));
+        }
+
+        // Use libc::kill via the libc crate — works on both Linux and macOS
         let result = unsafe { libc::kill(pid, signal) };
         if result == 0 {
             Ok(true)

--- a/src/lua/builtins/shell.rs
+++ b/src/lua/builtins/shell.rs
@@ -32,8 +32,17 @@ pub fn register_shell(lua: &Lua) -> mlua::Result<()> {
             }
         }
 
-        // Build command — use sh -c for shell interpretation
-        let mut command = std::process::Command::new("sh");
+        // Validate timeout before use — Duration::from_secs_f64 panics on NaN/negative
+        if let Some(secs) = timeout_secs
+            && (!secs.is_finite() || secs < 0.0)
+        {
+            return Err(mlua::Error::runtime(
+                "shell.exec: timeout must be a non-negative finite number",
+            ));
+        }
+
+        // Build command — use /bin/sh explicitly for predictable behavior
+        let mut command = std::process::Command::new("/bin/sh");
         command.arg("-c").arg(&cmd);
 
         if let Some(ref dir) = cwd {
@@ -72,25 +81,47 @@ pub fn register_shell(lua: &Lua) -> mlua::Result<()> {
         let output = if let Some(secs) = timeout_secs {
             let duration = std::time::Duration::from_secs_f64(secs);
             let start = std::time::Instant::now();
+
+            // Drain stdout/stderr in background threads to prevent pipe buffer deadlock.
+            // If the child fills the OS pipe buffer (~64KB), it blocks waiting for a reader.
+            // Without concurrent draining, try_wait() polls forever since the child never exits.
+            let mut stdout_handle = child.stdout.take().map(|mut s| {
+                std::thread::spawn(move || {
+                    let mut buf = String::new();
+                    let _ = std::io::Read::read_to_string(&mut s, &mut buf);
+                    buf
+                })
+            });
+            let mut stderr_handle = child.stderr.take().map(|mut s| {
+                std::thread::spawn(move || {
+                    let mut buf = String::new();
+                    let _ = std::io::Read::read_to_string(&mut s, &mut buf);
+                    buf
+                })
+            });
+
             loop {
                 match child.try_wait() {
                     Ok(Some(status)) => {
-                        let stdout = child.stdout.take().map_or_else(String::new, |mut s| {
-                            let mut buf = String::new();
-                            std::io::Read::read_to_string(&mut s, &mut buf).unwrap_or(0);
-                            buf
-                        });
-                        let stderr = child.stderr.take().map_or_else(String::new, |mut s| {
-                            let mut buf = String::new();
-                            std::io::Read::read_to_string(&mut s, &mut buf).unwrap_or(0);
-                            buf
-                        });
+                        let stdout = stdout_handle
+                            .take()
+                            .map_or_else(String::new, |h| h.join().unwrap_or_default());
+                        let stderr = stderr_handle
+                            .take()
+                            .map_or_else(String::new, |h| h.join().unwrap_or_default());
                         break Ok((status.code().unwrap_or(-1), stdout, stderr, false));
                     }
                     Ok(None) => {
                         if start.elapsed() >= duration {
                             let _ = child.kill();
                             let _ = child.wait();
+                            // Join reader threads to avoid leaking them
+                            if let Some(handle) = stdout_handle.take() {
+                                let _ = handle.join();
+                            }
+                            if let Some(handle) = stderr_handle.take() {
+                                let _ = handle.join();
+                            }
                             break Ok((-1, String::new(), String::new(), true));
                         }
                         std::thread::sleep(std::time::Duration::from_millis(10));

--- a/src/lua/builtins/shell.rs
+++ b/src/lua/builtins/shell.rs
@@ -1,0 +1,127 @@
+use mlua::Lua;
+
+pub fn register_shell(lua: &Lua) -> mlua::Result<()> {
+    let shell_table = lua.create_table()?;
+
+    let exec_fn = lua.create_function(|lua, args: mlua::MultiValue| {
+        let mut args_iter = args.into_iter();
+
+        let cmd: String = args_iter
+            .next()
+            .ok_or_else(|| mlua::Error::runtime("shell.exec: command string required"))
+            .and_then(|v| lua.unpack(v))?;
+
+        // Parse optional options table
+        let mut cwd: Option<String> = None;
+        let mut env_vars: Option<Vec<(String, String)>> = None;
+        let mut stdin_data: Option<String> = None;
+        let mut timeout_secs: Option<f64> = None;
+
+        if let Some(mlua::Value::Table(opts)) = args_iter.next() {
+            cwd = opts.get::<Option<String>>("cwd")?;
+            stdin_data = opts.get::<Option<String>>("stdin")?;
+            timeout_secs = opts.get::<Option<f64>>("timeout")?;
+
+            if let Some(env_table) = opts.get::<Option<mlua::Table>>("env")? {
+                let mut pairs = Vec::new();
+                for pair in env_table.pairs::<String, String>() {
+                    let (k, v) = pair?;
+                    pairs.push((k, v));
+                }
+                env_vars = Some(pairs);
+            }
+        }
+
+        // Build command — use sh -c for shell interpretation
+        let mut command = std::process::Command::new("sh");
+        command.arg("-c").arg(&cmd);
+
+        if let Some(ref dir) = cwd {
+            command.current_dir(dir);
+        }
+
+        if let Some(ref vars) = env_vars {
+            for (k, v) in vars {
+                command.env(k, v);
+            }
+        }
+
+        command.stdin(if stdin_data.is_some() {
+            std::process::Stdio::piped()
+        } else {
+            std::process::Stdio::null()
+        });
+        command.stdout(std::process::Stdio::piped());
+        command.stderr(std::process::Stdio::piped());
+
+        let mut child = command.spawn().map_err(|e| {
+            mlua::Error::runtime(format!("shell.exec: failed to spawn command: {e}"))
+        })?;
+
+        // Write stdin if provided
+        if let Some(ref data) = stdin_data {
+            use std::io::Write;
+            if let Some(mut child_stdin) = child.stdin.take() {
+                child_stdin.write_all(data.as_bytes()).map_err(|e| {
+                    mlua::Error::runtime(format!("shell.exec: failed to write stdin: {e}"))
+                })?;
+            }
+        }
+
+        // Wait with optional timeout
+        let output = if let Some(secs) = timeout_secs {
+            let duration = std::time::Duration::from_secs_f64(secs);
+            let start = std::time::Instant::now();
+            loop {
+                match child.try_wait() {
+                    Ok(Some(status)) => {
+                        let stdout = child.stdout.take().map_or_else(String::new, |mut s| {
+                            let mut buf = String::new();
+                            std::io::Read::read_to_string(&mut s, &mut buf).unwrap_or(0);
+                            buf
+                        });
+                        let stderr = child.stderr.take().map_or_else(String::new, |mut s| {
+                            let mut buf = String::new();
+                            std::io::Read::read_to_string(&mut s, &mut buf).unwrap_or(0);
+                            buf
+                        });
+                        break Ok((status.code().unwrap_or(-1), stdout, stderr, false));
+                    }
+                    Ok(None) => {
+                        if start.elapsed() >= duration {
+                            let _ = child.kill();
+                            let _ = child.wait();
+                            break Ok((-1, String::new(), String::new(), true));
+                        }
+                        std::thread::sleep(std::time::Duration::from_millis(10));
+                    }
+                    Err(e) => {
+                        break Err(mlua::Error::runtime(format!(
+                            "shell.exec: error waiting for process: {e}"
+                        )));
+                    }
+                }
+            }?
+        } else {
+            let output = child.wait_with_output().map_err(|e| {
+                mlua::Error::runtime(format!("shell.exec: failed to wait for command: {e}"))
+            })?;
+            let status = output.status.code().unwrap_or(-1);
+            let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+            let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+            (status, stdout, stderr, false)
+        };
+
+        let result = lua.create_table()?;
+        result.set("status", output.0)?;
+        result.set("stdout", output.1)?;
+        result.set("stderr", output.2)?;
+        result.set("timed_out", output.3)?;
+
+        Ok(result)
+    })?;
+    shell_table.set("exec", exec_fn)?;
+
+    lua.globals().set("shell", shell_table)?;
+    Ok(())
+}

--- a/src/lua/mod.rs
+++ b/src/lua/mod.rs
@@ -10,7 +10,7 @@ static STDLIB_DIR: Dir = include_dir!("$CARGO_MANIFEST_DIR/stdlib");
 /// Environment variable to override the global module search path.
 pub const MODULES_PATH_ENV: &str = "ASSAY_MODULES_PATH";
 
-const DANGEROUS_GLOBALS: &[&str] = &["load", "loadfile", "dofile", "collectgarbage", "print"];
+const DANGEROUS_GLOBALS: &[&str] = &["load", "loadfile", "dofile"];
 
 fn lua_err(e: mlua::Error) -> anyhow::Error {
     anyhow::anyhow!("{e}")
@@ -26,8 +26,8 @@ pub fn create_vm_with_lib_path(client: reqwest::Client, lib_path: String) -> Res
 }
 
 pub fn create_vm_with_paths(client: reqwest::Client, global_modules_path: Option<String>) -> Result<Lua> {
-    let safe_libs = StdLib::ALL_SAFE ^ StdLib::IO ^ StdLib::OS;
-    let lua = Lua::new_with(safe_libs, LuaOptions::default()).map_err(lua_err)?;
+    let libs = StdLib::ALL_SAFE;
+    let lua = Lua::new_with(libs, LuaOptions::default()).map_err(lua_err)?;
     lua.set_memory_limit(64 * 1024 * 1024).map_err(lua_err)?;
     sandbox(&lua).map_err(lua_err)?;
     register_fs_loader(&lua, global_modules_path).map_err(lua_err)?;

--- a/tests/fs.rs
+++ b/tests/fs.rs
@@ -96,3 +96,127 @@ async fn test_fs_write_invalid_path() {
     let result = run_lua(r#"fs.write("/proc/0/nonexistent", "data")"#).await;
     assert!(result.is_err());
 }
+
+#[tokio::test]
+async fn test_fs_exists() {
+    let script = r#"
+        assert.eq(fs.exists("Cargo.toml"), true)
+        assert.eq(fs.exists("/nonexistent/path"), false)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_fs_mkdir_and_remove() {
+    let dir = std::env::temp_dir().join("assay_test_mkdir");
+    let _ = std::fs::remove_dir_all(&dir);
+
+    let script = format!(
+        r#"
+        fs.mkdir("{}")
+        assert.eq(fs.exists("{}"), true)
+        fs.remove("{}")
+        assert.eq(fs.exists("{}"), false)
+        "#,
+        dir.display(), dir.display(), dir.display(), dir.display()
+    );
+    run_lua(&script).await.unwrap();
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[tokio::test]
+async fn test_fs_stat() {
+    let dir = std::env::temp_dir().join("assay_test_stat");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("stat_test.txt");
+    std::fs::write(&path, "hello stat").unwrap();
+
+    let script = format!(
+        r#"
+        local info = fs.stat("{}")
+        assert.eq(info.is_file, true)
+        assert.eq(info.is_dir, false)
+        assert.eq(info.size, 10)
+        assert.not_nil(info.modified)
+        "#,
+        path.display().to_string().replace('\\', "\\\\")
+    );
+    run_lua(&script).await.unwrap();
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[tokio::test]
+async fn test_fs_stat_directory() {
+    let script = r#"
+        local info = fs.stat("src")
+        assert.eq(info.is_dir, true)
+        assert.eq(info.is_file, false)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_fs_stat_nonexistent() {
+    let result = run_lua(r#"fs.stat("/nonexistent/file")"#).await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_fs_list() {
+    let dir = std::env::temp_dir().join("assay_test_list");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("a.txt"), "a").unwrap();
+    std::fs::write(dir.join("b.txt"), "b").unwrap();
+    std::fs::create_dir_all(dir.join("subdir")).unwrap();
+
+    let script = format!(
+        r#"
+        local entries = fs.list("{}")
+        assert.not_nil(entries)
+        local count = 0
+        local has_file = false
+        local has_dir = false
+        for _, e in ipairs(entries) do
+            count = count + 1
+            if e.type == "file" then has_file = true end
+            if e.type == "directory" then has_dir = true end
+        end
+        assert.eq(count, 3)
+        assert.eq(has_file, true)
+        assert.eq(has_dir, true)
+        "#,
+        dir.display().to_string().replace('\\', "\\\\")
+    );
+    run_lua(&script).await.unwrap();
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[tokio::test]
+async fn test_fs_remove_file() {
+    let dir = std::env::temp_dir().join("assay_test_remove_file");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("removeme.txt");
+    std::fs::write(&path, "bye").unwrap();
+
+    let script = format!(
+        r#"
+        assert.eq(fs.exists("{}"), true)
+        fs.remove("{}")
+        assert.eq(fs.exists("{}"), false)
+        "#,
+        path.display().to_string().replace('\\', "\\\\"),
+        path.display().to_string().replace('\\', "\\\\"),
+        path.display().to_string().replace('\\', "\\\\")
+    );
+    run_lua(&script).await.unwrap();
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[tokio::test]
+async fn test_fs_remove_nonexistent() {
+    let result = run_lua(r#"fs.remove("/nonexistent/file.txt")"#).await;
+    assert!(result.is_err());
+}

--- a/tests/http_serve.rs
+++ b/tests/http_serve.rs
@@ -7,14 +7,15 @@ async fn test_http_serve_get_body() {
     run_lua_local(
         r#"
         local server = async.spawn(function()
-            http.serve(18080, {
+            http.serve(0, {
                 GET = {
                     ["/health"] = function(req) return { status = 200, body = "ok" } end,
                 }
             })
         end)
         sleep(0.1)
-        local resp = http.get("http://127.0.0.1:18080/health")
+        local port = _SERVER_PORT
+        local resp = http.get("http://127.0.0.1:" .. port .. "/health")
         assert.eq(resp.status, 200)
         assert.eq(resp.body, "ok")
     "#,
@@ -28,7 +29,7 @@ async fn test_http_serve_post_body() {
     run_lua_local(
         r#"
         local server = async.spawn(function()
-            http.serve(18081, {
+            http.serve(0, {
                 POST = {
                     ["/submit"] = function(req)
                         return { status = 201, body = req.body }
@@ -37,7 +38,8 @@ async fn test_http_serve_post_body() {
             })
         end)
         sleep(0.1)
-        local resp = http.post("http://127.0.0.1:18081/submit", "hello world")
+        local port = _SERVER_PORT
+        local resp = http.post("http://127.0.0.1:" .. port .. "/submit", "hello world")
         assert.eq(resp.status, 201)
         assert.eq(resp.body, "hello world")
     "#,
@@ -51,7 +53,7 @@ async fn test_http_serve_json_response() {
     run_lua_local(
         r#"
         local server = async.spawn(function()
-            http.serve(18082, {
+            http.serve(0, {
                 GET = {
                     ["/data"] = function(req)
                         return { status = 200, json = { items = {1, 2, 3} } }
@@ -60,7 +62,8 @@ async fn test_http_serve_json_response() {
             })
         end)
         sleep(0.1)
-        local resp = http.get("http://127.0.0.1:18082/data")
+        local port = _SERVER_PORT
+        local resp = http.get("http://127.0.0.1:" .. port .. "/data")
         assert.eq(resp.status, 200)
         assert.contains(resp.headers["content-type"], "application/json")
         local data = json.parse(resp.body)
@@ -78,7 +81,7 @@ async fn test_http_serve_custom_headers() {
     run_lua_local(
         r#"
         local server = async.spawn(function()
-            http.serve(18083, {
+            http.serve(0, {
                 GET = {
                     ["/custom"] = function(req)
                         return {
@@ -91,7 +94,8 @@ async fn test_http_serve_custom_headers() {
             })
         end)
         sleep(0.1)
-        local resp = http.get("http://127.0.0.1:18083/custom")
+        local port = _SERVER_PORT
+        local resp = http.get("http://127.0.0.1:" .. port .. "/custom")
         assert.eq(resp.status, 200)
         assert.eq(resp.headers["x-custom"], "test-value")
     "#,
@@ -105,14 +109,15 @@ async fn test_http_serve_404_unregistered() {
     run_lua_local(
         r#"
         local server = async.spawn(function()
-            http.serve(18084, {
+            http.serve(0, {
                 GET = {
                     ["/exists"] = function(req) return { body = "here" } end,
                 }
             })
         end)
         sleep(0.1)
-        local resp = http.get("http://127.0.0.1:18084/missing")
+        local port = _SERVER_PORT
+        local resp = http.get("http://127.0.0.1:" .. port .. "/missing")
         assert.eq(resp.status, 404)
     "#,
     )
@@ -125,7 +130,7 @@ async fn test_http_serve_multiple_methods_same_path() {
     run_lua_local(
         r#"
         local server = async.spawn(function()
-            http.serve(18085, {
+            http.serve(0, {
                 GET = {
                     ["/resource"] = function(req) return { body = "get-result" } end,
                 },
@@ -135,10 +140,11 @@ async fn test_http_serve_multiple_methods_same_path() {
             })
         end)
         sleep(0.1)
-        local get_resp = http.get("http://127.0.0.1:18085/resource")
+        local port = _SERVER_PORT
+        local get_resp = http.get("http://127.0.0.1:" .. port .. "/resource")
         assert.eq(get_resp.status, 200)
         assert.eq(get_resp.body, "get-result")
-        local post_resp = http.post("http://127.0.0.1:18085/resource", "")
+        local post_resp = http.post("http://127.0.0.1:" .. port .. "/resource", "")
         assert.eq(post_resp.status, 201)
         assert.eq(post_resp.body, "post-result")
     "#,
@@ -152,7 +158,7 @@ async fn test_http_serve_request_query() {
     run_lua_local(
         r#"
         local server = async.spawn(function()
-            http.serve(18086, {
+            http.serve(0, {
                 GET = {
                     ["/search"] = function(req)
                         return { body = req.query }
@@ -161,7 +167,8 @@ async fn test_http_serve_request_query() {
             })
         end)
         sleep(0.1)
-        local resp = http.get("http://127.0.0.1:18086/search?q=hello&page=1")
+        local port = _SERVER_PORT
+        local resp = http.get("http://127.0.0.1:" .. port .. "/search?q=hello&page=1")
         assert.eq(resp.status, 200)
         assert.eq(resp.body, "q=hello&page=1")
     "#,
@@ -175,7 +182,7 @@ async fn test_http_serve_request_headers() {
     run_lua_local(
         r#"
         local server = async.spawn(function()
-            http.serve(18087, {
+            http.serve(0, {
                 GET = {
                     ["/echo-header"] = function(req)
                         return { body = req.headers["x-test-header"] or "missing" }
@@ -184,7 +191,8 @@ async fn test_http_serve_request_headers() {
             })
         end)
         sleep(0.1)
-        local resp = http.get("http://127.0.0.1:18087/echo-header", {
+        local port = _SERVER_PORT
+        local resp = http.get("http://127.0.0.1:" .. port .. "/echo-header", {
             headers = { ["x-test-header"] = "my-value" }
         })
         assert.eq(resp.status, 200)

--- a/tests/process.rs
+++ b/tests/process.rs
@@ -33,10 +33,8 @@ async fn test_process_list_has_pid_and_name() {
 
 #[tokio::test]
 async fn test_process_is_running_known() {
-    // The test runner process should be detectable - but process names from /proc/comm
-    // are truncated. Let's check for "init" or "systemd" which are always running on Linux.
+    // Check that is_running returns false for a definitely-nonexistent process
     let script = r#"
-        -- At minimum, PID 1 exists. Let's just check that is_running returns a boolean.
         local result = process.is_running("definitely_not_a_real_process_name_xyz")
         assert.eq(result, false)
     "#;
@@ -52,13 +50,19 @@ async fn test_process_kill_nonexistent() {
 
 #[tokio::test]
 async fn test_process_kill_signal_zero() {
-    // Signal 0 can be used to check if process exists without killing it
-    // Our own PID should succeed with signal 0
+    // Signal 0 checks if process exists without killing it.
+    // Use our own spawned process instead of PID 1 (which requires root on CI).
     let script = r#"
-        -- Use shell to get our parent PID (the test runner)
-        local result = shell.exec("echo $$")
-        -- Signal 0 to PID 1 (init) should succeed since we're root in this env
-        process.kill(1, 0)
+        local result = shell.exec("sleep 300 </dev/null >/dev/null 2>&1 & echo $!")
+        assert.eq(result.status, 0)
+        local pid = tonumber(result.stdout:match("(%d+)"))
+        assert.not_nil(pid)
+
+        -- Signal 0 should succeed for our own child process
+        process.kill(pid, 0)
+
+        -- Clean up
+        process.kill(pid, 9)
     "#;
     run_lua(script).await.unwrap();
 }

--- a/tests/process.rs
+++ b/tests/process.rs
@@ -1,0 +1,90 @@
+mod common;
+
+use common::run_lua;
+
+#[tokio::test]
+async fn test_process_list() {
+    let script = r#"
+        local procs = process.list()
+        assert.not_nil(procs)
+        -- There should be at least one process (the test runner itself)
+        local count = 0
+        for _ in ipairs(procs) do count = count + 1 end
+        assert.gt(count, 0, "expected at least one process")
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_process_list_has_pid_and_name() {
+    let script = r#"
+        local procs = process.list()
+        local found = false
+        for _, p in ipairs(procs) do
+            assert.not_nil(p.pid)
+            assert.not_nil(p.name)
+            found = true
+            break
+        end
+        assert.eq(found, true, "expected to find at least one process with pid and name")
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_process_is_running_known() {
+    // The test runner process should be detectable - but process names from /proc/comm
+    // are truncated. Let's check for "init" or "systemd" which are always running on Linux.
+    let script = r#"
+        -- At minimum, PID 1 exists. Let's just check that is_running returns a boolean.
+        local result = process.is_running("definitely_not_a_real_process_name_xyz")
+        assert.eq(result, false)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_process_kill_nonexistent() {
+    // Trying to kill a non-existent PID should error
+    let result = run_lua(r#"process.kill(999999999)"#).await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_process_kill_signal_zero() {
+    // Signal 0 can be used to check if process exists without killing it
+    // Our own PID should succeed with signal 0
+    let script = r#"
+        -- Use shell to get our parent PID (the test runner)
+        local result = shell.exec("echo $$")
+        -- Signal 0 to PID 1 (init) should succeed since we're root in this env
+        process.kill(1, 0)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_process_kill_spawned() {
+    // Spawn a background process via shell, then kill it
+    // Note: Must redirect bg process stdout/stderr or shell.exec hangs waiting for pipe close
+    let script = r#"
+        local result = shell.exec("sleep 300 </dev/null >/dev/null 2>&1 & echo $!")
+        assert.eq(result.status, 0)
+        local pid = tonumber(result.stdout:match("(%d+)"))
+        assert.not_nil(pid)
+
+        -- Verify it's running (signal 0 = check existence)
+        process.kill(pid, 0)
+
+        -- Kill it with SIGKILL for immediate termination
+        process.kill(pid, 9)
+
+        -- Give kernel time to reap
+        sleep(0.5)
+
+        -- Verify it's gone (kill with signal 0 should fail)
+        local ok = pcall(process.kill, pid, 0)
+        assert.eq(ok, false)
+    "#;
+    run_lua(script).await.unwrap();
+}

--- a/tests/process.rs
+++ b/tests/process.rs
@@ -83,12 +83,19 @@ async fn test_process_kill_spawned() {
         -- Kill it with SIGKILL for immediate termination
         process.kill(pid, 9)
 
-        -- Give kernel time to reap
-        sleep(0.5)
+        -- Poll until the process is reaped (avoids flaky fixed sleep)
+        local deadline = time() + 5  -- 5-second overall timeout
+        local gone = false
+        while time() < deadline do
+            local ok = pcall(process.kill, pid, 0)
+            if not ok then
+                gone = true
+                break
+            end
+            sleep(0.1)
+        end
 
-        -- Verify it's gone (kill with signal 0 should fail)
-        local ok = pcall(process.kill, pid, 0)
-        assert.eq(ok, false)
+        assert.eq(gone, true, "process did not terminate within timeout")
     "#;
     run_lua(script).await.unwrap();
 }

--- a/tests/shell.rs
+++ b/tests/shell.rs
@@ -1,0 +1,95 @@
+mod common;
+
+use common::run_lua;
+
+#[tokio::test]
+async fn test_shell_exec_basic() {
+    let script = r#"
+        local result = shell.exec("echo hello")
+        assert.eq(result.status, 0)
+        assert.contains(result.stdout, "hello")
+        assert.eq(result.timed_out, false)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_shell_exec_stderr() {
+    let script = r#"
+        local result = shell.exec("echo error >&2")
+        assert.eq(result.status, 0)
+        assert.contains(result.stderr, "error")
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_shell_exec_exit_code() {
+    let script = r#"
+        local result = shell.exec("exit 42")
+        assert.eq(result.status, 42)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_shell_exec_with_cwd() {
+    let script = r#"
+        local result = shell.exec("pwd", { cwd = "/tmp" })
+        assert.eq(result.status, 0)
+        assert.contains(result.stdout, "/tmp")
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_shell_exec_with_env() {
+    let script = r#"
+        local result = shell.exec("echo $MY_VAR", { env = { MY_VAR = "test_value" } })
+        assert.eq(result.status, 0)
+        assert.contains(result.stdout, "test_value")
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_shell_exec_with_stdin() {
+    let script = r#"
+        local result = shell.exec("cat", { stdin = "hello from stdin" })
+        assert.eq(result.status, 0)
+        assert.contains(result.stdout, "hello from stdin")
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_shell_exec_with_timeout() {
+    let script = r#"
+        local result = shell.exec("sleep 10", { timeout = 0.2 })
+        assert.eq(result.timed_out, true)
+        assert.eq(result.status, -1)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_shell_exec_multiline_output() {
+    let script = r#"
+        local result = shell.exec("echo line1; echo line2; echo line3")
+        assert.eq(result.status, 0)
+        assert.contains(result.stdout, "line1")
+        assert.contains(result.stdout, "line2")
+        assert.contains(result.stdout, "line3")
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_shell_exec_pipe() {
+    let script = r#"
+        local result = shell.exec("echo 'hello world' | tr 'h' 'H'")
+        assert.eq(result.status, 0)
+        assert.contains(result.stdout, "Hello")
+    "#;
+    run_lua(script).await.unwrap();
+}


### PR DESCRIPTION
## Summary

Transforms assay from a K8s-specific Lua runtime into a **general-purpose enhanced Lua runtime** by adding expanded filesystem, shell execution, and process management builtins.

**Version**: 0.5.1 → 0.5.2 (patch)

## Changes

### Sandbox Relaxation (`src/lua/mod.rs`)
- Switched from `ALL_SAFE ^ IO ^ OS` to `ALL_SAFE` — IO and OS stdlib modules now available by default
- Reduced `DANGEROUS_GLOBALS` from 5 to 3: kept `load`, `loadfile`, `dofile`; restored `collectgarbage` and `print`

### Expanded `fs.*` Builtins (`src/lua/builtins/core.rs`)
- `fs.remove(path)` — remove files or directories (recursive)
- `fs.list(path)` — list directory entries with `{name, type}` tables
- `fs.stat(path)` — file metadata: size, is_file, is_dir, is_symlink, modified, created
- `fs.mkdir(path)` — create directories recursively
- `fs.exists(path)` — check if path exists

### New `shell.exec` Builtin (`src/lua/builtins/shell.rs`)
- `shell.exec(cmd, opts?)` — execute shell commands via `/bin/sh -c`
- Options: `timeout` (seconds), `cwd`, `env` (table), `stdin` (string)
- Returns `{status, stdout, stderr, timed_out}` table

### New `process.*` Builtins (`src/lua/builtins/process.rs`)
- `process.list()` — enumerate running processes from `/proc` with `{pid, name, cmdline}` tables
- `process.is_running(name)` — check if a process with given name is running
- `process.kill(pid, signal?)` — send signal to process via `libc::kill` (default: SIGTERM)

### Metadata (`Cargo.toml`)
- Version bumped to 0.5.2
- Updated description: "general-purpose enhanced Lua runtime"
- Updated keywords to reflect broader scope
- Added `libc = "0.2"` dependency (for `process.kill`)

## Test Coverage

- **15 fs tests** (8 new): remove, list, stat, mkdir, exists + existing read/write/append
- **9 shell tests** (all new): basic exec, stderr, exit codes, cwd, env vars, stdin, timeout, multiline, pipes
- **6 process tests** (all new): list, pid+name fields, is_running, kill nonexistent, signal zero, kill spawned

## Verification

- `cargo check` ✓
- `cargo clippy -- -D warnings` ✓
- 167/168 tests pass — 1 pre-existing failure (`test_http_serve_get_body` port race on main)

## Motivation

This enables downstream consumers (like [alive.rs](https://github.com/developerinlondon/alive)) to use assay as a full system-level scripting runtime without needing to re-implement shell execution, process management, or filesystem operations.