### PR TITLE
chore: bump version to 0.5.6

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ Available in all `.lua` scripts — no `require` needed:
 | WebSocket | `ws.connect(url)`, `ws.send(conn, msg)`, `ws.recv(conn)`, `ws.close(conn)` |
 | Templates | `template.render(path, vars)`, `template.render_string(tmpl, vars)` |
 | Async | `async.spawn(fn)`, `async.spawn_interval(fn, ms)`, `handle:await()`, `handle:cancel()` |
-| Assert | `assert.eq(a, b, msg?)`, `assert.gt(a, b, msg?)`, `assert.lt(a, b, msg?)`, `assert.contains(str, sub, msg?)`, `assert.not_nil(val, msg?)`, `assert.matches(str, pat, msg?)` |
+| Assert | `assert.eq(a, b, msg?)`, `assert.ne(a, b, msg?)`, `assert.gt(a, b, msg?)`, `assert.lt(a, b, msg?)`, `assert.contains(str, sub, msg?)`, `assert.not_nil(val, msg?)`, `assert.matches(str, pat, msg?)` |
 | Logging | `log.info(msg)`, `log.warn(msg)`, `log.error(msg)` |
 | Utilities | `env.get(key)`, `env.set(key, value)`, `env.list()`, `sleep(secs)`, `time()` |
 | Shell | `shell.exec(cmd, opts?)` — execute commands with timeout, working dir, env |
@@ -293,7 +293,7 @@ assay/
 │           ├── json.rs       # json.{parse,encode}
 │           ├── serialization.rs  # yaml + toml parse/encode
 │           ├── core.rs       # env, sleep, time, fs, base64, regex, log, async
-│           ├── assert.rs     # assert.{eq,gt,lt,contains,not_nil,matches}
+│           ├── assert.rs     # assert.{eq,ne,gt,lt,contains,not_nil,matches}
 │           ├── crypto.rs     # crypto.{jwt_sign,hash,hmac,random}
 │           ├── db.rs         # db.{connect,query,execute,close}
 │           ├── ws.rs         # ws.{connect,send,recv,close}
@@ -319,6 +319,28 @@ assay/
 | Not Luau | Rejected | Lua 5.1 base, Roblox ecosystem, no int64 |
 | Not Rhai | Rejected | 6x slower, no async, no coroutines |
 | Not Wasmtime | Rejected | Requires compile step, bad for script iteration |
+
+## Release Process
+
+After merging a feature PR, always create a version bump PR before moving on:
+
+1. **Bump version** in `Cargo.toml` (triggers `Cargo.lock` update on next build)
+2. **Update CHANGELOG.md** — add new version section at the top with date and changes
+3. **Update AGENTS.md** — if new builtins/functions were added, update the tables
+4. **Update all docs** — README.md, SKILL.md, site/modules.html, site/llms.txt, site/llms-full.txt
+5. **Run checks**: `cargo clippy --tests -- -D warnings && cargo test`
+6. **Create a new branch** (e.g., `chore/bump-0.5.6`), commit, push, open PR
+7. **After merge**: tag the release (`git tag v0.5.6 && git push origin v0.5.6`)
+
+Files to update per release:
+- `Cargo.toml` — version field
+- `CHANGELOG.md` — new version entry
+- `AGENTS.md` — if API surface changed
+- `README.md` — if API surface changed
+- `SKILL.md` — if API surface changed
+- `site/modules.html` — if API surface changed
+- `site/llms.txt` — if API surface changed
+- `site/llms-full.txt` — if API surface changed
 
 ## Commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,34 @@ Available in all `.lua` scripts — no `require` needed:
 
 HTTP responses: `{status, body, headers}`. Options: `{headers = {["X-Key"] = "val"}}`.
 
+### `http.serve` Response Shapes
+
+Route handlers return a table. Three shapes are supported:
+
+```lua
+-- Body response (default Content-Type: text/plain)
+return { status = 200, body = "hello" }
+
+-- JSON response (default Content-Type: application/json)
+return { status = 200, json = { ok = true } }
+
+-- SSE streaming response (default Content-Type: text/event-stream)
+return {
+  status = 200,
+  sse = function(send)
+    send({ data = "connected" })
+    sleep(1)  -- async builtins work inside SSE handlers
+    send({ event = "update", data = json.encode({ count = 1 }), id = "1" })
+    -- stream closes when function returns
+  end
+}
+```
+
+Custom headers override defaults: `headers = { ["content-type"] = "text/html" }`.
+
+SSE `send()` accepts: `event` (string), `data` (string), `id` (string), `retry` (integer).
+`event` and `id` must not contain newlines. `data` handles multi-line automatically.
+
 ## Stdlib Modules
 
 23 embedded Lua modules loaded via `require("assay.<name>")`:
@@ -289,7 +317,7 @@ assay/
 │       ├── async_bridge.rs   # Async Lua execution, shebang stripping
 │       └── builtins/
 │           ├── mod.rs        # register_all() — wires builtins into Lua globals
-│           ├── http.rs       # http.{get,post,put,patch,delete,serve}
+│           ├── http.rs       # http.{get,post,put,patch,delete,serve} + SSE streaming
 │           ├── json.rs       # json.{parse,encode}
 │           ├── serialization.rs  # yaml + toml parse/encode
 │           ├── core.rs       # env, sleep, time, fs, base64, regex, log, async

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to Assay are documented here.
 
 
+## [0.5.6] - 2026-04-03
+
+### Added
+
+- **SSE streaming** for `http.serve` via `{ sse = function(send) ... end }` return shape.
+  SSE handler runs async so `sleep()` and other async builtins work inside the producer.
+  `send` callback uses async channel send with proper backpressure handling.
+  Custom headers take precedence over SSE defaults (Content-Type, Cache-Control, Connection).
+- **assert.ne(a, b, msg?)** — inequality assertion for the test framework.
+
+### Fixed
+
+- **Content-Type precedence**: User-provided `Content-Type` header no longer overwritten
+  by defaults (`text/plain` / `application/json`) in `http.serve` responses.
+- **SSE newline validation**: `event` and `id` fields reject values containing newlines
+  or carriage returns to prevent SSE field injection.
+
 ## [0.5.5] - 2026-03-13
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "assay-lua"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-lua"
-version = "0.5.5"
+version = "0.5.6"
 categories = ["command-line-utilities", "development-tools::testing"]
 edition = "2024"
 homepage = "https://assay.rs"


### PR DESCRIPTION
## Changes

Bump version to 0.5.6 after merging SSE streaming support (#12).

### Included in 0.5.6
- SSE streaming response support via `{ sse = function(send) ... end }`
- Content-Type precedence fix (custom headers take priority over defaults)
- `assert.ne(a, b, msg?)` inequality assertion
- SSE newline validation for event/id fields

### Housekeeping
- Update CHANGELOG.md with 0.5.6 entry
- Update AGENTS.md with assert.ne in API tables
- Document release process in AGENTS.md