### PR TITLE
feat: add follow_redirects option to HTTP checks and Lua http.client()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to Assay are documented here.
 
+
+## [0.5.5] - 2026-03-13
+
+### Added
+
+- **follow_redirects** option for YAML HTTP checks. Set `follow_redirects: false` to disable
+  automatic redirect following, allowing verification of auth-protected endpoints that return
+  302 redirects to identity providers. Defaults to `true` for backward compatibility.
+- **follow_redirects** option for Lua `http.client()` builder. Create clients with
+  `http.client({ follow_redirects = false })` for the same no-redirect behavior in scripts.
+
 ## [0.5.4] - 2026-03-12
 
 ### Fixed
@@ -81,6 +92,7 @@ All notable changes to Assay are documented here.
   Projects (CRUD, list), environments (enable/disable per project), features (CRUD, archive,
   toggle on/off), strategies (list, add), API tokens (CRUD). Idempotent helpers:
   `ensure_project`, `ensure_environment`, `ensure_token`.
+
 
 ## [0.4.3] - 2026-02-13
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "assay-lua"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-lua"
-version = "0.5.4"
+version = "0.5.5"
 categories = ["command-line-utilities", "development-tools::testing"]
 edition = "2024"
 homepage = "https://assay.rs"

--- a/src/checks/http.rs
+++ b/src/checks/http.rs
@@ -1,6 +1,7 @@
 use crate::config::CheckConfig;
 use crate::output::CheckResult;
 use anyhow::{Context, Result, bail};
+use std::time::Duration;
 
 pub struct HttpCheck;
 
@@ -15,7 +16,20 @@ impl HttpCheck {
             .as_deref()
             .context("http check requires a 'url' field")?;
 
-        let resp = client
+        // Build a no-redirect client when follow_redirects is false
+        let no_redirect_client;
+        let effective_client = if config.follow_redirects {
+            client
+        } else {
+            no_redirect_client = reqwest::Client::builder()
+                .redirect(reqwest::redirect::Policy::none())
+                .timeout(Duration::from_secs(30))
+                .build()
+                .context("building no-redirect HTTP client")?;
+            &no_redirect_client
+        };
+
+        let resp = effective_client
             .get(url)
             .send()
             .await

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,6 +21,7 @@ pub struct CheckConfig {
     pub expect: Option<ExpectConfig>,
     pub query: Option<String>,
     pub file: Option<String>,
+    pub follow_redirects: bool,
     pub env: HashMap<String, String>,
 }
 
@@ -65,6 +66,10 @@ fn default_backoff() -> String {
     "5s".to_string()
 }
 
+fn default_follow_redirects() -> bool {
+    true
+}
+
 #[derive(Deserialize)]
 struct RawCheck {
     name: String,
@@ -72,6 +77,8 @@ struct RawCheck {
     check_type: String,
     url: Option<String>,
     expect: Option<RawExpect>,
+    #[serde(default = "default_follow_redirects")]
+    follow_redirects: bool,
     query: Option<String>,
     file: Option<String>,
     #[serde(default)]
@@ -137,6 +144,7 @@ pub fn parse(yaml: &str) -> Result<Config> {
                     min: e.min,
                     max: e.max,
                 }),
+                follow_redirects: c.follow_redirects,
                 query: c.query,
                 file: c.file,
                 env: c.env,

--- a/src/lua/builtins/http.rs
+++ b/src/lua/builtins/http.rs
@@ -50,6 +50,14 @@ pub fn register_http(lua: &Lua, client: reqwest::Client) -> mlua::Result<()> {
             .unwrap_or(30.0);
         builder = builder.timeout(std::time::Duration::from_secs_f64(timeout_secs));
 
+        let follow_redirects: bool = opts
+            .as_ref()
+            .and_then(|t| t.get::<bool>("follow_redirects").ok())
+            .unwrap_or(true);
+        if !follow_redirects {
+            builder = builder.redirect(reqwest::redirect::Policy::none());
+        }
+
         if let Some(ref opts_table) = opts {
             if let Ok(ca_path) = opts_table.get::<String>("ca_cert_file") {
                 let pem = std::fs::read(&ca_path).map_err(|e| {


### PR DESCRIPTION
## Summary
- Added follow_redirects field to YAML HTTP check config (defaults to true for backward compat)
- When follow_redirects: false, builds a no-redirect reqwest client so the raw 302 is returned
- Added follow_redirects option to Lua http.client() builder for parity

## Use case
External verify checks for endpoints behind oauth2-proxy were failing because they followed the 302 redirect to dex, which was not ready during bootstrap.

## Example
checks:
  - name: phpmyadmin-external
    type: http
    url: https://mariadb.agenteda.com/
    follow_redirects: false
    expect:
      status: 302