### PR TITLE
feat: SSE streaming support and Content-Type fix for http.serve

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ yaml, assert, log, env, sleep, time, base64).
 | `http.serve(port, routes)`               | Start HTTP server (blocking)               |
 | `opts.headers = {["X-Key"] = "value"}`   | Custom headers                             |
 | `routes = {GET = {["/path"] = handler}}` | Route table for server                     |
+| `return {sse = function(send) ... end}`  | SSE streaming response (server)            |
 
 ### Serialization
 
@@ -496,6 +497,39 @@ http.serve(8080, {
   }
 })
 ```
+
+### Server-Sent Events (SSE)
+
+```lua
+#!/usr/bin/assay
+-- Stream events to clients in real-time
+http.serve(8080, {
+  GET = {
+    ["/events"] = function(req)
+      return {
+        status = 200,
+        sse = function(send)
+          send({ data = "connected" })
+          for i = 1, 5 do
+            sleep(1)
+            send({
+              event = "update",
+              data = json.encode({ count = i }),
+              id = tostring(i)
+            })
+          end
+          send({ event = "done", data = "stream complete" })
+        end
+      }
+    end
+  }
+})
+```
+
+The `send` callback accepts a table with optional fields: `event`, `data`, `id`, `retry`.
+Headers `Content-Type: text/event-stream`, `Cache-Control: no-cache`, and
+`Connection: keep-alive` are set automatically. The stream closes when the
+function returns.
 
 ### Prometheus Verification
 

--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ Supported URLs:
 | Function                          | Description         |
 | --------------------------------- | ------------------- |
 | `assert.eq(a, b, msg?)`           | Assert equal        |
+| `assert.ne(a, b, msg?)`           | Assert not equal    |
 | `assert.gt(a, b, msg?)`           | Assert greater than |
 | `assert.lt(a, b, msg?)`           | Assert less than    |
 | `assert.contains(str, sub, msg?)` | Assert substring    |

--- a/SKILL.md
+++ b/SKILL.md
@@ -189,6 +189,7 @@ URLs: `postgres://user:pass@host:5432/db`, `mysql://...`, `sqlite:///path/to/fil
 | Function                          | Description              |
 | --------------------------------- | ------------------------ |
 | `assert.eq(a, b, msg?)`           | Assert equal             |
+| `assert.ne(a, b, msg?)`           | Assert not equal         |
 | `assert.gt(a, b, msg?)`           | Assert greater than      |
 | `assert.lt(a, b, msg?)`           | Assert less than         |
 | `assert.contains(str, sub, msg?)` | Assert substring present |

--- a/site/index.html
+++ b/site/index.html
@@ -63,7 +63,7 @@
     </p>
 
     <h3>Lua Script Mode</h3>
-    <p>Run any Lua script with all builtins available &mdash; HTTP, JSON, crypto, database, and 23 embedded stdlib modules:</p>
+    <p>Run any Lua script with all builtins available &mdash; HTTP client/server, SSE streaming, JSON, crypto, database, and 23 embedded stdlib modules:</p>
     <pre><code>-- Lua mode: query Prometheus directly
 local prom = require("assay.prometheus")
 local result = prom.query("http://prom:9090", "up")

--- a/site/llms-full.txt
+++ b/site/llms-full.txt
@@ -31,6 +31,10 @@ Options table supports `{headers = {["X-Key"] = "value"}}`.
 - `http.serve(port, routes)` → blocks — Start HTTP server
   - Routes: `{GET = {["/path"] = function(req) return {status=200, body="ok"} end}}`
   - Handlers receive `{method, path, body, headers, query}`, return `{status, body, json?, headers?}`
+  - SSE: return `{sse = function(send) send({event="update", data="hello", id="1"}) end}`
+    - `send()` accepts: `event`, `data`, `id`, `retry` fields
+    - Sets `Content-Type: text/event-stream` automatically
+    - Stream closes when function returns
 
 ## json
 

--- a/site/llms-full.txt
+++ b/site/llms-full.txt
@@ -139,6 +139,7 @@ Async task management. No `require()` needed.
 Assertion utilities. No `require()` needed. All raise `error()` on failure.
 
 - `assert.eq(a, b, msg?)` — Assert `a == b`
+- `assert.ne(a, b, msg?)` — Assert `a ~= b`
 - `assert.gt(a, b, msg?)` — Assert `a > b`
 - `assert.lt(a, b, msg?)` — Assert `a < b`
 - `assert.contains(str, sub, msg?)` — Assert string contains substring

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -13,7 +13,7 @@
 - [GitHub](https://github.com/developerinlondon/assay): Source code and issues
 
 ## Built-in Globals (no require needed)
-- [http](https://assay.rs/modules.html#http): HTTP client and server — http.get/post/put/patch/delete/serve
+- [http](https://assay.rs/modules.html#http): HTTP client, server, SSE streaming — http.get/post/put/patch/delete/serve
 - [json](https://assay.rs/modules.html#json): JSON parse and encode
 - [yaml](https://assay.rs/modules.html#yaml): YAML parse and encode
 - [toml](https://assay.rs/modules.html#toml): TOML parse and encode

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -25,7 +25,7 @@
 - [ws](https://assay.rs/modules.html#ws): WebSocket client — ws.connect/send/recv/close
 - [template](https://assay.rs/modules.html#template): Jinja2-compatible template rendering
 - [async](https://assay.rs/modules.html#async): Async task spawn and await
-- [assert](https://assay.rs/modules.html#assert): Assertions — assert.eq/gt/lt/contains/not_nil/matches
+- [assert](https://assay.rs/modules.html#assert): Assertions — assert.eq/ne/gt/lt/contains/not_nil/matches
 - [log](https://assay.rs/modules.html#log): Logging — log.info/warn/error
 - [env](https://assay.rs/modules.html#env): Environment variables — env.get
 - [sleep](https://assay.rs/modules.html#sleep): Sleep for N seconds

--- a/site/modules.html
+++ b/site/modules.html
@@ -230,7 +230,7 @@ assay context "grafana health"   # get detailed docs for LLM</code></pre>
       <tbody>
         <tr>
           <td><code>assert</code></td>
-          <td><code>assert.eq/gt/lt/contains/not_nil/matches</code></td>
+          <td><code>assert.eq/ne/gt/lt/contains/not_nil/matches</code></td>
           <td>Assertions</td>
         </tr>
         <tr>

--- a/site/modules.html
+++ b/site/modules.html
@@ -61,6 +61,27 @@ assay context "grafana health"   # get detailed docs for LLM</code></pre>
       </tbody>
     </table>
 
+    <h4>SSE Streaming Example</h4>
+    <pre><code>http.serve(8080, {
+  GET = {
+    ["/events"] = function(req)
+      return {
+        sse = function(send)
+          send({ data = "connected" })
+          sleep(1)
+          send({ event = "update", data = json.encode({count = 1}), id = "1" })
+          -- stream closes when function returns
+        end
+      }
+    end
+  }
+})</code></pre>
+    <p>
+      The <code>send</code> callback accepts <code>event</code>, <code>data</code>, <code>id</code>,
+      and <code>retry</code> fields. SSE headers (<code>text/event-stream</code>, <code>no-cache</code>,
+      <code>keep-alive</code>) are set automatically.
+    </p>
+
     <!-- Serialization -->
     <h3>Serialization</h3>
     <table>

--- a/site/modules.html
+++ b/site/modules.html
@@ -51,7 +51,7 @@ assay context "grafana health"   # get detailed docs for LLM</code></pre>
         <tr>
           <td><code>http</code></td>
           <td><code>http.get/post/put/patch/delete/serve</code></td>
-          <td>HTTP client and server</td>
+          <td>HTTP client, server, and SSE streaming</td>
         </tr>
         <tr>
           <td><code>ws</code></td>

--- a/src/lua/builtins/assert.rs
+++ b/src/lua/builtins/assert.rs
@@ -22,6 +22,25 @@ pub fn register_assert(lua: &Lua) -> mlua::Result<()> {
     })?;
     assert_table.set("eq", eq_fn)?;
 
+    let ne_fn = lua.create_function(|lua, args: mlua::MultiValue| {
+        let mut args_iter = args.into_iter();
+        let a = args_iter.next().unwrap_or(Value::Nil);
+        let b = args_iter.next().unwrap_or(Value::Nil);
+        let msg = extract_string_arg(lua, args_iter.next());
+
+        if lua_values_equal(&a, &b) {
+            let detail = format!(
+                "assert.ne failed: {:?} == {:?}{}",
+                format_lua_value(&a),
+                format_lua_value(&b),
+                msg.map(|m| format!(" - {m}")).unwrap_or_default()
+            );
+            return Err(mlua::Error::runtime(detail));
+        }
+        Ok(())
+    })?;
+    assert_table.set("ne", ne_fn)?;
+
     let gt_fn = lua.create_function(|lua, args: mlua::MultiValue| {
         let mut args_iter = args.into_iter();
         let a = lua_value_to_f64(args_iter.next().unwrap_or(Value::Nil));

--- a/src/lua/builtins/http.rs
+++ b/src/lua/builtins/http.rs
@@ -545,12 +545,12 @@ fn lua_response_to_http(
             let send_fn = match lua_clone.create_async_function(move |_lua, event_table: Table| {
                 let tx_ref = tx_for_fn.clone();
                 async move {
-                    let binding = tx_ref.borrow();
-                    if let Some(ref tx) = *binding {
-                        let formatted = format_sse_event(&event_table)?;
-                        if tx.send(Bytes::from(formatted)).await.is_err() {
-                            return Err(mlua::Error::runtime("SSE stream closed"));
-                        }
+                    let formatted = format_sse_event(&event_table)?;
+                    let tx_clone = tx_ref.borrow().clone();
+                    if let Some(tx) = tx_clone
+                        && tx.send(Bytes::from(formatted)).await.is_err()
+                    {
+                        return Err(mlua::Error::runtime("SSE stream closed"));
                     }
                     Ok(())
                 }

--- a/src/lua/builtins/http.rs
+++ b/src/lua/builtins/http.rs
@@ -543,10 +543,10 @@ fn lua_response_to_http(
                 }
             };
 
-            if let Err(e) = sse_fn.call::<()>(send_fn) {
-                if !e.to_string().contains("SSE stream closed") {
-                    error!("http.serve SSE: handler error: {e}");
-                }
+            if let Err(e) = sse_fn.call::<()>(send_fn)
+                && !e.to_string().contains("SSE stream closed")
+            {
+                error!("http.serve SSE: handler error: {e}");
             }
 
             // Explicitly close the channel so the response body completes

--- a/src/lua/builtins/http.rs
+++ b/src/lua/builtins/http.rs
@@ -2,9 +2,9 @@ use super::json::lua_table_to_json;
 #[cfg(feature = "server")]
 use super::json::lua_value_to_json;
 #[cfg(feature = "server")]
-use http_body_util::Full;
+use http_body_util::{Either, Full};
 #[cfg(feature = "server")]
-use hyper::body::{Bytes, Incoming};
+use hyper::body::{Bytes, Frame, Incoming};
 #[cfg(feature = "server")]
 use hyper::server::conn::http1;
 #[cfg(feature = "server")]
@@ -15,7 +15,13 @@ use mlua::{Lua, Table, UserData, Value};
 #[cfg(feature = "server")]
 use std::collections::HashMap;
 #[cfg(feature = "server")]
+use std::cell::RefCell;
+#[cfg(feature = "server")]
+use std::pin::Pin;
+#[cfg(feature = "server")]
 use std::rc::Rc;
+#[cfg(feature = "server")]
+use std::task::{Context, Poll};
 #[cfg(feature = "server")]
 use tokio::net::TcpListener;
 #[cfg(feature = "server")]
@@ -336,6 +342,63 @@ async fn execute_http_request(
     Ok(Value::Table(result))
 }
 
+/// A streaming body backed by an mpsc channel, used for SSE responses.
+#[cfg(feature = "server")]
+struct SseBody {
+    rx: tokio::sync::mpsc::Receiver<Bytes>,
+}
+
+#[cfg(feature = "server")]
+impl hyper::body::Body for SseBody {
+    type Data = Bytes;
+    type Error = std::convert::Infallible;
+
+    fn poll_frame(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<Option<Result<Frame<Self::Data>, Self::Error>>> {
+        match self.rx.poll_recv(cx) {
+            Poll::Ready(Some(bytes)) => Poll::Ready(Some(Ok(Frame::data(bytes)))),
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+/// Format a Lua table with optional `event`, `data`, `id`, `retry` fields into an SSE text block.
+#[cfg(feature = "server")]
+fn format_sse_event(event_table: &Table) -> mlua::Result<String> {
+    let mut out = String::new();
+
+    if let Ok(Some(event)) = event_table.get::<Option<String>>("event") {
+        out.push_str("event: ");
+        out.push_str(&event);
+        out.push('\n');
+    }
+    if let Ok(Some(data)) = event_table.get::<Option<String>>("data") {
+        // SSE spec: each line of data gets its own "data:" prefix
+        for line in data.split('\n') {
+            out.push_str("data: ");
+            out.push_str(line);
+            out.push('\n');
+        }
+    }
+    if let Ok(Some(id)) = event_table.get::<Option<String>>("id") {
+        out.push_str("id: ");
+        out.push_str(&id);
+        out.push('\n');
+    }
+    if let Ok(Some(retry)) = event_table.get::<Option<i64>>("retry") {
+        out.push_str("retry: ");
+        out.push_str(&retry.to_string());
+        out.push('\n');
+    }
+
+    // SSE events are terminated by a blank line
+    out.push('\n');
+    Ok(out)
+}
+
 #[cfg(feature = "server")]
 fn parse_routes(routes_table: &Table) -> mlua::Result<HashMap<(String, String), mlua::Function>> {
     let mut routes = HashMap::new();
@@ -351,11 +414,14 @@ fn parse_routes(routes_table: &Table) -> mlua::Result<HashMap<(String, String), 
 }
 
 #[cfg(feature = "server")]
+type ServerBody = Either<Full<Bytes>, SseBody>;
+
+#[cfg(feature = "server")]
 async fn handle_request(
     lua: &Lua,
     routes: &HashMap<(String, String), mlua::Function>,
     req: Request<Incoming>,
-) -> Result<Response<Full<Bytes>>, hyper::Error> {
+) -> Result<Response<ServerBody>, hyper::Error> {
     let method = req.method().to_string();
     let path = req.uri().path().to_string();
     let query = req.uri().query().unwrap_or("").to_string();
@@ -378,17 +444,19 @@ async fn handle_request(
             return Ok(Response::builder()
                 .status(StatusCode::NOT_FOUND)
                 .header("content-type", "text/plain")
-                .body(Full::new(Bytes::from("not found")))
+                .body(Either::Left(Full::new(Bytes::from("not found"))))
                 .unwrap());
         }
     };
 
     match build_lua_request_and_call(lua, handler, &method, &path, &query, &headers, &body_str) {
-        Ok(lua_resp) => lua_response_to_http(&lua_resp),
+        Ok(lua_resp) => lua_response_to_http(lua, &lua_resp),
         Err(e) => Ok(Response::builder()
             .status(StatusCode::INTERNAL_SERVER_ERROR)
             .header("content-type", "text/plain")
-            .body(Full::new(Bytes::from(format!("handler error: {e}"))))
+            .body(Either::Left(Full::new(Bytes::from(format!(
+                "handler error: {e}"
+            )))))
             .unwrap()),
     }
 }
@@ -419,11 +487,74 @@ fn build_lua_request_and_call(
 }
 
 #[cfg(feature = "server")]
-fn lua_response_to_http(resp_table: &Table) -> Result<Response<Full<Bytes>>, hyper::Error> {
+fn lua_response_to_http(
+    lua: &Lua,
+    resp_table: &Table,
+) -> Result<Response<ServerBody>, hyper::Error> {
     let status = resp_table
         .get::<Option<u16>>("status")
         .unwrap_or(None)
         .unwrap_or(200);
+
+    // Check for SSE function first
+    if let Ok(Some(sse_fn)) = resp_table.get::<Option<mlua::Function>>("sse") {
+        let (tx, rx) = tokio::sync::mpsc::channel::<Bytes>(32);
+
+        let mut builder =
+            Response::builder().status(StatusCode::from_u16(status).unwrap_or(StatusCode::OK));
+        builder = builder.header("content-type", "text/event-stream");
+        builder = builder.header("cache-control", "no-cache");
+        builder = builder.header("connection", "keep-alive");
+
+        // Apply any custom headers from the response table
+        if let Ok(Some(headers_table)) = resp_table.get::<Option<Table>>("headers") {
+            for (k, v) in headers_table.pairs::<String, String>().flatten() {
+                builder = builder.header(k, v);
+            }
+        }
+
+        let response = builder.body(Either::Right(SseBody { rx })).unwrap();
+
+        // Spawn the SSE function on the local set.
+        // We wrap tx in Rc<RefCell<Option>> so we can explicitly close the channel
+        // after the SSE function returns. If tx were only inside the Lua closure,
+        // it would stay alive as long as Lua's GC keeps the closure, preventing the
+        // channel from closing and the response body from completing.
+        let lua_clone = lua.clone();
+        tokio::task::spawn_local(async move {
+            let tx_holder: Rc<RefCell<Option<tokio::sync::mpsc::Sender<Bytes>>>> =
+                Rc::new(RefCell::new(Some(tx)));
+            let tx_for_fn = tx_holder.clone();
+
+            let send_fn = match lua_clone.create_function(move |_lua, event_table: Table| {
+                let binding = tx_for_fn.borrow();
+                if let Some(ref tx) = *binding {
+                    let formatted = format_sse_event(&event_table)?;
+                    if tx.try_send(Bytes::from(formatted)).is_err() {
+                        return Err(mlua::Error::runtime("SSE stream closed"));
+                    }
+                }
+                Ok(())
+            }) {
+                Ok(f) => f,
+                Err(e) => {
+                    error!("http.serve SSE: failed to create send callback: {e}");
+                    return;
+                }
+            };
+
+            if let Err(e) = sse_fn.call::<()>(send_fn) {
+                if !e.to_string().contains("SSE stream closed") {
+                    error!("http.serve SSE: handler error: {e}");
+                }
+            }
+
+            // Explicitly close the channel so the response body completes
+            tx_holder.borrow_mut().take();
+        });
+
+        return Ok(response);
+    }
 
     let mut builder =
         Response::builder().status(StatusCode::from_u16(status).unwrap_or(StatusCode::OK));
@@ -463,5 +594,7 @@ fn lua_response_to_http(resp_table: &Table) -> Result<Response<Full<Bytes>>, hyp
         Bytes::new()
     };
 
-    Ok(builder.body(Full::new(body_bytes)).unwrap())
+    Ok(builder
+        .body(Either::Left(Full::new(body_bytes)))
+        .unwrap())
 }

--- a/src/lua/builtins/http.rs
+++ b/src/lua/builtins/http.rs
@@ -371,6 +371,11 @@ fn format_sse_event(event_table: &Table) -> mlua::Result<String> {
     let mut out = String::new();
 
     if let Ok(Some(event)) = event_table.get::<Option<String>>("event") {
+        if event.contains('\n') || event.contains('\r') {
+            return Err(mlua::Error::runtime(
+                "SSE event name must not contain newlines",
+            ));
+        }
         out.push_str("event: ");
         out.push_str(&event);
         out.push('\n');
@@ -384,6 +389,9 @@ fn format_sse_event(event_table: &Table) -> mlua::Result<String> {
         }
     }
     if let Ok(Some(id)) = event_table.get::<Option<String>>("id") {
+        if id.contains('\n') || id.contains('\r') {
+            return Err(mlua::Error::runtime("SSE id must not contain newlines"));
+        }
         out.push_str("id: ");
         out.push_str(&id);
         out.push('\n');
@@ -546,10 +554,11 @@ fn lua_response_to_http(
                 let tx_ref = tx_for_fn.clone();
                 async move {
                     let formatted = format_sse_event(&event_table)?;
-                    let tx_clone = tx_ref.borrow().clone();
-                    if let Some(tx) = tx_clone
-                        && tx.send(Bytes::from(formatted)).await.is_err()
-                    {
+                    let tx = tx_ref
+                        .borrow()
+                        .clone()
+                        .ok_or_else(|| mlua::Error::runtime("SSE stream closed"))?;
+                    if tx.send(Bytes::from(formatted)).await.is_err() {
                         return Err(mlua::Error::runtime("SSE stream closed"));
                     }
                     Ok(())

--- a/src/lua/builtins/http.rs
+++ b/src/lua/builtins/http.rs
@@ -428,23 +428,38 @@ fn lua_response_to_http(resp_table: &Table) -> Result<Response<Full<Bytes>>, hyp
     let mut builder =
         Response::builder().status(StatusCode::from_u16(status).unwrap_or(StatusCode::OK));
 
-    if let Ok(Some(headers_table)) = resp_table.get::<Option<Table>>("headers") {
+    let has_content_type = if let Ok(Some(headers_table)) =
+        resp_table.get::<Option<Table>>("headers")
+    {
+        let mut found_ct = false;
         for (k, v) in headers_table.pairs::<String, String>().flatten() {
+            if k.eq_ignore_ascii_case("content-type") {
+                found_ct = true;
+            }
             builder = builder.header(k, v);
         }
-    }
+        found_ct
+    } else {
+        false
+    };
 
     let body_bytes = if let Ok(Some(json_table)) = resp_table.get::<Option<Table>>("json") {
         let json_val =
             lua_value_to_json(&Value::Table(json_table)).unwrap_or(serde_json::Value::Null);
         let serialized = serde_json::to_string(&json_val).unwrap_or_else(|_| "null".to_string());
-        builder = builder.header("content-type", "application/json");
+        if !has_content_type {
+            builder = builder.header("content-type", "application/json");
+        }
         Bytes::from(serialized)
     } else if let Ok(Some(body_str)) = resp_table.get::<Option<String>>("body") {
-        builder = builder.header("content-type", "text/plain");
+        if !has_content_type {
+            builder = builder.header("content-type", "text/plain");
+        }
         Bytes::from(body_str)
     } else {
-        builder = builder.header("content-type", "text/plain");
+        if !has_content_type {
+            builder = builder.header("content-type", "text/plain");
+        }
         Bytes::new()
     };
 

--- a/src/lua/builtins/http.rs
+++ b/src/lua/builtins/http.rs
@@ -502,18 +502,34 @@ fn lua_response_to_http(
 
         let mut builder =
             Response::builder().status(StatusCode::from_u16(status).unwrap_or(StatusCode::OK));
-        builder = builder.header("content-type", "text/event-stream");
-        builder = builder.header("cache-control", "no-cache");
-        builder = builder.header("connection", "keep-alive");
 
-        // Apply any custom headers from the response table
+        // Apply custom headers first so they take precedence over SSE defaults
         if let Ok(Some(headers_table)) = resp_table.get::<Option<Table>>("headers") {
             for (k, v) in headers_table.pairs::<String, String>().flatten() {
                 builder = builder.header(k, v);
             }
         }
 
-        let response = builder.body(Either::Right(SseBody { rx })).unwrap();
+        let mut response = builder.body(Either::Right(SseBody { rx })).unwrap();
+        let response_headers = response.headers_mut();
+        if !response_headers.contains_key(hyper::header::CONTENT_TYPE) {
+            response_headers.insert(
+                hyper::header::CONTENT_TYPE,
+                hyper::header::HeaderValue::from_static("text/event-stream"),
+            );
+        }
+        if !response_headers.contains_key(hyper::header::CACHE_CONTROL) {
+            response_headers.insert(
+                hyper::header::CACHE_CONTROL,
+                hyper::header::HeaderValue::from_static("no-cache"),
+            );
+        }
+        if !response_headers.contains_key(hyper::header::CONNECTION) {
+            response_headers.insert(
+                hyper::header::CONNECTION,
+                hyper::header::HeaderValue::from_static("keep-alive"),
+            );
+        }
 
         // Spawn the SSE function on the local set.
         // We wrap tx in Rc<RefCell<Option>> so we can explicitly close the channel
@@ -526,15 +542,18 @@ fn lua_response_to_http(
                 Rc::new(RefCell::new(Some(tx)));
             let tx_for_fn = tx_holder.clone();
 
-            let send_fn = match lua_clone.create_function(move |_lua, event_table: Table| {
-                let binding = tx_for_fn.borrow();
-                if let Some(ref tx) = *binding {
-                    let formatted = format_sse_event(&event_table)?;
-                    if tx.try_send(Bytes::from(formatted)).is_err() {
-                        return Err(mlua::Error::runtime("SSE stream closed"));
+            let send_fn = match lua_clone.create_async_function(move |_lua, event_table: Table| {
+                let tx_ref = tx_for_fn.clone();
+                async move {
+                    let binding = tx_ref.borrow();
+                    if let Some(ref tx) = *binding {
+                        let formatted = format_sse_event(&event_table)?;
+                        if tx.send(Bytes::from(formatted)).await.is_err() {
+                            return Err(mlua::Error::runtime("SSE stream closed"));
+                        }
                     }
+                    Ok(())
                 }
-                Ok(())
             }) {
                 Ok(f) => f,
                 Err(e) => {
@@ -543,7 +562,7 @@ fn lua_response_to_http(
                 }
             };
 
-            if let Err(e) = sse_fn.call::<()>(send_fn)
+            if let Err(e) = sse_fn.call_async::<()>(send_fn).await
                 && !e.to_string().contains("SSE stream closed")
             {
                 error!("http.serve SSE: handler error: {e}");

--- a/tests/http_serve.rs
+++ b/tests/http_serve.rs
@@ -202,3 +202,41 @@ async fn test_http_serve_request_headers() {
     .await
     .unwrap();
 }
+
+#[tokio::test]
+async fn test_http_serve_sse() {
+    run_lua_local(
+        r#"
+        local server = async.spawn(function()
+            http.serve(0, {
+                GET = {
+                    ["/events"] = function(req)
+                        return {
+                            status = 200,
+                            sse = function(send)
+                                send({ data = "hello" })
+                                send({ event = "update", data = "world" })
+                                send({ event = "done", data = "bye", id = "3" })
+                            end
+                        }
+                    end,
+                }
+            })
+        end)
+        sleep(0.2)
+        local port = _SERVER_PORT
+        local resp = http.get("http://127.0.0.1:" .. port .. "/events")
+        assert.eq(resp.status, 200)
+        assert.contains(resp.headers["content-type"], "text/event-stream")
+        -- Verify SSE events are present in order
+        assert.contains(resp.body, "data: hello")
+        assert.contains(resp.body, "event: update")
+        assert.contains(resp.body, "data: world")
+        assert.contains(resp.body, "event: done")
+        assert.contains(resp.body, "data: bye")
+        assert.contains(resp.body, "id: 3")
+    "#,
+    )
+    .await
+    .unwrap();
+}

--- a/tests/http_serve.rs
+++ b/tests/http_serve.rs
@@ -229,12 +229,47 @@ async fn test_http_serve_sse() {
         assert.eq(resp.status, 200)
         assert.contains(resp.headers["content-type"], "text/event-stream")
         -- Verify SSE events are present in order
-        assert.contains(resp.body, "data: hello")
-        assert.contains(resp.body, "event: update")
-        assert.contains(resp.body, "data: world")
-        assert.contains(resp.body, "event: done")
-        assert.contains(resp.body, "data: bye")
-        assert.contains(resp.body, "id: 3")
+        local hello_idx = string.find(resp.body, "data: hello", 1, true)
+        assert.ne(hello_idx, nil)
+        local update_idx = string.find(resp.body, "event: update", hello_idx + 1, true)
+        assert.ne(update_idx, nil)
+        local world_idx = string.find(resp.body, "data: world", update_idx + 1, true)
+        assert.ne(world_idx, nil)
+        local done_idx = string.find(resp.body, "event: done", world_idx + 1, true)
+        assert.ne(done_idx, nil)
+        local bye_idx = string.find(resp.body, "data: bye", done_idx + 1, true)
+        assert.ne(bye_idx, nil)
+        local id_idx = string.find(resp.body, "id: 3", bye_idx + 1, true)
+        assert.ne(id_idx, nil)
+    "#,
+    )
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn test_http_serve_custom_content_type() {
+    run_lua_local(
+        r#"
+        local server = async.spawn(function()
+            http.serve(0, {
+                GET = {
+                    ["/html"] = function(req)
+                        return {
+                            status = 200,
+                            body = "<h1>ok</h1>",
+                            headers = { ["content-type"] = "text/html" }
+                        }
+                    end,
+                }
+            })
+        end)
+        sleep(0.2)
+        local port = _SERVER_PORT
+        local resp = http.get("http://127.0.0.1:" .. port .. "/html")
+        assert.eq(resp.status, 200)
+        assert.eq(resp.headers["content-type"], "text/html")
+        assert.eq(resp.body, "<h1>ok</h1>")
     "#,
     )
     .await


### PR DESCRIPTION
## Changes

- Add SSE streaming response support via `{ sse = function(send) ... end }` in `http.serve` handlers
- Ensure custom `Content-Type` in headers takes precedence over default `text/plain` / `application/json`
- Add/extend tests and update README + site docs to describe SSE usage
- Add `assert.ne` (not equal) assertion to the test framework and all docs

## Details

### SSE Streaming
- SSE handler runs async (`call_async`) so `sleep()` and other async builtins work inside SSE functions
- `send` callback uses `tx.send().await` for proper backpressure handling
- Custom headers take precedence over SSE defaults (Content-Type, Cache-Control, Connection)
- Stream closes when the SSE function returns

### Content-Type Fix
- User-provided `Content-Type` header no longer gets overwritten by defaults
- Added `test_http_serve_custom_content_type` regression test

### assert.ne
- New inequality assertion: `assert.ne(a, b, msg?)`
- Documented in README, SKILL.md, site/modules.html, llms.txt, llms-full.txt