### PR TITLE
feat: assay v0.5.3 — disk, os, expanded fs/env builtins + Tier 3 Lua helpers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,7 @@ Available in all `.lua` scripts — no `require` needed:
 |----------|-----------|
 | HTTP | `http.get(url, opts?)`, `http.post(url, body, opts?)`, `http.put(url, body, opts?)`, `http.patch(url, body, opts?)`, `http.delete(url, opts?)`, `http.serve(port, routes)` |
 | JSON/YAML/TOML | `json.parse(str)`, `json.encode(tbl)`, `yaml.parse(str)`, `yaml.encode(tbl)`, `toml.parse(str)`, `toml.encode(tbl)` |
-| Filesystem | `fs.read(path)`, `fs.write(path, str)`, `fs.remove(path)`, `fs.list(path)`, `fs.stat(path)`, `fs.mkdir(path)`, `fs.exists(path)` |
+| Filesystem | `fs.read(path)`, `fs.write(path, str)`, `fs.remove(path)`, `fs.list(path)`, `fs.stat(path)`, `fs.mkdir(path)`, `fs.exists(path)`, `fs.copy(src, dst)`, `fs.rename(src, dst)`, `fs.glob(pattern)`, `fs.tempdir()`, `fs.chmod(path, mode)`, `fs.readdir(path, opts?)` |
 | Crypto | `crypto.jwt_sign(claims, key, alg, opts?)`, `crypto.hash(str, alg)`, `crypto.hmac(key, data, alg?, raw?)`, `crypto.random(len)` |
 | Base64 | `base64.encode(str)`, `base64.decode(str)` |
 | Regex | `regex.match(pat, str)`, `regex.find(pat, str)`, `regex.find_all(pat, str)`, `regex.replace(pat, str, repl)` |
@@ -91,9 +91,11 @@ Available in all `.lua` scripts — no `require` needed:
 | Async | `async.spawn(fn)`, `async.spawn_interval(fn, ms)`, `handle:await()`, `handle:cancel()` |
 | Assert | `assert.eq(a, b, msg?)`, `assert.gt(a, b, msg?)`, `assert.lt(a, b, msg?)`, `assert.contains(str, sub, msg?)`, `assert.not_nil(val, msg?)`, `assert.matches(str, pat, msg?)` |
 | Logging | `log.info(msg)`, `log.warn(msg)`, `log.error(msg)` |
-| Utilities | `env.get(key)`, `sleep(secs)`, `time()` |
+| Utilities | `env.get(key)`, `env.set(key, value)`, `env.list()`, `sleep(secs)`, `time()` |
 | Shell | `shell.exec(cmd, opts?)` — execute commands with timeout, working dir, env |
-| Process | `process.list()`, `process.is_running(name)`, `process.kill(pid, signal?)` |
+| Process | `process.list()`, `process.is_running(name)`, `process.kill(pid, signal?)`, `process.wait_idle(names, timeout, interval)` |
+| Disk | `disk.usage(path)` — returns `{total, used, available, percent}`, `disk.sweep(dir, age_secs)`, `disk.dir_size(path)` |
+| OS | `os.hostname()`, `os.arch()`, `os.platform()` |
 
 HTTP responses: `{status, body, headers}`. Options: `{headers = {["X-Key"] = "val"}}`.
 
@@ -295,7 +297,9 @@ assay/
 │           ├── crypto.rs     # crypto.{jwt_sign,hash,hmac,random}
 │           ├── db.rs         # db.{connect,query,execute,close}
 │           ├── ws.rs         # ws.{connect,send,recv,close}
-│           └── template.rs   # template.{render,render_string}
+│           ├── template.rs   # template.{render,render_string}
+│           ├── disk.rs       # disk.{usage} + Lua helpers: disk.sweep, disk.dir_size
+│           └── os_info.rs    # os.{hostname,arch,platform}
 ├── stdlib/                   # Embedded Lua modules (auto-discovered)
 │   ├── vault.lua             # Comprehensive reference (330 lines)
 │   ├── grafana.lua           # Simple reference (110 lines)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "assay-lua"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "anyhow",
  "axum",
@@ -83,6 +83,7 @@ dependencies = [
  "data-encoding",
  "digest",
  "futures-util",
+ "glob",
  "http-body-util",
  "hyper",
  "hyper-util",
@@ -927,6 +928,12 @@ dependencies = [
  "wasip2",
  "wasip3",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "group"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-lua"
-version = "0.5.2"
+version = "0.5.3"
 categories = ["command-line-utilities", "development-tools::testing"]
 edition = "2024"
 homepage = "https://assay.rs"
@@ -72,6 +72,9 @@ regex-lite = "0.1.9"
 
 # Process signals (kill)
 libc = "0.2"
+
+# Glob pattern matching
+glob = "0.3.3"
 
 # TOML parsing/encoding
 toml = "0.9.12"

--- a/src/lua/builtins/core.rs
+++ b/src/lua/builtins/core.rs
@@ -1,5 +1,6 @@
 use data_encoding::BASE64;
 use mlua::{Lua, Value};
+use std::os::unix::fs::PermissionsExt;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tracing::{error, info, warn};
 
@@ -50,6 +51,33 @@ pub fn register_env(lua: &Lua) -> mlua::Result<()> {
         "#,
     )
     .exec()?;
+
+    // env.set(key, val) — set env var (nil val = unset)
+    let set_fn = lua.create_function(|_, (key, val): (String, Option<String>)| {
+        match val {
+            Some(v) => unsafe { std::env::set_var(&key, &v) },
+            None => unsafe { std::env::remove_var(&key) },
+        }
+        Ok(())
+    })?;
+    lua.globals()
+        .get::<mlua::Table>("env")?
+        .set("set", set_fn)?;
+
+    // env.list() — returns table of {key, value} for all env vars
+    let list_fn = lua.create_function(|lua, ()| {
+        let results = lua.create_table()?;
+        for (i, (key, val)) in (1..).zip(std::env::vars()) {
+            let entry = lua.create_table()?;
+            entry.set("key", key)?;
+            entry.set("value", val)?;
+            results.set(i, entry)?;
+        }
+        Ok(results)
+    })?;
+    lua.globals()
+        .get::<mlua::Table>("env")?
+        .set("list", list_fn)?;
 
     Ok(())
 }
@@ -184,6 +212,132 @@ pub fn register_fs(lua: &Lua) -> mlua::Result<()> {
 
     let exists_fn = lua.create_function(|_, path: String| Ok(std::path::Path::new(&path).exists()))?;
     fs_table.set("exists", exists_fn)?;
+
+    // fs.copy(src, dst) — copy file, returns bytes copied
+    let copy_fn = lua.create_function(|_, (src, dst): (String, String)| {
+        let bytes = std::fs::copy(&src, &dst).map_err(|e| {
+            mlua::Error::runtime(format!("fs.copy: failed to copy {src:?} to {dst:?}: {e}"))
+        })?;
+        Ok(bytes)
+    })?;
+    fs_table.set("copy", copy_fn)?;
+
+    // fs.rename(src, dst) — atomic rename
+    let rename_fn = lua.create_function(|_, (src, dst): (String, String)| {
+        std::fs::rename(&src, &dst).map_err(|e| {
+            mlua::Error::runtime(format!("fs.rename: failed to rename {src:?} to {dst:?}: {e}"))
+        })
+    })?;
+    fs_table.set("rename", rename_fn)?;
+
+    // fs.glob(pattern) — glob pattern matching, returns array of path strings
+    let glob_fn = lua.create_function(|lua, pattern: String| {
+        let paths = glob::glob(&pattern).map_err(|e| {
+            mlua::Error::runtime(format!("fs.glob: invalid pattern {pattern:?}: {e}"))
+        })?;
+        let results = lua.create_table()?;
+        for (i, entry) in (1..).zip(paths) {
+            let path = entry.map_err(|e| {
+                mlua::Error::runtime(format!("fs.glob: error reading entry: {e}"))
+            })?;
+            results.set(i, path.to_string_lossy().to_string())?;
+        }
+        Ok(results)
+    })?;
+    fs_table.set("glob", glob_fn)?;
+
+    // fs.tempdir() — create a temporary directory, returns path string
+    let tempdir_fn = lua.create_function(|_, ()| {
+        let base = std::env::temp_dir();
+        let suffix: u64 = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos() as u64;
+        let dir = base.join(format!("assay-{suffix:x}"));
+        std::fs::create_dir_all(&dir).map_err(|e| {
+            mlua::Error::runtime(format!("fs.tempdir: failed to create {dir:?}: {e}"))
+        })?;
+        Ok(dir.to_string_lossy().to_string())
+    })?;
+    fs_table.set("tempdir", tempdir_fn)?;
+
+    // fs.chmod(path, mode) — set file permissions (octal integer, e.g. 493 = 0o755)
+    let chmod_fn = lua.create_function(|_, (path, mode): (String, u32)| {
+        let perms = std::fs::Permissions::from_mode(mode);
+        std::fs::set_permissions(&path, perms).map_err(|e| {
+            mlua::Error::runtime(format!("fs.chmod: failed to chmod {path:?}: {e}"))
+        })
+    })?;
+    fs_table.set("chmod", chmod_fn)?;
+
+    // fs.readdir(path, opts?) — recursive directory listing
+    // opts: { depth = N } — max recursion depth (nil = unlimited)
+    let readdir_fn = lua.create_function(|lua, args: mlua::MultiValue| {
+        let mut args_iter = args.into_iter();
+        let path: String = args_iter
+            .next()
+            .ok_or_else(|| mlua::Error::runtime("fs.readdir: path required"))
+            .and_then(|v| lua.unpack(v))?;
+
+        let max_depth: Option<usize> = if let Some(Value::Table(opts)) = args_iter.next() {
+            opts.get::<Option<usize>>("depth")?
+        } else {
+            None
+        };
+
+        let results = lua.create_table()?;
+        let mut i = 1u64;
+        let base = std::path::PathBuf::from(&path);
+
+        fn walk(
+            base: &std::path::Path,
+            dir: &std::path::Path,
+            results: &mlua::Table,
+            lua: &Lua,
+            i: &mut u64,
+            depth: usize,
+            max_depth: Option<usize>,
+        ) -> mlua::Result<()> {
+            let entries = std::fs::read_dir(dir).map_err(|e| {
+                mlua::Error::runtime(format!("fs.readdir: failed to read {dir:?}: {e}"))
+            })?;
+            for entry in entries {
+                let entry = entry.map_err(|e| {
+                    mlua::Error::runtime(format!("fs.readdir: error reading entry: {e}"))
+                })?;
+                let file_type = entry.file_type().map_err(|e| {
+                    mlua::Error::runtime(format!("fs.readdir: failed to get file type: {e}"))
+                })?;
+                let rel_path = entry
+                    .path()
+                    .strip_prefix(base)
+                    .unwrap_or(&entry.path())
+                    .to_string_lossy()
+                    .to_string();
+                let info = lua.create_table()?;
+                info.set("path", rel_path)?;
+                if file_type.is_dir() {
+                    info.set("type", "directory")?;
+                } else if file_type.is_symlink() {
+                    info.set("type", "symlink")?;
+                } else {
+                    info.set("type", "file")?;
+                }
+                results.set(*i, info)?;
+                *i += 1;
+                if file_type.is_dir()
+                    && (max_depth.is_none() || depth < max_depth.unwrap())
+                {
+                    walk(base, &entry.path(), results, lua, i, depth + 1, max_depth)?;
+                }
+            }
+            Ok(())
+        }
+
+        walk(&base, &base, &results, lua, &mut i, 1, max_depth)?;
+        Ok(results)
+    })?;
+    fs_table.set("readdir", readdir_fn)?;
 
     lua.globals().set("fs", fs_table)?;
     Ok(())

--- a/src/lua/builtins/disk.rs
+++ b/src/lua/builtins/disk.rs
@@ -75,6 +75,7 @@ struct StatvfsInfo {
     free: u64,
 }
 
+#[allow(clippy::unnecessary_cast)] // f_frsize/f_blocks/f_bfree are u32 on macOS, u64 on Linux
 fn statvfs_info(path: &str) -> Result<StatvfsInfo, String> {
     use std::ffi::CString;
 

--- a/src/lua/builtins/disk.rs
+++ b/src/lua/builtins/disk.rs
@@ -1,0 +1,97 @@
+use mlua::Lua;
+
+pub fn register_disk(lua: &Lua) -> mlua::Result<()> {
+    let disk_table = lua.create_table()?;
+
+    // disk.usage(path) — returns {total, free, used, percent}
+    let usage_fn = lua.create_function(|lua, path: String| {
+        let stat = statvfs_info(&path).map_err(|e| {
+            mlua::Error::runtime(format!("disk.usage: failed to stat {path:?}: {e}"))
+        })?;
+
+        let info = lua.create_table()?;
+        info.set("total", stat.total)?;
+        info.set("free", stat.free)?;
+        info.set("used", stat.total - stat.free)?;
+        info.set(
+            "percent",
+            if stat.total == 0 {
+                0.0
+            } else {
+                (stat.total - stat.free) as f64 / stat.total as f64 * 100.0
+            },
+        )?;
+        Ok(info)
+    })?;
+    disk_table.set("usage", usage_fn)?;
+
+    lua.globals().set("disk", disk_table)?;
+
+    // Tier 3: Lua composable helpers injected after Rust builtins
+    lua.load(
+        r#"
+        -- disk.sweep(dir, age_secs) — remove entries older than age_secs seconds
+        function disk.sweep(dir, age_secs)
+            local now = time()
+            local entries = fs.list(dir)
+            local removed = 0
+            for _, entry in ipairs(entries) do
+                local full_path = dir .. "/" .. entry.name
+                local stat = fs.stat(full_path)
+                if stat and stat.modified then
+                    if (now - stat.modified) > age_secs then
+                        fs.remove(full_path)
+                        removed = removed + 1
+                    end
+                end
+            end
+            return removed
+        end
+
+        -- disk.dir_size(path) — recursive directory size in bytes
+        function disk.dir_size(path)
+            local total = 0
+            local entries = fs.readdir(path)
+            for _, entry in ipairs(entries) do
+                if entry.type == "file" then
+                    local full_path = path .. "/" .. entry.path
+                    local stat = fs.stat(full_path)
+                    if stat then
+                        total = total + stat.size
+                    end
+                end
+            end
+            return total
+        end
+        "#,
+    )
+    .exec()?;
+
+    Ok(())
+}
+
+struct StatvfsInfo {
+    total: u64,
+    free: u64,
+}
+
+fn statvfs_info(path: &str) -> Result<StatvfsInfo, String> {
+    use std::ffi::CString;
+
+    let c_path = CString::new(path).map_err(|e| format!("invalid path: {e}"))?;
+
+    // SAFETY: statvfs is a standard POSIX function. We pass a valid null-terminated
+    // path and a zeroed-out buffer. The kernel fills the buffer on success (ret 0).
+    unsafe {
+        let mut stat: libc::statvfs = std::mem::zeroed();
+        let ret = libc::statvfs(c_path.as_ptr(), &mut stat);
+        if ret != 0 {
+            let err = std::io::Error::last_os_error();
+            return Err(format!("{err}"));
+        }
+        let block_size = stat.f_frsize as u64;
+        let total = stat.f_blocks as u64 * block_size;
+        let free = stat.f_bfree as u64 * block_size;
+        Ok(StatvfsInfo { total, free })
+    }
+}

--- a/src/lua/builtins/mod.rs
+++ b/src/lua/builtins/mod.rs
@@ -1,9 +1,11 @@
 mod assert;
 mod core;
 mod crypto;
+mod disk;
 #[cfg(feature = "db")]
 mod db;
 mod http;
+mod os_info;
 mod json;
 mod process;
 mod serialization;
@@ -32,5 +34,7 @@ pub fn register_all(lua: &mlua::Lua, client: reqwest::Client) -> mlua::Result<()
     template::register_template(lua)?;
     shell::register_shell(lua)?;
     process::register_process(lua)?;
+    disk::register_disk(lua)?;
+    os_info::register_os(lua)?;
     Ok(())
 }

--- a/src/lua/builtins/os_info.rs
+++ b/src/lua/builtins/os_info.rs
@@ -1,0 +1,36 @@
+use mlua::Lua;
+
+pub fn register_os(lua: &Lua) -> mlua::Result<()> {
+    let os_table = lua.create_table()?;
+
+    // os.hostname() — returns hostname string
+    let hostname_fn = lua.create_function(|_, ()| {
+        get_hostname().map_err(|e| mlua::Error::runtime(format!("os.hostname: {e}")))
+    })?;
+    os_table.set("hostname", hostname_fn)?;
+
+    // os.arch() — returns architecture string (e.g. "x86_64", "aarch64")
+    let arch_fn = lua.create_function(|_, ()| Ok(std::env::consts::ARCH.to_string()))?;
+    os_table.set("arch", arch_fn)?;
+
+    // os.platform() — returns OS string (e.g. "linux", "macos", "windows")
+    let platform_fn = lua.create_function(|_, ()| Ok(std::env::consts::OS.to_string()))?;
+    os_table.set("platform", platform_fn)?;
+
+    lua.globals().set("os", os_table)?;
+    Ok(())
+}
+
+fn get_hostname() -> Result<String, String> {
+    let mut buf = [0u8; 256];
+    // SAFETY: gethostname is a standard POSIX function. We pass a valid buffer
+    // and its length. The kernel writes a null-terminated hostname into the buffer.
+    let ret = unsafe { libc::gethostname(buf.as_mut_ptr().cast::<libc::c_char>(), buf.len()) };
+    if ret != 0 {
+        let err = std::io::Error::last_os_error();
+        return Err(format!("{err}"));
+    }
+    // Find the null terminator
+    let len = buf.iter().position(|&b| b == 0).unwrap_or(buf.len());
+    String::from_utf8(buf[..len].to_vec()).map_err(|e| format!("hostname is not valid UTF-8: {e}"))
+}

--- a/src/lua/builtins/process.rs
+++ b/src/lua/builtins/process.rs
@@ -177,5 +177,37 @@ pub fn register_process(lua: &Lua) -> mlua::Result<()> {
     process_table.set("kill", kill_fn)?;
 
     lua.globals().set("process", process_table)?;
+
+    // Tier 3: Lua composable helper
+    lua.load(
+        r#"
+        -- process.wait_idle(names, timeout, interval)
+        -- Wait until none of the named processes are running.
+        -- names: string or table of strings
+        -- timeout: max seconds to wait (default 30)
+        -- interval: poll interval in seconds (default 1)
+        -- Returns true if all idle, false if timed out.
+        function process.wait_idle(names, timeout, interval)
+            timeout = timeout or 30
+            interval = interval or 1
+            if type(names) == "string" then names = {names} end
+            local deadline = time() + timeout
+            while time() < deadline do
+                local any_running = false
+                for _, name in ipairs(names) do
+                    if process.is_running(name) then
+                        any_running = true
+                        break
+                    end
+                end
+                if not any_running then return true end
+                sleep(interval)
+            end
+            return false
+        end
+        "#,
+    )
+    .exec()?;
+
     Ok(())
 }

--- a/tests/disk.rs
+++ b/tests/disk.rs
@@ -1,0 +1,105 @@
+mod common;
+
+use common::run_lua;
+
+#[tokio::test]
+async fn test_disk_usage_root() {
+    let script = r#"
+        local usage = disk.usage("/")
+        assert.not_nil(usage.total)
+        assert.not_nil(usage.free)
+        assert.not_nil(usage.used)
+        assert.not_nil(usage.percent)
+        assert.gt(usage.total, 0, "total should be > 0")
+        assert.gt(usage.free, 0, "free should be > 0")
+        assert.gt(usage.used, 0, "used should be > 0")
+        assert.gt(usage.percent, 0, "percent should be > 0")
+        assert.lt(usage.percent, 100.1, "percent should be <= 100")
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_disk_usage_arithmetic() {
+    let script = r#"
+        local usage = disk.usage("/")
+        -- used = total - free
+        assert.eq(usage.used, usage.total - usage.free)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_disk_usage_invalid_path() {
+    let result = run_lua(r#"disk.usage("/nonexistent/path/that/does/not/exist")"#).await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_disk_sweep() {
+    let script = r#"
+        local dir = fs.tempdir()
+        -- Create some files
+        fs.write(dir .. "/old1.txt", "old content 1")
+        fs.write(dir .. "/old2.txt", "old content 2")
+
+        -- Sweep with age_secs=0 should remove everything (all files are > 0 seconds old)
+        sleep(0.1)
+        local removed = disk.sweep(dir, 0)
+        assert.eq(removed, 2, "should have removed 2 files")
+
+        -- Directory should now be empty
+        local entries = fs.list(dir)
+        local count = 0
+        for _ in ipairs(entries) do count = count + 1 end
+        assert.eq(count, 0, "directory should be empty after sweep")
+
+        fs.remove(dir)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_disk_sweep_preserves_new_files() {
+    let script = r#"
+        local dir = fs.tempdir()
+        fs.write(dir .. "/new.txt", "new content")
+
+        -- Sweep with a large age should remove nothing
+        local removed = disk.sweep(dir, 999999)
+        assert.eq(removed, 0, "should not have removed any files")
+
+        -- File should still exist
+        assert.eq(fs.exists(dir .. "/new.txt"), true)
+
+        fs.remove(dir)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_disk_dir_size() {
+    let script = r#"
+        local dir = fs.tempdir()
+        fs.write(dir .. "/a.txt", "hello")
+        fs.write(dir .. "/b.txt", "world!")
+
+        local size = disk.dir_size(dir)
+        -- "hello" = 5 bytes, "world!" = 6 bytes
+        assert.eq(size, 11, "expected 11 bytes total")
+
+        fs.remove(dir)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_disk_dir_size_empty() {
+    let script = r#"
+        local dir = fs.tempdir()
+        local size = disk.dir_size(dir)
+        assert.eq(size, 0, "empty dir should be 0 bytes")
+        fs.remove(dir)
+    "#;
+    run_lua(script).await.unwrap();
+}

--- a/tests/env.rs
+++ b/tests/env.rs
@@ -18,3 +18,56 @@ async fn test_env_get_missing() {
     "#;
     common::run_lua(script).await.unwrap();
 }
+
+#[tokio::test]
+async fn test_env_set() {
+    let script = r#"
+        -- Set a new env var
+        env.set("ASSAY_TEST_SET_VAR", "from_lua")
+        local val = env.get("ASSAY_TEST_SET_VAR")
+        assert.eq(val, "from_lua")
+
+        -- Unset it by passing nil
+        env.set("ASSAY_TEST_SET_VAR", nil)
+        local val2 = env.get("ASSAY_TEST_SET_VAR")
+        assert.eq(val2, nil)
+    "#;
+    common::run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_env_set_overwrite() {
+    let script = r#"
+        env.set("ASSAY_TEST_OVERWRITE", "first")
+        assert.eq(env.get("ASSAY_TEST_OVERWRITE"), "first")
+        env.set("ASSAY_TEST_OVERWRITE", "second")
+        assert.eq(env.get("ASSAY_TEST_OVERWRITE"), "second")
+        env.set("ASSAY_TEST_OVERWRITE", nil)
+    "#;
+    common::run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_env_list() {
+    let script = r#"
+        env.set("ASSAY_TEST_LIST_VAR", "present")
+        local vars = env.list()
+        assert.not_nil(vars)
+
+        local count = 0
+        local found = false
+        for _, v in ipairs(vars) do
+            count = count + 1
+            assert.not_nil(v.key)
+            assert.not_nil(v.value)
+            if v.key == "ASSAY_TEST_LIST_VAR" and v.value == "present" then
+                found = true
+            end
+        end
+        assert.gt(count, 0, "should have at least one env var")
+        assert.eq(found, true, "should find ASSAY_TEST_LIST_VAR in list")
+
+        env.set("ASSAY_TEST_LIST_VAR", nil)
+    "#;
+    common::run_lua(script).await.unwrap();
+}

--- a/tests/fs.rs
+++ b/tests/fs.rs
@@ -220,3 +220,209 @@ async fn test_fs_remove_nonexistent() {
     let result = run_lua(r#"fs.remove("/nonexistent/file.txt")"#).await;
     assert!(result.is_err());
 }
+
+#[tokio::test]
+async fn test_fs_copy() {
+    let script = r#"
+        local dir = fs.tempdir()
+        fs.write(dir .. "/source.txt", "copy me")
+        local bytes = fs.copy(dir .. "/source.txt", dir .. "/dest.txt")
+        assert.eq(bytes, 7)
+        local content = fs.read(dir .. "/dest.txt")
+        assert.eq(content, "copy me")
+        -- Source should still exist
+        assert.eq(fs.exists(dir .. "/source.txt"), true)
+        fs.remove(dir)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_fs_copy_nonexistent() {
+    let result = run_lua(r#"fs.copy("/nonexistent/src", "/tmp/dst")"#).await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_fs_rename() {
+    let script = r#"
+        local dir = fs.tempdir()
+        fs.write(dir .. "/before.txt", "rename me")
+        fs.rename(dir .. "/before.txt", dir .. "/after.txt")
+        assert.eq(fs.exists(dir .. "/before.txt"), false)
+        assert.eq(fs.exists(dir .. "/after.txt"), true)
+        local content = fs.read(dir .. "/after.txt")
+        assert.eq(content, "rename me")
+        fs.remove(dir)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_fs_rename_nonexistent() {
+    let result = run_lua(r#"fs.rename("/nonexistent/src", "/tmp/dst")"#).await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_fs_glob() {
+    let script = r#"
+        local dir = fs.tempdir()
+        fs.write(dir .. "/a.txt", "a")
+        fs.write(dir .. "/b.txt", "b")
+        fs.write(dir .. "/c.log", "c")
+
+        local matches = fs.glob(dir .. "/*.txt")
+        local count = 0
+        for _ in ipairs(matches) do count = count + 1 end
+        assert.eq(count, 2, "should match 2 .txt files")
+
+        local all = fs.glob(dir .. "/*")
+        local all_count = 0
+        for _ in ipairs(all) do all_count = all_count + 1 end
+        assert.eq(all_count, 3, "should match all 3 files")
+
+        fs.remove(dir)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_fs_glob_recursive() {
+    let script = r#"
+        local dir = fs.tempdir()
+        fs.mkdir(dir .. "/sub")
+        fs.write(dir .. "/top.txt", "top")
+        fs.write(dir .. "/sub/nested.txt", "nested")
+
+        local matches = fs.glob(dir .. "/**/*.txt")
+        local count = 0
+        for _ in ipairs(matches) do count = count + 1 end
+        assert.eq(count, 2, "should match 2 .txt files recursively")
+
+        fs.remove(dir)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_fs_glob_no_match() {
+    let script = r#"
+        local matches = fs.glob("/tmp/assay-nonexistent-pattern-*.xyz")
+        local count = 0
+        for _ in ipairs(matches) do count = count + 1 end
+        assert.eq(count, 0)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_fs_glob_invalid_pattern() {
+    let result = run_lua(r#"fs.glob("[invalid")"#).await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_fs_tempdir() {
+    let script = r#"
+        local dir = fs.tempdir()
+        assert.not_nil(dir)
+        assert.gt(#dir, 0, "tempdir path should not be empty")
+        assert.eq(fs.exists(dir), true)
+
+        -- Should be able to write into it
+        fs.write(dir .. "/test.txt", "hello")
+        assert.eq(fs.read(dir .. "/test.txt"), "hello")
+
+        fs.remove(dir)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_fs_chmod() {
+    let script = r#"
+        local dir = fs.tempdir()
+        local path = dir .. "/chmod_test.txt"
+        fs.write(path, "test")
+
+        -- Set to 0o644 = 420 decimal
+        fs.chmod(path, 420)
+        local stat = fs.stat(path)
+        assert.eq(stat.is_file, true)
+
+        -- Set to 0o755 = 493 decimal
+        fs.chmod(path, 493)
+
+        fs.remove(dir)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_fs_chmod_nonexistent() {
+    let result = run_lua(r#"fs.chmod("/nonexistent/file", 420)"#).await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_fs_readdir() {
+    let script = r#"
+        local dir = fs.tempdir()
+        fs.write(dir .. "/a.txt", "a")
+        fs.mkdir(dir .. "/sub")
+        fs.write(dir .. "/sub/b.txt", "b")
+
+        local entries = fs.readdir(dir)
+        local count = 0
+        local has_file = false
+        local has_dir = false
+        local has_nested = false
+        for _, e in ipairs(entries) do
+            count = count + 1
+            if e.path == "a.txt" and e.type == "file" then has_file = true end
+            if e.path == "sub" and e.type == "directory" then has_dir = true end
+            if e.path == "sub/b.txt" and e.type == "file" then has_nested = true end
+        end
+        assert.eq(count, 3, "should have 3 entries (a.txt, sub, sub/b.txt)")
+        assert.eq(has_file, true, "should have a.txt")
+        assert.eq(has_dir, true, "should have sub directory")
+        assert.eq(has_nested, true, "should have sub/b.txt")
+
+        fs.remove(dir)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_fs_readdir_with_depth() {
+    let script = r#"
+        local dir = fs.tempdir()
+        fs.write(dir .. "/top.txt", "top")
+        fs.mkdir(dir .. "/a")
+        fs.write(dir .. "/a/mid.txt", "mid")
+        fs.mkdir(dir .. "/a/b")
+        fs.write(dir .. "/a/b/deep.txt", "deep")
+
+        -- depth=1 should only list top level
+        local entries = fs.readdir(dir, {depth = 1})
+        local count = 0
+        local has_deep = false
+        for _, e in ipairs(entries) do
+            count = count + 1
+            if e.path == "a/b/deep.txt" then has_deep = true end
+        end
+        -- Should have: top.txt, a, a/mid.txt (a is listed, mid.txt at depth 1 inside a)
+        -- but NOT a/b/deep.txt (that's depth 2)
+        assert.eq(has_deep, false, "should not include deep entries at depth=1")
+
+        fs.remove(dir)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_fs_readdir_nonexistent() {
+    let result = run_lua(r#"fs.readdir("/nonexistent/path")"#).await;
+    assert!(result.is_err());
+}

--- a/tests/os_info.rs
+++ b/tests/os_info.rs
@@ -1,0 +1,55 @@
+mod common;
+
+use common::run_lua;
+
+#[tokio::test]
+async fn test_os_hostname() {
+    let script = r#"
+        local h = os.hostname()
+        assert.not_nil(h)
+        -- hostname should be a non-empty string
+        assert.gt(#h, 0, "hostname should not be empty")
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_os_arch() {
+    let script = r#"
+        local arch = os.arch()
+        assert.not_nil(arch)
+        assert.gt(#arch, 0, "arch should not be empty")
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_os_arch_known_value() {
+    // On this machine it should be x86_64 or aarch64
+    let script = r#"
+        local arch = os.arch()
+        local known = (arch == "x86_64" or arch == "aarch64" or arch == "arm")
+        assert.eq(known, true, "arch should be a known architecture, got: " .. arch)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_os_platform() {
+    let script = r#"
+        local p = os.platform()
+        assert.not_nil(p)
+        assert.gt(#p, 0, "platform should not be empty")
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_os_platform_known_value() {
+    let script = r#"
+        local p = os.platform()
+        local known = (p == "linux" or p == "macos" or p == "windows")
+        assert.eq(known, true, "platform should be a known OS, got: " .. p)
+    "#;
+    run_lua(script).await.unwrap();
+}

--- a/tests/process.rs
+++ b/tests/process.rs
@@ -99,3 +99,22 @@ async fn test_process_kill_spawned() {
     "#;
     run_lua(script).await.unwrap();
 }
+
+#[tokio::test]
+async fn test_process_wait_idle_not_running() {
+    // A process that doesn't exist should return true immediately
+    let script = r#"
+        local result = process.wait_idle("definitely_nonexistent_process_xyz123", 2, 0.1)
+        assert.eq(result, true)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_process_wait_idle_table_of_names() {
+    let script = r#"
+        local result = process.wait_idle({"nonexistent_a", "nonexistent_b"}, 2, 0.1)
+        assert.eq(result, true)
+    "#;
+    run_lua(script).await.unwrap();
+}


### PR DESCRIPTION
## Summary

Adds all three tiers of new builtins to make assay a richer general-purpose Lua runtime, preparing for embedding in alive.rs and visor-init.

### Tier 1 — Filesystem Expansion
- `fs.copy(src, dst)` — file copy with metadata preservation
- `fs.rename(src, dst)` — atomic move/rename
- `fs.glob(pattern)` — glob pattern matching via `glob` crate (supports `**` recursion)
- `fs.tempdir()` — create OS temp directory, returns path
- `fs.chmod(path, mode)` — Unix permission change (octal mode)

### Tier 2 — New Modules
- `fs.readdir(path, opts?)` — recursive directory walk with optional `{depth=N}` limit
- `env.set(key, value)` — set/unset environment variables
- `env.list()` — list all environment variables as table
- `os.hostname()`, `os.arch()`, `os.platform()` — system info (new `os_info.rs` module)
- `disk.usage(path)` — filesystem usage via `libc::statvfs` (new `disk.rs` module)

### Tier 3 — Composable Lua Helpers
Pure Lua functions composed from existing builtins:
- `disk.sweep(dir, age_secs)` — remove files older than threshold
- `disk.dir_size(path)` — sum file sizes recursively
- `process.wait_idle(names, timeout, interval)` — poll until processes exit

### Changes
- **New dep**: `glob = "0.3.3"` (only new dependency)
- **New files**: `src/lua/builtins/disk.rs`, `src/lua/builtins/os_info.rs`, `tests/disk.rs`, `tests/os_info.rs`
- **Modified**: `core.rs` (fs/env builtins), `process.rs` (wait_idle helper), `mod.rs` (wiring)
- **Tests**: 30 new tests across 5 test files (750 total, all passing)
- **AGENTS.md**: Updated builtin table and directory structure
- **Version**: 0.5.2 → 0.5.3

### Quality Gates
- `cargo check` ✅
- `cargo clippy -- -D warnings` ✅
- `cargo test` ✅ (750 tests, 0 failures)