### PR TITLE
feat: OpenClaw integration — full Lobster replacement (v0.6.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,19 @@ permissions:
   contents: read
 
 jobs:
+  extension-tests:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: openclaw-extension
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - run: npm install
+      - run: npx vitest run
+
   check:
     strategy:
       fail-fast: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,3 +105,26 @@ jobs:
           tags: |
             ghcr.io/developerinlondon/assay:${{ github.ref_name }}
             ghcr.io/developerinlondon/assay:latest
+
+  npm:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://npm.pkg.github.com"
+
+      - name: Sync version from git tag
+        working-directory: openclaw-extension
+        run: npm version "${GITHUB_REF_NAME#v}" --no-git-tag-version --allow-same-version
+
+      - name: Publish to GitHub Packages
+        working-directory: openclaw-extension
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.opencode/plans/05-openclaw-integration.md
+++ b/.opencode/plans/05-openclaw-integration.md
@@ -1,0 +1,297 @@
+# Plan 05: OpenClaw Integration — Full Lobster Replacement (v0.6.0)
+
+**Status**: Approved — implementation in progress
+**Created**: 2026-04-05
+**Branch**: `feat/openclaw-integration`
+**Version**: 0.5.6 → 0.6.0 (minor release — new capability domain)
+
+## Context
+
+Assay is replacing Lobster as the workflow runtime for OpenClaw. Lobster is a Node.js YAML pipeline
+runner (~80MB runtime). Assay replaces it with a 9MB static binary, proper control flow (Lua),
+parallel execution, error handling, and 27 stdlib modules Lobster has no equivalent for.
+
+This plan covers two directions of integration:
+- **Assay → OpenClaw**: Lua modules that call the OpenClaw HTTP API (stdlib)
+- **OpenClaw → Assay**: TypeScript plugin that spawns the `assay` binary (extension)
+
+## Architecture
+
+```
++------------------------------------------------------------------+
+|               OpenClaw Server (TypeScript)                        |
+|                                                                  |
+|  extensions/lobster/  <-- existing, spawns lobster (DEPRECATED)   |
+|                                                                  |
+|  User installs @assay/openclaw-extension via:                    |
+|    openclaw plugins install @assay/openclaw-extension             |
+|                                                                  |
+|  POST /tools/invoke   <-- HTTP gateway (already exists)          |
++--------+--------------------------+------------------------------+
+         | spawns                   | HTTP responses
+         v                         |
++------------------+    +-----------+------------------------------+
+| assay binary     |    | assay script (standalone mode)            |
+| (tool mode)      |    |                                          |
+|                  |    | local oc = require("assay.openclaw")      |
+| --mode tool      |    | c:invoke("message","send",{...})          |
+| JSON envelope    |    |    --- HTTP POST ---> OpenClaw API        |
+| on stdout        |    |                                          |
+| resume support   |    | c:state_set("key", data)                  |
++------------------+    |    --- local fs ---> ~/.assay/state/      |
+                        +------------------------------------------+
+```
+
+```
++------------------------------------------------------------------+
+|                    WHAT LIVES WHERE                               |
+|                                                                  |
+|  assay repo (Rust + Lua + TS extension):                         |
+|  +-- src/                     Rust runtime                       |
+|  |   +-- tool_mode.rs         NEW: --mode tool envelope output   |
+|  |   +-- resume.rs            NEW: assay resume --token X        |
+|  +-- stdlib/                  Lua modules                        |
+|  |   +-- openclaw.lua         DONE: OpenClaw API client          |
+|  |   +-- github.lua           DONE: GitHub REST API              |
+|  |   +-- gmail.lua            DONE: Gmail REST + OAuth2          |
+|  |   +-- gcal.lua             DONE: Google Calendar + OAuth2     |
+|  |   +-- oauth2.lua           TODO: Shared token management      |
+|  |   +-- email_triage.lua     TODO: Email classification         |
+|  +-- openclaw-extension/      NEW: TypeScript OpenClaw plugin    |
+|  |   +-- package.json         @assay/openclaw-extension          |
+|  |   +-- openclaw.plugin.json Plugin manifest                    |
+|  |   +-- index.ts             register(api) entry point          |
+|  |   +-- src/assay-tool.ts    Spawn assay, parse JSON envelope   |
+|  |   +-- SKILL.md             Agent-facing docs                  |
+|  |   +-- README.md            User-facing docs                   |
+|  +-- tests/                   Wiremock-based Rust tests           |
+|  +-- examples/                Example Lua scripts                |
+|                                                                  |
+|  openclaw-ts repo: NO CHANGES (users install extension via npm)  |
++------------------------------------------------------------------+
+```
+
+## What's Already Done
+
+Commit `c77b505` on `feat/openclaw-integration` (20 files, +2173/-100):
+
+| Item                       | Status | Detail                                    |
+| -------------------------- | ------ | ----------------------------------------- |
+| `stdlib/openclaw.lua`      | Done   | 166 lines, 12 methods, 7 tests           |
+| `stdlib/github.lua`        | Done   | 179 lines, 12 methods, 9 tests           |
+| `stdlib/gmail.lua`         | Done   | 204 lines, 5 methods, 6 tests            |
+| `stdlib/gcal.lua`          | Done   | 170 lines, 6 methods, 6 tests            |
+| Cargo.toml version bump    | Done   | 0.5.6 → 0.6.0                            |
+| CHANGELOG.md               | Done   | v0.6.0 section                            |
+| README.md                  | Done   | Module count 23→27, new table rows        |
+| SKILL.md                   | Done   | Module count 23→27, new table rows        |
+| AGENTS.md                  | Done   | Description + module table updated        |
+| llms.txt (root + site)     | Done   | New AI Agent & Workflow section            |
+| site/llms-full.txt         | Done   | Full code examples for 4 modules          |
+| site/modules.html          | Done   | New HTML section with examples            |
+| examples/openclaw-health   | Done   | 22 lines                                  |
+| examples/github-pr-monitor | Done   | 37 lines                                  |
+
+## What Remains
+
+### Sprint 1: Stdlib Completion (Lua only, no Rust)
+
+- [ ] **1.1** Extract `stdlib/oauth2.lua` (~120 lines) from duplicated inline code in gmail.lua
+      and gcal.lua. Functions: `M.from_file(creds_path, token_path)`, `client:access_token()`,
+      `client:refresh()`, `client:save()`. Default paths: `~/.config/gog/credentials.json` and
+      `~/.config/gog/token.json`. Support overrides via opts table.
+- [ ] **1.2** Refactor `gmail.lua` and `gcal.lua` to `require("assay.oauth2")` internally instead
+      of inline token refresh. No API changes to gmail/gcal — purely internal refactor.
+- [ ] **1.3** Create `stdlib/email_triage.lua` (~100 lines). Functions:
+      `M.categorize(emails, opts)` — deterministic rules (subject keywords, noreply detection),
+      returns `{needs_reply={}, needs_action={}, fyi={}}`.
+      `M.categorize_llm(emails, openclaw_client, opts)` — uses OpenClaw LLM task for smarter
+      classification + optional draft replies.
+- [ ] **1.4** Add tests for `oauth2.lua` — wiremock tests for token refresh, expired token,
+      file persistence, error handling (~6 tests)
+- [ ] **1.5** Add tests for `email_triage.lua` — unit tests for deterministic categorization,
+      wiremock test for LLM-assisted mode (~5 tests)
+- [ ] **1.6** Fill test gaps in existing modules (~12 missing method tests):
+      - openclaw: `notify`, `cron_add`, `spawn`, `approve`
+      - github: `pr_reviews`, `pr_merge`, `issue_get`, `issue_comment`, `run_get`
+      - gmail: `reply`
+      - gcal: `event_update`, token refresh
+- [ ] **1.7** Add example scripts: `examples/gmail-digest.lua`, `examples/gcal-daily-agenda.lua`,
+      `examples/email-triage.lua`
+
+### Sprint 2: Rust Tool-Mode Envelope
+
+Assay needs a "tool mode" so OpenClaw can spawn it and read structured JSON from stdout.
+
+- [ ] **2.1** Add `--mode tool` CLI flag (clap). When set, assay wraps script output in a JSON
+      envelope on stdout:
+      ```json
+      {
+        "ok": true,
+        "status": "ok",
+        "output": "<script return value as JSON>",
+        "requiresApproval": null
+      }
+      ```
+      Error case: `{ "ok": false, "status": "error", "error": "<message>" }`
+- [ ] **2.2** Also support `ASSAY_MODE=tool` env var (same behavior as `--mode tool`).
+      Env var takes precedence if both are set.
+- [ ] **2.3** In tool mode, suppress all log.info/log.warn output to stderr (not stdout).
+      Only the final JSON envelope goes to stdout.
+- [ ] **2.4** Add stdout size cap (512KB, matching Lobster's limit) and execution timeout
+      (configurable via `--timeout <secs>`, default 20s).
+- [ ] **2.5** Tests for tool mode: envelope format, error envelope, timeout, stdout cap,
+      stderr separation (~8 tests)
+
+### Sprint 3: Resume/Halt Mechanism (Rust)
+
+For approval gates to work when Assay runs as an OpenClaw tool, the binary needs to halt
+mid-execution and resume later.
+
+- [ ] **3.1** Add `assay resume --token <token> --approve yes|no` CLI subcommand.
+- [ ] **3.2** When `openclaw.approve()` is called in tool mode, the script halts and emits:
+      ```json
+      {
+        "ok": true,
+        "status": "needs_approval",
+        "requiresApproval": {
+          "prompt": "Deploy to production?",
+          "context": { ... },
+          "resumeToken": "<base64-encoded state>"
+        }
+      }
+      ```
+- [ ] **3.3** State serialization: save Lua VM state to `~/.assay/state/resume/<token>.json`.
+      State includes: script path, environment, approval context, and a continuation marker.
+      (Full VM serialization is not feasible — the resume re-runs the script with the approval
+      result injected, matching Lobster's pattern.)
+- [ ] **3.4** On `assay resume --token X --approve yes`, load state, re-execute script with
+      `ASSAY_APPROVAL_RESULT=yes` env var. The `openclaw.approve()` function checks this var
+      and returns the result immediately instead of halting.
+- [ ] **3.5** Resume token expiry: state files expire after 1 hour (configurable via
+      `--resume-ttl <secs>`). Expired tokens return error envelope.
+- [ ] **3.6** Tests for resume: approve/reject flow, expired token, invalid token,
+      state cleanup (~7 tests)
+
+### Sprint 4: OpenClaw Extension (TypeScript, in assay repo)
+
+The TypeScript plugin that lets OpenClaw spawn and communicate with the assay binary.
+Lives in `assay/openclaw-extension/` and is published to npm as `@assay/openclaw-extension`.
+
+- [ ] **4.1** Create `openclaw-extension/package.json`:
+      ```json
+      {
+        "name": "@assay/openclaw-extension",
+        "version": "0.6.0",
+        "description": "Assay workflow runtime for OpenClaw",
+        "openclaw": { "extensions": ["./index.ts"] },
+        "peerDependencies": { "openclaw": "*" }
+      }
+      ```
+- [ ] **4.2** Create `openclaw-extension/openclaw.plugin.json`:
+      ```json
+      {
+        "id": "assay",
+        "name": "Assay Workflow Runtime",
+        "description": "Run Lua workflow scripts via Assay",
+        "configSchema": {
+          "type": "object",
+          "properties": {
+            "binaryPath": { "type": "string", "description": "Path to assay binary" },
+            "timeout": { "type": "number", "default": 20 },
+            "maxOutputSize": { "type": "number", "default": 524288 },
+            "stateDir": { "type": "string" },
+            "scriptsDir": { "type": "string" }
+          }
+        }
+      }
+      ```
+- [ ] **4.3** Create `openclaw-extension/index.ts` — `register(api)` that calls
+      `api.registerTool()` with optional flag, skip when sandboxed.
+- [ ] **4.4** Create `openclaw-extension/src/assay-tool.ts` (~250 lines):
+      - `run` action: spawn `assay run --mode tool <script>`, parse JSON envelope from stdout
+      - `resume` action: spawn `assay resume --token <token> --approve yes|no`
+      - Sandboxed CWD (relative paths only, no path traversal)
+      - Timeout + stdout cap enforcement
+      - Tolerant JSON parser (skip debug output before final JSON, match Lobster's pattern)
+- [ ] **4.5** Create `openclaw-extension/SKILL.md` (~100 lines) — agent-facing documentation:
+      when to use assay vs shell, available modules, script patterns, approval workflow.
+      Must list all 29 stdlib modules (27 existing + oauth2 + email_triage).
+- [ ] **4.6** Create `openclaw-extension/README.md` — user-facing: installation, configuration,
+      security model, examples.
+- [ ] **4.7** Tests for the tool: mock assay binary spawning, envelope parsing, timeout,
+      sandbox path validation, resume flow (~8 tests)
+
+### Sprint 5: Documentation & Release
+
+- [ ] **5.1** Update CHANGELOG.md with complete v0.6.0 notes covering all new modules,
+      tool mode, resume support, and OpenClaw extension.
+- [ ] **5.2** Update README.md — add OpenClaw integration section, update module count to 29,
+      add `openclaw-extension` section.
+- [ ] **5.3** Update AGENTS.md — module count 27→29, add tool mode and extension docs.
+- [ ] **5.4** Update SKILL.md — module count 27→29.
+- [ ] **5.5** Update site/modules.html — add oauth2 and email_triage to the Agent & Workflow
+      section.
+- [ ] **5.6** Update llms.txt, site/llms.txt, site/llms-full.txt — add oauth2 and
+      email_triage docs.
+- [ ] **5.7** Run full verification: `cargo clippy --tests -- -D warnings && cargo test`
+- [ ] **5.8** Verify openclaw-extension builds: `cd openclaw-extension && npm install && npm test`
+
+## Key Design Decisions
+
+| Decision                   | Choice                    | Why                                        |
+| -------------------------- | ------------------------- | ------------------------------------------ |
+| Version                    | 0.6.0 (minor)            | New capability domain, 6+ new modules      |
+| email_triage location      | stdlib module             | Reusable, not just an example              |
+| OAuth2 credentials         | gog config files default  | Existing infra, overridable via opts       |
+| State directory            | ~/.assay/state/           | Overridable via ASSAY_STATE_DIR env var    |
+| Extension packaging        | In assay repo             | Versions with assay, team controls it      |
+| Extension distribution     | npm as @assay/openclaw-ext| Users: openclaw plugins install ...        |
+| YAML workflow compat       | Skipped                   | Clean break — Lua only, no .lobster shim   |
+| Shell-free                 | All HTTP-native           | No subprocess overhead, proper errors      |
+| Resume mechanism           | Re-run with env var       | Full VM serialization not feasible in Lua  |
+| Tool mode output           | JSON envelope on stdout   | Matches Lobster protocol for compatibility |
+
+## Extension Versioning Strategy
+
+The `openclaw-extension/` directory has its own `package.json` with semver. The version tracks
+Assay's version (both start at 0.6.0) but can diverge if the extension needs a hotfix without
+a runtime change. The SKILL.md is the coupling point — it must accurately reflect which Assay
+version's modules are available.
+
+```
+assay v0.6.0  <-->  @assay/openclaw-extension v0.6.0   (initial release)
+assay v0.6.1  <-->  @assay/openclaw-extension v0.6.1   (both get bugfixes)
+assay v0.7.0  <-->  @assay/openclaw-extension v0.7.0   (new modules added)
+assay v0.7.0  <-->  @assay/openclaw-extension v0.7.1   (extension-only fix)
+```
+
+## Dependency Graph
+
+```
+stdlib/oauth2.lua          (standalone)
+stdlib/openclaw.lua        (standalone)
+stdlib/github.lua          (standalone)
+stdlib/gmail.lua       --> oauth2.lua (internal require, lazy)
+stdlib/gcal.lua        --> oauth2.lua (internal require, lazy)
+stdlib/email_triage.lua -> gmail.lua + openclaw.lua (lazy require)
+
+src/tool_mode.rs       --> src/main.rs (CLI integration)
+src/resume.rs          --> src/tool_mode.rs (reuses envelope format)
+
+openclaw-extension/    --> assay binary (spawns it as subprocess)
+                       --> openclaw/plugin-sdk (peerDependency)
+```
+
+## Effort Estimate
+
+| Sprint                       | Effort   | Blocked by |
+| ---------------------------- | -------- | ---------- |
+| Sprint 1: Stdlib completion  | ~4h      | Nothing    |
+| Sprint 2: Rust tool-mode     | ~3h      | Nothing    |
+| Sprint 3: Resume mechanism   | ~3h      | Sprint 2   |
+| Sprint 4: OpenClaw extension | ~3h      | Sprint 2   |
+| Sprint 5: Docs & release     | ~2h      | All above  |
+| **Total**                    | **~15h** |            |
+
+Sprints 1 and 2 can run in parallel. Sprint 3 and 4 depend on Sprint 2. Sprint 5 is last.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,12 +16,14 @@ Key skills that apply to this project:
 
 ## What is Assay
 
-General-purpose enhanced Lua runtime. Single ~9 MB static binary with batteries
-included: HTTP client/server, JSON/YAML/TOML, crypto, database, WebSocket,
-filesystem, shell execution, process management, async, and 23 embedded stdlib
-modules for infrastructure services (Kubernetes, Prometheus, Vault, ArgoCD, etc.).
+General-purpose enhanced Lua runtime. Single ~9 MB static binary with batteries included: HTTP
+client/server, JSON/YAML/TOML, crypto, database, WebSocket, filesystem, shell execution, process
+management, async, and 29 embedded stdlib modules for infrastructure services (Kubernetes,
+Prometheus, Vault, ArgoCD, etc.) and AI agent integrations (OpenClaw, GitHub, Gmail, Google
+Calendar).
 
 Use cases:
+
 - **Standalone scripting** — system automation, CI/CD tasks, file processing
 - **Embedded runtime** — other Rust services embed assay as a library (`pub mod lua`)
 - **Kubernetes Jobs** — replaces 50–250 MB Python/Node/kubectl containers (~6 MB image)
@@ -77,25 +79,25 @@ spec:
 
 Available in all `.lua` scripts — no `require` needed:
 
-| Category | Functions |
-|----------|-----------|
-| HTTP | `http.get(url, opts?)`, `http.post(url, body, opts?)`, `http.put(url, body, opts?)`, `http.patch(url, body, opts?)`, `http.delete(url, opts?)`, `http.serve(port, routes)` |
-| JSON/YAML/TOML | `json.parse(str)`, `json.encode(tbl)`, `yaml.parse(str)`, `yaml.encode(tbl)`, `toml.parse(str)`, `toml.encode(tbl)` |
-| Filesystem | `fs.read(path)`, `fs.write(path, str)`, `fs.remove(path)`, `fs.list(path)`, `fs.stat(path)`, `fs.mkdir(path)`, `fs.exists(path)`, `fs.copy(src, dst)`, `fs.rename(src, dst)`, `fs.glob(pattern)`, `fs.tempdir()`, `fs.chmod(path, mode)`, `fs.readdir(path, opts?)` |
-| Crypto | `crypto.jwt_sign(claims, key, alg, opts?)`, `crypto.hash(str, alg)`, `crypto.hmac(key, data, alg?, raw?)`, `crypto.random(len)` |
-| Base64 | `base64.encode(str)`, `base64.decode(str)` |
-| Regex | `regex.match(pat, str)`, `regex.find(pat, str)`, `regex.find_all(pat, str)`, `regex.replace(pat, str, repl)` |
-| Database | `db.connect(url)`, `db.query(conn, sql, params?)`, `db.execute(conn, sql, params?)`, `db.close(conn)` |
-| WebSocket | `ws.connect(url)`, `ws.send(conn, msg)`, `ws.recv(conn)`, `ws.close(conn)` |
-| Templates | `template.render(path, vars)`, `template.render_string(tmpl, vars)` |
-| Async | `async.spawn(fn)`, `async.spawn_interval(fn, ms)`, `handle:await()`, `handle:cancel()` |
-| Assert | `assert.eq(a, b, msg?)`, `assert.ne(a, b, msg?)`, `assert.gt(a, b, msg?)`, `assert.lt(a, b, msg?)`, `assert.contains(str, sub, msg?)`, `assert.not_nil(val, msg?)`, `assert.matches(str, pat, msg?)` |
-| Logging | `log.info(msg)`, `log.warn(msg)`, `log.error(msg)` |
-| Utilities | `env.get(key)`, `env.set(key, value)`, `env.list()`, `sleep(secs)`, `time()` |
-| Shell | `shell.exec(cmd, opts?)` — execute commands with timeout, working dir, env |
-| Process | `process.list()`, `process.is_running(name)`, `process.kill(pid, signal?)`, `process.wait_idle(names, timeout, interval)` |
-| Disk | `disk.usage(path)` — returns `{total, used, available, percent}`, `disk.sweep(dir, age_secs)`, `disk.dir_size(path)` |
-| OS | `os.hostname()`, `os.arch()`, `os.platform()` |
+| Category       | Functions                                                                                                                                                                                                                                                           |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| HTTP           | `http.get(url, opts?)`, `http.post(url, body, opts?)`, `http.put(url, body, opts?)`, `http.patch(url, body, opts?)`, `http.delete(url, opts?)`, `http.serve(port, routes)`                                                                                          |
+| JSON/YAML/TOML | `json.parse(str)`, `json.encode(tbl)`, `yaml.parse(str)`, `yaml.encode(tbl)`, `toml.parse(str)`, `toml.encode(tbl)`                                                                                                                                                 |
+| Filesystem     | `fs.read(path)`, `fs.write(path, str)`, `fs.remove(path)`, `fs.list(path)`, `fs.stat(path)`, `fs.mkdir(path)`, `fs.exists(path)`, `fs.copy(src, dst)`, `fs.rename(src, dst)`, `fs.glob(pattern)`, `fs.tempdir()`, `fs.chmod(path, mode)`, `fs.readdir(path, opts?)` |
+| Crypto         | `crypto.jwt_sign(claims, key, alg, opts?)`, `crypto.hash(str, alg)`, `crypto.hmac(key, data, alg?, raw?)`, `crypto.random(len)`                                                                                                                                     |
+| Base64         | `base64.encode(str)`, `base64.decode(str)`                                                                                                                                                                                                                          |
+| Regex          | `regex.match(pat, str)`, `regex.find(pat, str)`, `regex.find_all(pat, str)`, `regex.replace(pat, str, repl)`                                                                                                                                                        |
+| Database       | `db.connect(url)`, `db.query(conn, sql, params?)`, `db.execute(conn, sql, params?)`, `db.close(conn)`                                                                                                                                                               |
+| WebSocket      | `ws.connect(url)`, `ws.send(conn, msg)`, `ws.recv(conn)`, `ws.close(conn)`                                                                                                                                                                                          |
+| Templates      | `template.render(path, vars)`, `template.render_string(tmpl, vars)`                                                                                                                                                                                                 |
+| Async          | `async.spawn(fn)`, `async.spawn_interval(fn, ms)`, `handle:await()`, `handle:cancel()`                                                                                                                                                                              |
+| Assert         | `assert.eq(a, b, msg?)`, `assert.ne(a, b, msg?)`, `assert.gt(a, b, msg?)`, `assert.lt(a, b, msg?)`, `assert.contains(str, sub, msg?)`, `assert.not_nil(val, msg?)`, `assert.matches(str, pat, msg?)`                                                                |
+| Logging        | `log.info(msg)`, `log.warn(msg)`, `log.error(msg)`                                                                                                                                                                                                                  |
+| Utilities      | `env.get(key)`, `env.set(key, value)`, `env.list()`, `sleep(secs)`, `time()`                                                                                                                                                                                        |
+| Shell          | `shell.exec(cmd, opts?)` — execute commands with timeout, working dir, env                                                                                                                                                                                          |
+| Process        | `process.list()`, `process.is_running(name)`, `process.kill(pid, signal?)`, `process.wait_idle(names, timeout, interval)`                                                                                                                                           |
+| Disk           | `disk.usage(path)` — returns `{total, used, available, percent}`, `disk.sweep(dir, age_secs)`, `disk.dir_size(path)`                                                                                                                                                |
+| OS             | `os.hostname()`, `os.arch()`, `os.platform()`                                                                                                                                                                                                                       |
 
 HTTP responses: `{status, body, headers}`. Options: `{headers = {["X-Key"] = "val"}}`.
 
@@ -124,38 +126,44 @@ return {
 
 Custom headers override defaults: `headers = { ["content-type"] = "text/html" }`.
 
-SSE `send()` accepts: `event` (string), `data` (string), `id` (string), `retry` (integer).
-`event` and `id` must not contain newlines. `data` handles multi-line automatically.
+SSE `send()` accepts: `event` (string), `data` (string), `id` (string), `retry` (integer). `event`
+and `id` must not contain newlines. `data` handles multi-line automatically.
 
 ## Stdlib Modules
 
-23 embedded Lua modules loaded via `require("assay.<name>")`:
+29 embedded Lua modules loaded via `require("assay.<name>")`:
 
-| Module | Description |
-|--------|-------------|
-| `assay.prometheus` | Query metrics, alerts, targets, rules, label values, series |
-| `assay.alertmanager` | Manage alerts, silences, receivers, config |
-| `assay.loki` | Push logs, query, labels, series |
-| `assay.grafana` | Health, dashboards, datasources, annotations |
-| `assay.k8s` | 30+ resource types, CRDs, readiness checks |
-| `assay.argocd` | Apps, sync, health, projects, repositories |
-| `assay.kargo` | Stages, freight, promotions, verification |
-| `assay.flux` | GitRepositories, Kustomizations, HelmReleases |
-| `assay.traefik` | Routers, services, middlewares, entrypoints |
-| `assay.vault` | KV secrets, policies, auth, transit, PKI |
-| `assay.openbao` | Alias for vault (API-compatible) |
-| `assay.certmanager` | Certificates, issuers, ACME challenges |
-| `assay.eso` | ExternalSecrets, SecretStores, ClusterSecretStores |
-| `assay.dex` | OIDC discovery, JWKS, health |
-| `assay.crossplane` | Providers, XRDs, compositions, managed resources |
-| `assay.velero` | Backups, restores, schedules, storage locations |
-| `assay.temporal` | Workflows, task queues, schedules |
-| `assay.harbor` | Projects, repositories, artifacts, vulnerability scanning |
-| `assay.healthcheck` | HTTP checks, JSON path, body matching, latency, multi-check |
-| `assay.s3` | S3-compatible storage (AWS, R2, MinIO) with Sig V4 |
-| `assay.postgres` | Postgres-specific helpers |
-| `assay.zitadel` | OIDC identity management with JWT machine auth |
-| `assay.unleash` | Feature flags: projects, environments, features, strategies, API tokens |
+| Module                | Description                                                                       |
+| --------------------- | --------------------------------------------------------------------------------- |
+| `assay.prometheus`    | Query metrics, alerts, targets, rules, label values, series                       |
+| `assay.alertmanager`  | Manage alerts, silences, receivers, config                                        |
+| `assay.loki`          | Push logs, query, labels, series                                                  |
+| `assay.grafana`       | Health, dashboards, datasources, annotations                                      |
+| `assay.k8s`           | 30+ resource types, CRDs, readiness checks                                        |
+| `assay.argocd`        | Apps, sync, health, projects, repositories                                        |
+| `assay.kargo`         | Stages, freight, promotions, verification                                         |
+| `assay.flux`          | GitRepositories, Kustomizations, HelmReleases                                     |
+| `assay.traefik`       | Routers, services, middlewares, entrypoints                                       |
+| `assay.vault`         | KV secrets, policies, auth, transit, PKI                                          |
+| `assay.openbao`       | Alias for vault (API-compatible)                                                  |
+| `assay.certmanager`   | Certificates, issuers, ACME challenges                                            |
+| `assay.eso`           | ExternalSecrets, SecretStores, ClusterSecretStores                                |
+| `assay.dex`           | OIDC discovery, JWKS, health                                                      |
+| `assay.crossplane`    | Providers, XRDs, compositions, managed resources                                  |
+| `assay.velero`        | Backups, restores, schedules, storage locations                                   |
+| `assay.temporal`      | Workflows, task queues, schedules                                                 |
+| `assay.harbor`        | Projects, repositories, artifacts, vulnerability scanning                         |
+| `assay.healthcheck`   | HTTP checks, JSON path, body matching, latency, multi-check                       |
+| `assay.s3`            | S3-compatible storage (AWS, R2, MinIO) with Sig V4                                |
+| `assay.postgres`      | Postgres-specific helpers                                                         |
+| `assay.zitadel`       | OIDC identity management with JWT machine auth                                    |
+| `assay.unleash`       | Feature flags: projects, environments, features, strategies, API tokens           |
+| `assay.openclaw`      | OpenClaw AI agent platform — invoke tools, state, diff, approve, LLM tasks        |
+| `assay.github`        | GitHub REST API — PRs, issues, actions, repos, GraphQL                            |
+| `assay.gmail`         | Gmail REST API with OAuth2 — search, read, reply, send, labels                    |
+| `assay.gcal`          | Google Calendar REST API with OAuth2 — events CRUD, calendar list                 |
+| `assay.oauth2`        | Google OAuth2 token management — file-based credentials, auto-refresh, persistence |
+| `assay.email_triage`  | Email classification — deterministic rules + optional LLM-assisted triage via OpenClaw |
 
 ### Client Pattern
 
@@ -173,7 +181,56 @@ assert.eq(h.database, "ok")
 3. Client methods use `c:method()` (colon = implicit self)
 4. Errors raised via `error()` — use `pcall()` to catch
 
-Auth varies by service: `{ token = "..." }`, `{ api_key = "..." }`, `{ username = "...", password = "..." }`.
+Auth varies by service: `{ token = "..." }`, `{ api_key = "..." }`,
+`{ username = "...", password = "..." }`.
+
+## Tool Mode (OpenClaw Integration)
+
+Assay v0.6.0 adds tool mode for integration with OpenClaw AI agents:
+
+```bash
+assay run --mode tool script.lua                    # Run as agent tool, structured JSON output
+assay resume --token <token> --approve yes|no       # Resume paused approval gate
+```
+
+Tool mode produces structured JSON output suitable for agent consumption. When a script hits an
+approval gate (via `openclaw.approve()`), execution pauses and returns a resume token. The agent or
+human can then approve or reject via `assay resume`.
+
+```
++-------------------------------------------------------+
+| OpenClaw Agent                                        |
+|   |                                                   |
+|   +--> assay run --mode tool deploy.lua               |
+|   |      |                                            |
+|   |      +--> approval gate -> pauses, returns token  |
+|   |                                                   |
+|   +--> human reviews                                  |
+|   |                                                   |
+|   +--> assay resume --token <t> --approve yes         |
+|          |                                            |
+|          +--> script resumes from gate                |
++-------------------------------------------------------+
+```
+
+### OpenClaw Extension
+
+The `@assay/openclaw-extension` npm package registers Assay as an OpenClaw agent tool:
+
+```bash
+openclaw plugins install @assay/openclaw-extension
+```
+
+Configuration in OpenClaw plugin config:
+
+| Key              | Default        | Description                              |
+| ---------------- | -------------- | ---------------------------------------- |
+| `binaryPath`     | PATH lookup    | Explicit path to the `assay` binary      |
+| `timeout`        | `20`           | Execution timeout in seconds             |
+| `maxOutputSize`  | `524288`       | Maximum stdout collected from Assay      |
+| `scriptsDir`     | workspace root | Root directory for Lua scripts           |
+
+See [openclaw-extension/README.md](openclaw-extension/README.md) for full details.
 
 ## Adding a New Stdlib Module
 
@@ -182,8 +239,8 @@ in `src/lua/mod.rs`.
 
 ### 1. Create `stdlib/<name>.lua`
 
-Follow the client pattern. Reference `grafana.lua` (simple, 110 lines) or `vault.lua` (comprehensive,
-330 lines):
+Follow the client pattern. Reference `grafana.lua` (simple, 110 lines) or `vault.lua`
+(comprehensive, 330 lines):
 
 ```lua
 local M = {}
@@ -341,12 +398,12 @@ assay/
 
 ## Design Decisions (FINAL)
 
-| Decision | Choice | Reason |
-|----------|--------|--------|
-| Language runtime | Lua 5.5 | ArgoCD compatible, 30yr ecosystem, native int64, perf irrelevant for I/O |
-| Not Luau | Rejected | Lua 5.1 base, Roblox ecosystem, no int64 |
-| Not Rhai | Rejected | 6x slower, no async, no coroutines |
-| Not Wasmtime | Rejected | Requires compile step, bad for script iteration |
+| Decision         | Choice   | Reason                                                                   |
+| ---------------- | -------- | ------------------------------------------------------------------------ |
+| Language runtime | Lua 5.5  | ArgoCD compatible, 30yr ecosystem, native int64, perf irrelevant for I/O |
+| Not Luau         | Rejected | Lua 5.1 base, Roblox ecosystem, no int64                                 |
+| Not Rhai         | Rejected | 6x slower, no async, no coroutines                                       |
+| Not Wasmtime     | Rejected | Requires compile step, bad for script iteration                          |
 
 ## Release Process
 
@@ -361,6 +418,7 @@ After merging a feature PR, always create a version bump PR before moving on:
 7. **After merge**: tag the release (`git tag v0.5.6 && git push origin v0.5.6`)
 
 Files to update per release:
+
 - `Cargo.toml` — version field
 - `CHANGELOG.md` — new version entry
 - `AGENTS.md` — if API surface changed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,10 +215,15 @@ human can then approve or reject via `assay resume`.
 
 ### OpenClaw Extension
 
-The `@assay/openclaw-extension` npm package registers Assay as an OpenClaw agent tool:
+The `@developerinlondon/assay-openclaw-extension` package (GitHub Packages) registers Assay as an
+OpenClaw agent tool:
 
 ```bash
-openclaw plugins install @assay/openclaw-extension
+# One-time: configure npm to use GitHub Packages for @developerinlondon scope
+echo "@developerinlondon:registry=https://npm.pkg.github.com" >> ~/.npmrc
+
+# Install the extension
+openclaw plugins install @developerinlondon/assay-openclaw-extension
 ```
 
 Configuration in OpenClaw plugin config:
@@ -427,6 +432,14 @@ Files to update per release:
 - `site/modules.html` — if API surface changed
 - `site/llms.txt` — if API surface changed
 - `site/llms-full.txt` — if API surface changed
+- `openclaw-extension/package.json` — version field (auto-synced from git tag by CI, but keep
+  in sync manually for local development)
+
+The tag push triggers `.github/workflows/release.yml` which publishes:
+- GitHub Release (binaries + checksums)
+- crates.io (`assay-lua` crate)
+- Docker image (`ghcr.io/developerinlondon/assay`)
+- GitHub Packages npm (`@developerinlondon/assay-openclaw-extension`)
 
 ## Commands
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,31 +2,66 @@
 
 All notable changes to Assay are documented here.
 
+## [0.6.0] - 2026-04-05
+
+### Added
+
+- **6 new stdlib modules** (23 -> 29 total):
+  - **assay.openclaw** — OpenClaw AI agent platform integration. Invoke tools, send messages,
+    manage persistent state with JSON files, diff detection, approval gates, cron jobs, sub-agent
+    spawning, and LLM task execution. Auto-discovers `$OPENCLAW_URL`/`$CLAWD_URL`.
+  - **assay.github** — GitHub REST API client (no `gh` CLI dependency). Pull requests (view, list,
+    reviews, merge), issues (list, get, create, comment), repositories, Actions workflow runs, and
+    GraphQL queries. Bearer token auth via `$GITHUB_TOKEN`.
+  - **assay.gmail** — Gmail REST API client with OAuth2 token auto-refresh. Search, read, reply,
+    send emails, and list labels. Uses Google OAuth2 credentials and token files.
+  - **assay.gcal** — Google Calendar REST API client with OAuth2 token auto-refresh. Events CRUD
+    (list, get, create, update, delete) and calendar list. Same auth pattern as gmail.
+  - **assay.oauth2** — Google OAuth2 token management. File-based credentials loading, automatic
+    access token refresh via refresh_token grant, token persistence, and auth header generation.
+    Used internally by gmail and gcal modules. Default paths: `~/.config/gog/credentials.json`
+    and `~/.config/gog/token.json`.
+  - **assay.email_triage** — Email classification and triage. Deterministic rule-based
+    categorization of emails into needs_reply, needs_action, and fyi buckets. Optional
+    LLM-assisted triage via OpenClaw for smarter classification. Subject and sender pattern
+    matching for automated mail detection.
+- **Tool mode**: `assay run --mode tool` for OpenClaw integration. Runs Lua scripts as
+  deterministic tools invoked by AI agents, with structured JSON output.
+- **Resume mechanism**: `assay resume --token <token> --approve yes|no` for resuming paused
+  workflows after human approval gates.
+- **OpenClaw extension**: `@assay/openclaw-extension` npm package. Registers Assay as an OpenClaw
+  agent tool with configurable script directory, timeout, output size limits, and approval-based
+  resume flow. Install via `openclaw plugins install @assay/openclaw-extension`.
+
+### Architecture
+
+- **Shell-free design**: All 6 new modules use native HTTP APIs exclusively. No shell commands,
+  no CLI dependencies (no `gh`, no `gcloud`, no `oauth2l`). Pure Lua over Assay HTTP builtins.
 
 ## [0.5.6] - 2026-04-03
 
 ### Added
 
-- **SSE streaming** for `http.serve` via `{ sse = function(send) ... end }` return shape.
-  SSE handler runs async so `sleep()` and other async builtins work inside the producer.
-  `send` callback uses async channel send with proper backpressure handling.
-  Custom headers take precedence over SSE defaults (Content-Type, Cache-Control, Connection).
+- **SSE streaming** for `http.serve` via `{ sse = function(send) ... end }` return shape. SSE
+  handler runs async so `sleep()` and other async builtins work inside the producer. `send` callback
+  uses async channel send with proper backpressure handling. Custom headers take precedence over SSE
+  defaults (Content-Type, Cache-Control, Connection).
 - **assert.ne(a, b, msg?)** — inequality assertion for the test framework.
 
 ### Fixed
 
-- **Content-Type precedence**: User-provided `Content-Type` header no longer overwritten
-  by defaults (`text/plain` / `application/json`) in `http.serve` responses.
-- **SSE newline validation**: `event` and `id` fields reject values containing newlines
-  or carriage returns to prevent SSE field injection.
+- **Content-Type precedence**: User-provided `Content-Type` header no longer overwritten by defaults
+  (`text/plain` / `application/json`) in `http.serve` responses.
+- **SSE newline validation**: `event` and `id` fields reject values containing newlines or carriage
+  returns to prevent SSE field injection.
 
 ## [0.5.5] - 2026-03-13
 
 ### Added
 
 - **follow_redirects** option for YAML HTTP checks. Set `follow_redirects: false` to disable
-  automatic redirect following, allowing verification of auth-protected endpoints that return
-  302 redirects to identity providers. Defaults to `true` for backward compatibility.
+  automatic redirect following, allowing verification of auth-protected endpoints that return 302
+  redirects to identity providers. Defaults to `true` for backward compatibility.
 - **follow_redirects** option for Lua `http.client()` builder. Create clients with
   `http.client({ follow_redirects = false })` for the same no-redirect behavior in scripts.
 
@@ -34,10 +69,10 @@ All notable changes to Assay are documented here.
 
 ### Fixed
 
-- **unleash.ensure_token**: Send `tokenName` instead of `username` in create token API payload.
-  The Unleash API expects `tokenName` — sending `username` caused HTTP 400 (BadDataError).
-  Function now accepts both `opts.tokenName` and `opts.username` for backward compatibility.
-  Existing token matching also checks `t.tokenName` with fallback to `t.username`.
+- **unleash.ensure_token**: Send `tokenName` instead of `username` in create token API payload. The
+  Unleash API expects `tokenName` — sending `username` caused HTTP 400 (BadDataError). Function now
+  accepts both `opts.tokenName` and `opts.username` for backward compatibility. Existing token
+  matching also checks `t.tokenName` with fallback to `t.username`.
 
 ## [0.5.3] - 2026-03-12
 
@@ -72,8 +107,8 @@ All notable changes to Assay are documented here.
 
 ### Added
 
-- **Website**: Static site at assay.rs on Cloudflare Pages with homepage, module reference,
-  AI agent integration guides, and MCP comparison page mapping 42 servers
+- **Website**: Static site at assay.rs on Cloudflare Pages with homepage, module reference, AI agent
+  integration guides, and MCP comparison page mapping 42 servers
 - **llms.txt**: LLM agent context traversal files (`llms.txt` and `llms-full.txt`)
 - **Enriched search keywords**: All 23 stdlib modules and builtins enriched with `@keywords`
   metadata for improved discovery
@@ -105,20 +140,19 @@ All notable changes to Assay are documented here.
 
 ### Added
 
-- **Unleash stdlib module** (`assay.unleash`): Feature flag management client for Unleash.
-  Projects (CRUD, list), environments (enable/disable per project), features (CRUD, archive,
-  toggle on/off), strategies (list, add), API tokens (CRUD). Idempotent helpers:
-  `ensure_project`, `ensure_environment`, `ensure_token`.
-
+- **Unleash stdlib module** (`assay.unleash`): Feature flag management client for Unleash. Projects
+  (CRUD, list), environments (enable/disable per project), features (CRUD, archive, toggle on/off),
+  strategies (list, add), API tokens (CRUD). Idempotent helpers: `ensure_project`,
+  `ensure_environment`, `ensure_token`.
 
 ## [0.4.3] - 2026-02-13
 
 ### Added
 
 - **crypto.hmac**: HMAC builtin supporting all 8 hash algorithms (SHA-224/256/384/512,
-  SHA3-224/256/384/512). Binary-safe key/data via `mlua::String`. Supports `raw` output mode for
-  key chaining (required by AWS Sig V4). Manual RFC 2104 implementation using existing sha2/sha3
-  crates — zero new dependencies.
+  SHA3-224/256/384/512). Binary-safe key/data via `mlua::String`. Supports `raw` output mode for key
+  chaining (required by AWS Sig V4). Manual RFC 2104 implementation using existing sha2/sha3 crates
+  — zero new dependencies.
 - **S3 stdlib module** (`assay.s3`): Pure Lua S3 client with AWS Signature V4 request signing. Works
   with any S3-compatible endpoint (AWS, iDrive e2, Cloudflare R2, MinIO). Operations: create/delete
   bucket, list buckets, put/get/delete/list/head/copy objects, bucket_exists. Path-style URLs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,10 @@ All notable changes to Assay are documented here.
   deterministic tools invoked by AI agents, with structured JSON output.
 - **Resume mechanism**: `assay resume --token <token> --approve yes|no` for resuming paused
   workflows after human approval gates.
-- **OpenClaw extension**: `@assay/openclaw-extension` npm package. Registers Assay as an OpenClaw
-  agent tool with configurable script directory, timeout, output size limits, and approval-based
-  resume flow. Install via `openclaw plugins install @assay/openclaw-extension`.
+- **OpenClaw extension**: `@developerinlondon/assay-openclaw-extension` package (GitHub Packages).
+  Registers Assay as an OpenClaw agent tool with configurable script directory, timeout, output
+  size limits, and approval-based resume flow.
+  Install via `openclaw plugins install @developerinlondon/assay-openclaw-extension`.
 
 ### Architecture
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "assay-lua"
-version = "0.5.6"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-lua"
-version = "0.5.6"
+version = "0.6.0"
 categories = ["command-line-utilities", "development-tools::testing"]
 edition = "2024"
 homepage = "https://assay.rs"

--- a/README.md
+++ b/README.md
@@ -692,10 +692,15 @@ assay resume --token <token> --approve yes|no   # Resume after human approval
 
 ### OpenClaw Extension
 
-Install the `@assay/openclaw-extension` npm package to register Assay as an OpenClaw tool:
+Install the `@developerinlondon/assay-openclaw-extension` package (GitHub Packages) to register
+Assay as an OpenClaw tool:
 
 ```bash
-openclaw plugins install @assay/openclaw-extension
+# One-time: configure npm to use GitHub Packages for @developerinlondon scope
+echo "@developerinlondon:registry=https://npm.pkg.github.com" >> ~/.npmrc
+
+# Install the extension
+openclaw plugins install @developerinlondon/assay-openclaw-extension
 ```
 
 See [openclaw-extension/README.md](openclaw-extension/README.md) for full configuration details.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ and web services.
 
 Assay is a single ~9 MB binary that replaces 50-250 MB Python/Node/kubectl containers in Kubernetes
 Jobs. It provides a full-featured Lua runtime with built-in HTTP client/server, database access,
-WebSocket, JWT signing, templates, and 20+ embedded Kubernetes-native libraries.
+WebSocket, JWT signing, templates, and 29 embedded Kubernetes-native and AI agent libraries.
 
 One binary, auto-detected behavior:
 
@@ -382,8 +382,9 @@ Supported URLs:
 
 ## Stdlib Modules
 
-Assay embeds 23 Lua modules for Kubernetes-native operations. Use `require("assay.<module>")` — or
-run `assay modules` to see all 40+ available modules including Rust builtins:
+Assay embeds 29 Lua modules for Kubernetes-native and AI agent operations. Use
+`require("assay.<module>")` — or run `assay modules` to see all 46+ available modules including Rust
+builtins:
 
 | Module               | Description                                                                   |
 | -------------------- | ----------------------------------------------------------------------------- |
@@ -410,6 +411,12 @@ run `assay modules` to see all 40+ available modules including Rust builtins:
 | `assay.unleash`      | Feature flags: projects, environments, features, strategies, API tokens       |
 | `assay.postgres`     | PostgreSQL helpers. User/database management, grants, Vault integration       |
 | `assay.zitadel`      | Zitadel OIDC identity management. Projects, apps, IdPs, users, login policies |
+| `assay.openclaw`     | OpenClaw AI agent platform — invoke tools, state, diff, approve, LLM tasks    |
+| `assay.github`       | GitHub REST API — PRs, issues, actions, repos, GraphQL                        |
+| `assay.gmail`        | Gmail REST API with OAuth2 — search, read, reply, send, labels                |
+| `assay.gcal`         | Google Calendar REST API with OAuth2 — events CRUD, calendar list             |
+| `assay.oauth2`       | Google OAuth2 token management — file-based credentials, auto-refresh         |
+| `assay.email_triage` | Email classification — deterministic rules + optional LLM-assisted triage     |
 
 Example:
 
@@ -527,10 +534,9 @@ http.serve(8080, {
 })
 ```
 
-The `send` callback accepts a table with optional fields: `event`, `data`, `id`, `retry`.
-Headers `Content-Type: text/event-stream`, `Cache-Control: no-cache`, and
-`Connection: keep-alive` are set automatically. The stream closes when the
-function returns.
+The `send` callback accepts a table with optional fields: `event`, `data`, `id`, `retry`. Headers
+`Content-Type: text/event-stream`, `Cache-Control: no-cache`, and `Connection: keep-alive` are set
+automatically. The stream closes when the function returns.
 
 ### Prometheus Verification
 
@@ -672,19 +678,43 @@ cargo run -- examples/prometheus-scrape.lua
 cargo run -- examples/loki-test.lua
 ```
 
+## OpenClaw Integration
+
+Assay v0.6.0 integrates with [OpenClaw](https://openclaw.dev) as an agent tool. This enables AI
+agents to execute deterministic Lua workflows with human approval gates.
+
+### Tool Mode
+
+```bash
+assay run --mode tool script.lua    # Structured JSON output for agent consumption
+assay resume --token <token> --approve yes|no   # Resume after human approval
+```
+
+### OpenClaw Extension
+
+Install the `@assay/openclaw-extension` npm package to register Assay as an OpenClaw tool:
+
+```bash
+openclaw plugins install @assay/openclaw-extension
+```
+
+See [openclaw-extension/README.md](openclaw-extension/README.md) for full configuration details.
+
 ## Architecture
 
 ```
 +------------------------------------------------------------------+
-| Assay v0.5.0 (~9 MB static MUSL binary, Alpine container)       |
+| Assay v0.6.0 (~9 MB static MUSL binary, Alpine container)       |
 |                                                                  |
 | CLI subcommands:                                                 |
 |   assay <file.yaml>           (.yaml -> check orchestration)     |
 |   assay <file.lua>            (.lua  -> run script)              |
 |   assay run <file>            (explicit run, any extension)      |
-|   assay exec -e '<lua>'       (inline Lua evaluation)           |
-|   assay modules               (list all 40+ modules)            |
-|   assay context <query>       (LLM-ready module context)        |
+|   assay run --mode tool <f>   (tool mode for OpenClaw agents)    |
+|   assay resume --token <t>    (resume paused approval gates)     |
+|   assay exec -e '<lua>'       (inline Lua evaluation)            |
+|   assay modules               (list all 46+ modules)             |
+|   assay context <query>       (LLM-ready module context)         |
 |                                                                  |
 | Shebang support:                                                 |
 |   #!/usr/bin/assay            (works like #!/usr/bin/python3)    |
@@ -702,7 +732,7 @@ cargo run -- examples/loki-test.lua
 | Rust Builtins (all available to .lua scripts):                   |
 |   http.{get,post,put,patch,delete,serve}                         |
 |   ws.{connect,send,recv,close}                                   |
-|   json.{parse,encode}  yaml.{parse,encode}  toml.{parse,encode}  |
+|   json.{parse,encode}  yaml.{parse,encode}  toml.{parse,encode} |
 |   fs.{read,write}  base64.{encode,decode}                        |
 |   crypto.{jwt_sign,hash,random}  regex.{match,find,replace}      |
 |   db.{connect,query,execute,close}  (postgres, mysql, sqlite)    |
@@ -711,7 +741,7 @@ cargo run -- examples/loki-test.lua
 |   log.{info,warn,error}  env.get  sleep  time                    |
 |   async.{spawn,spawn_interval}                                   |
 |                                                                  |
-| Lua Stdlib (23 embedded .lua files via include_dir!):            |
+| Lua Stdlib (29 embedded .lua files via include_dir!):            |
 |   Monitoring: prometheus, alertmanager, loki, grafana             |
 |   K8s/GitOps: k8s, argocd, kargo, flux, traefik                 |
 |   Security:   vault, openbao, certmanager, eso, dex              |
@@ -719,6 +749,8 @@ cargo run -- examples/loki-test.lua
 |   Data:       postgres, s3                                       |
 |   Identity:   zitadel                                            |
 |   Utilities:  healthcheck, unleash                               |
+|   AI/Agent:   openclaw, github, gmail, gcal, oauth2,             |
+|               email_triage                                        |
 +------------------------------------------------------------------+
 ```
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -36,7 +36,7 @@ assay modules
 | `assay exec -e 'lua code'`  | Evaluate Lua inline                           |
 | `assay exec script.lua`     | Run Lua file via exec subcommand              |
 | `assay context "<keyword>"` | Find modules matching keyword, shows quickref |
-| `assay modules`             | List all 40 modules (23 stdlib + 17 builtins) |
+| `assay modules`             | List all 46 modules (29 stdlib + 17 builtins) |
 
 ## Discovering Modules
 
@@ -209,33 +209,39 @@ URLs: `postgres://user:pass@host:5432/db`, `mysql://...`, `sqlite:///path/to/fil
 
 ## Stdlib Modules Quick Reference
 
-All 23 modules follow `require("assay.<name>")` then `M.client(url, opts)`.
+All 29 modules follow `require("assay.<name>")` then `M.client(url, opts)`.
 
-| Module               | Description                                                         |
-| -------------------- | ------------------------------------------------------------------- |
-| `assay.prometheus`   | PromQL queries, alerts, targets, rules, label values, series        |
-| `assay.alertmanager` | Manage alerts, silences, receivers, config                          |
-| `assay.loki`         | Push logs, query with LogQL, labels, series, tail                   |
-| `assay.grafana`      | Health, dashboards, datasources, annotations, alert rules, folders  |
-| `assay.k8s`          | 30+ resource types, CRDs, readiness checks, pod logs, rollouts      |
-| `assay.argocd`       | Apps, sync, health, projects, repositories, clusters                |
-| `assay.kargo`        | Stages, freight, promotions, warehouses, pipeline status            |
-| `assay.flux`         | GitRepositories, Kustomizations, HelmReleases, notifications        |
-| `assay.traefik`      | Routers, services, middlewares, entrypoints, TLS status             |
-| `assay.vault`        | KV secrets, policies, auth, transit, PKI, token management          |
-| `assay.openbao`      | Alias for vault (OpenBao API-compatible)                            |
-| `assay.certmanager`  | Certificates, issuers, ACME orders and challenges                   |
-| `assay.eso`          | ExternalSecrets, SecretStores, ClusterSecretStores sync status      |
-| `assay.dex`          | OIDC discovery, JWKS, health, configuration validation              |
-| `assay.crossplane`   | Providers, XRDs, compositions, managed resources                    |
-| `assay.velero`       | Backups, restores, schedules, storage locations                     |
-| `assay.temporal`     | Workflows, task queues, schedules, signals                          |
-| `assay.harbor`       | Projects, repositories, artifacts, vulnerability scanning           |
-| `assay.healthcheck`  | HTTP checks, JSON path, body matching, latency, multi-check         |
-| `assay.s3`           | S3-compatible storage (AWS, R2, MinIO) with Sig V4 auth             |
-| `assay.postgres`     | Postgres helpers: users, databases, grants, Vault integration       |
-| `assay.zitadel`      | OIDC identity management with JWT machine auth                      |
-| `assay.unleash`      | Feature flags: projects, environments, features, strategies, tokens |
+| Module                | Description                                                                |
+| --------------------- | -------------------------------------------------------------------------- |
+| `assay.prometheus`    | PromQL queries, alerts, targets, rules, label values, series               |
+| `assay.alertmanager`  | Manage alerts, silences, receivers, config                                 |
+| `assay.loki`          | Push logs, query with LogQL, labels, series, tail                          |
+| `assay.grafana`       | Health, dashboards, datasources, annotations, alert rules, folders         |
+| `assay.k8s`           | 30+ resource types, CRDs, readiness checks, pod logs, rollouts             |
+| `assay.argocd`        | Apps, sync, health, projects, repositories, clusters                       |
+| `assay.kargo`         | Stages, freight, promotions, warehouses, pipeline status                   |
+| `assay.flux`          | GitRepositories, Kustomizations, HelmReleases, notifications               |
+| `assay.traefik`       | Routers, services, middlewares, entrypoints, TLS status                    |
+| `assay.vault`         | KV secrets, policies, auth, transit, PKI, token management                 |
+| `assay.openbao`       | Alias for vault (OpenBao API-compatible)                                   |
+| `assay.certmanager`   | Certificates, issuers, ACME orders and challenges                          |
+| `assay.eso`           | ExternalSecrets, SecretStores, ClusterSecretStores sync status             |
+| `assay.dex`           | OIDC discovery, JWKS, health, configuration validation                     |
+| `assay.crossplane`    | Providers, XRDs, compositions, managed resources                           |
+| `assay.velero`        | Backups, restores, schedules, storage locations                            |
+| `assay.temporal`      | Workflows, task queues, schedules, signals                                 |
+| `assay.harbor`        | Projects, repositories, artifacts, vulnerability scanning                  |
+| `assay.healthcheck`   | HTTP checks, JSON path, body matching, latency, multi-check                |
+| `assay.s3`            | S3-compatible storage (AWS, R2, MinIO) with Sig V4 auth                    |
+| `assay.postgres`      | Postgres helpers: users, databases, grants, Vault integration              |
+| `assay.zitadel`       | OIDC identity management with JWT machine auth                             |
+| `assay.unleash`       | Feature flags: projects, environments, features, strategies, tokens        |
+| `assay.openclaw`      | OpenClaw AI agent — invoke tools, state, diff, approve, LLM tasks          |
+| `assay.github`        | GitHub REST API — PRs, issues, actions, repos, GraphQL                     |
+| `assay.gmail`         | Gmail REST API with OAuth2 — search, read, reply, send, labels             |
+| `assay.gcal`          | Google Calendar REST API with OAuth2 — events CRUD, calendar list          |
+| `assay.oauth2`        | Google OAuth2 token management — credentials, auto-refresh, persistence    |
+| `assay.email_triage`  | Email classification — deterministic rules + LLM-assisted triage           |
 
 ## Common Patterns
 
@@ -408,7 +414,7 @@ hardcode credentials in scripts.
 **Shebang scripts**: Add `#!/usr/bin/assay` as the first line and `chmod +x script.lua` to run
 scripts directly without the `assay` prefix.
 
-**Module not found**: All 23 stdlib modules are embedded in the binary. If `require("assay.foo")`
+**Module not found**: All 29 stdlib modules are embedded in the binary. If `require("assay.foo")`
 fails, run `assay modules` to see the exact module names.
 
 **Lua 5.5 specifics**: Assay uses Lua 5.5 (not LuaJIT). Integer division is `//`, bitwise ops use

--- a/examples/email-triage.lua
+++ b/examples/email-triage.lua
@@ -1,0 +1,28 @@
+#!/usr/bin/assay
+
+local gmail = require("assay.gmail")
+local triage = require("assay.email_triage")
+local openclaw = require("assay.openclaw")
+
+local gc = gmail.client({
+  credentials_file = env.get("GMAIL_CREDENTIALS_FILE"),
+  token_file = env.get("GMAIL_TOKEN_FILE"),
+})
+
+local oc = openclaw.client()
+local emails = gc:search(env.get("GMAIL_QUERY") or "is:unread newer_than:2d", { max = 20 })
+local buckets = triage.categorize(emails)
+
+local lines = {
+  "Email triage results",
+  "needs_action=" .. #buckets.needs_action,
+  "needs_reply=" .. #buckets.needs_reply,
+  "fyi=" .. #buckets.fyi,
+}
+
+if #buckets.needs_action > 0 then
+  lines[#lines + 1] = "top_action=" .. (buckets.needs_action[1].subject or buckets.needs_action[1].snippet or "(no subject)")
+end
+
+oc:notify(env.get("OPENCLAW_NOTIFY_TARGET") or "ops", table.concat(lines, "\n"))
+log.info(table.concat(lines, " | "))

--- a/examples/gcal-daily-agenda.lua
+++ b/examples/gcal-daily-agenda.lua
@@ -1,0 +1,23 @@
+#!/usr/bin/assay
+
+local gcal = require("assay.gcal")
+
+local c = gcal.client({
+  credentials_file = env.get("GCAL_CREDENTIALS_FILE"),
+  token_file = env.get("GCAL_TOKEN_FILE"),
+})
+
+local now = time()
+local start_of_day = now:sub(1, 10) .. "T00:00:00Z"
+local end_of_day = now:sub(1, 10) .. "T23:59:59Z"
+local events = c:events({
+  timeMin = start_of_day,
+  timeMax = end_of_day,
+  maxResults = 20,
+})
+
+log.info("Today's agenda")
+for _, event in ipairs(events) do
+  local start_at = event.start and (event.start.dateTime or event.start.date) or "unknown"
+  log.info("- " .. start_at .. " | " .. (event.summary or "(no title)"))
+end

--- a/examples/github-pr-monitor.lua
+++ b/examples/github-pr-monitor.lua
@@ -1,0 +1,37 @@
+#!/usr/bin/assay
+-- Monitor open PRs and notify via OpenClaw when new ones appear
+-- Requires: GITHUB_TOKEN, OPENCLAW_URL, OPENCLAW_TOKEN
+-- Usage: assay examples/github-pr-monitor.lua
+
+local github = require("assay.github")
+local openclaw = require("assay.openclaw")
+
+local repo = env.get("GITHUB_REPO") or "developerinlondon/assay"
+local gh = github.client()
+local oc = openclaw.client()
+
+-- Fetch open PRs
+local prs = gh:pr_list(repo, { state = "open", per_page = 10 })
+if not prs then
+  log.warn("No PRs found or repo not accessible")
+  return
+end
+
+-- Compare with previous state to detect new PRs
+local pr_ids = {}
+for _, pr in ipairs(prs) do
+  pr_ids[#pr_ids + 1] = pr.number
+end
+
+local diff = oc:diff("pr-monitor-" .. repo:gsub("/", "-"), pr_ids)
+
+if diff.changed then
+  local msg = repo .. ": " .. #prs .. " open PRs"
+  for _, pr in ipairs(prs) do
+    msg = msg .. "\n  #" .. pr.number .. " " .. pr.title .. " (" .. pr.user.login .. ")"
+  end
+  oc:notify("dev-team", msg)
+  log.info("Notified: " .. #prs .. " open PRs")
+else
+  log.info("No change: " .. #prs .. " open PRs")
+end

--- a/examples/gmail-digest.lua
+++ b/examples/gmail-digest.lua
@@ -1,0 +1,26 @@
+#!/usr/bin/assay
+
+local gmail = require("assay.gmail")
+local openclaw = require("assay.openclaw")
+
+local gc = gmail.client({
+  credentials_file = env.get("GMAIL_CREDENTIALS_FILE"),
+  token_file = env.get("GMAIL_TOKEN_FILE"),
+})
+
+local oc = openclaw.client()
+local messages = gc:search(env.get("GMAIL_QUERY") or "is:unread newer_than:1d", { max = 10 })
+
+local digest = oc:llm_task("Summarize these unread emails into a short digest with priorities.", {
+  artifacts = messages,
+  temperature = 0.1,
+})
+
+log.info("Unread messages: " .. #messages)
+if digest.response then
+  log.info(digest.response)
+elseif digest.summary then
+  log.info(digest.summary)
+else
+  log.info(json.encode(digest))
+end

--- a/examples/openclaw-health.lua
+++ b/examples/openclaw-health.lua
@@ -1,0 +1,22 @@
+#!/usr/bin/assay
+-- Health check that reports status to OpenClaw
+-- Requires: OPENCLAW_URL and OPENCLAW_TOKEN environment variables
+-- Override: OPENCLAW_URL=http://localhost:8080 assay examples/openclaw-health.lua
+
+local openclaw = require("assay.openclaw")
+local hc = require("assay.healthcheck")
+
+local c = openclaw.client()
+
+-- Check a service endpoint
+local target_url = env.get("HEALTH_TARGET") or "http://localhost:8080/health"
+local result = hc.endpoint(target_url, { max_latency_ms = 2000 })
+
+if result.ok then
+  c:notify("ops", "Health check passed: " .. target_url .. " (" .. result.latency_ms .. "ms)")
+  log.info("Health OK: " .. target_url .. " latency=" .. result.latency_ms .. "ms")
+else
+  c:send("slack", "#alerts", "Health check FAILED: " .. target_url .. " - " .. (result.error or "unknown"))
+  log.error("Health FAILED: " .. target_url)
+  error("Health check failed")
+end

--- a/llms.txt
+++ b/llms.txt
@@ -1,8 +1,8 @@
 # Assay
 
 > Assay is a ~9 MB static binary that runs Lua scripts in Kubernetes. It replaces 50-250 MB
-> Python/Node/kubectl containers. One binary handles HTTP, database, crypto, WebSocket, and 23
-> Kubernetes-native service integrations. No `require()` for builtins — they are global.
+> Python/Node/kubectl containers. One binary handles HTTP, database, crypto, WebSocket, and 29
+> Kubernetes-native and AI agent service integrations. No `require()` for builtins — they are global.
 > Stdlib modules use `require("assay.<name>")` then `M.client(url, opts)` → `c:method()`.
 > Run `assay context <query>` to get LLM-ready method signatures for any module.
 > HTTP responses are `{status, body, headers}` tables. Errors raised via `error()` — use `pcall()`.
@@ -65,6 +65,14 @@
 ## Feature Flags & Utilities
 - [assay.unleash](https://assay.rs/modules.html#unleash): Unleash feature flags, environments, strategies
 - [assay.healthcheck](https://assay.rs/modules.html#healthcheck): HTTP health checks, JSON path, latency
+
+## AI Agent & Workflow
+- [assay.openclaw](https://assay.rs/modules.html#openclaw): OpenClaw AI agent platform — invoke tools, state, diff, approve, LLM tasks, cron, sub-agents
+- [assay.github](https://assay.rs/modules.html#github): GitHub REST API — PRs, issues, actions, GraphQL (no gh CLI)
+- [assay.gmail](https://assay.rs/modules.html#gmail): Gmail REST API with OAuth2 — search, read, reply, send
+- [assay.gcal](https://assay.rs/modules.html#gcal): Google Calendar REST API with OAuth2 — events CRUD, calendar list
+- [assay.oauth2](https://assay.rs/modules.html#oauth2): Google OAuth2 token management — file-based credentials, auto-refresh, persistence
+- [assay.email_triage](https://assay.rs/modules.html#email_triage): Email triage — deterministic rules + LLM-assisted classification
 
 ## Optional
 - [Crates.io](https://crates.io/crates/assay-lua): Use Assay as a Rust crate in your own projects

--- a/openclaw-extension/.gitignore
+++ b/openclaw-extension/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+bun.lock

--- a/openclaw-extension/README.md
+++ b/openclaw-extension/README.md
@@ -2,12 +2,18 @@
 
 Adds the `assay` agent tool to OpenClaw so agents can run checked-in Assay Lua workflows with resumable approvals.
 
+Published to [GitHub Packages](https://github.com/developerinlondon/assay/pkgs/npm/assay-openclaw-extension).
+
 ## Installation
 
-Install from npm:
+Install from GitHub Packages:
 
 ```bash
-openclaw plugins install @assay/openclaw-extension
+# One-time: configure npm to use GitHub Packages for @developerinlondon scope
+echo "@developerinlondon:registry=https://npm.pkg.github.com" >> ~/.npmrc
+
+# Install the extension
+openclaw plugins install @developerinlondon/assay-openclaw-extension
 ```
 
 Install from a local checkout:

--- a/openclaw-extension/README.md
+++ b/openclaw-extension/README.md
@@ -1,0 +1,98 @@
+# Assay OpenClaw Extension
+
+Adds the `assay` agent tool to OpenClaw so agents can run checked-in Assay Lua workflows with resumable approvals.
+
+## Installation
+
+Install from npm:
+
+```bash
+openclaw plugins install @assay/openclaw-extension
+```
+
+Install from a local checkout:
+
+```bash
+openclaw plugins install -l ./openclaw-extension
+```
+
+## What this plugin does
+
+- Runs `assay run --mode tool <script>` for deterministic workflow execution
+- Supports approval pauses via `assay resume --token <token> --approve yes|no`
+- Exposes Assay as an optional OpenClaw tool so you can allowlist it per agent
+- Keeps execution local to the configured script directory
+
+## Configuration
+
+Set plugin config under `plugins.entries.assay.config`.
+
+| Key | Type | Default | Description |
+| --- | --- | --- | --- |
+| `binaryPath` | string | PATH lookup | Explicit path to the `assay` binary |
+| `timeout` | number | `20` | Execution timeout in seconds |
+| `maxOutputSize` | number | `524288` | Maximum stdout collected from Assay |
+| `scriptsDir` | string | workspace root | Root directory for Lua scripts |
+
+Example:
+
+```json
+{
+  "plugins": {
+    "entries": {
+      "assay": {
+        "enabled": true,
+        "config": {
+          "binaryPath": "/usr/local/bin/assay",
+          "timeout": 30,
+          "maxOutputSize": 524288,
+          "scriptsDir": "./assay-workflows"
+        }
+      }
+    }
+  }
+}
+```
+
+## Usage
+
+Run a workflow:
+
+```json
+{
+  "action": "run",
+  "script": "deploy/check-rollout.lua",
+  "args": {
+    "APP": "payments",
+    "NAMESPACE": "prod"
+  }
+}
+```
+
+Resume after approval:
+
+```json
+{
+  "action": "resume",
+  "token": "<resumeToken>",
+  "approve": "yes"
+}
+```
+
+## Security
+
+- Script paths must be relative and stay inside `scriptsDir`
+- Absolute paths and `..` traversal are rejected
+- The subprocess is killed if stdout exceeds `maxOutputSize`
+- The subprocess is killed if it exceeds the configured timeout
+- The tool is not registered inside OpenClaw sandboxed contexts
+
+## Requirements
+
+- The `assay` binary must already be installed
+- Binary resolution order is plugin `binaryPath`, then `ASSAY_BINARY`, then `PATH`
+- OpenClaw loads the TypeScript entrypoint directly with `jiti`; no separate build step is required
+
+## Recommended agent policy
+
+Because Assay scripts can perform side effects, enable this tool only for agents that should run infrastructure or workflow automation.

--- a/openclaw-extension/SKILL.md
+++ b/openclaw-extension/SKILL.md
@@ -1,0 +1,160 @@
+# Assay
+
+Assay executes Lua workflows for infrastructure automation, AI agent orchestration, and resumable approval flows.
+
+## When to use Assay
+
+- Multi-step infrastructure tasks that should live in a checked-in Lua script
+- Scheduled or repeatable workflows with deterministic behavior
+- Data processing or service automation that benefits from Assay's built-in HTTP, JSON, DB, and filesystem support
+- Tasks that may pause for human approval and resume later
+- Workflows that need Assay stdlib modules for Kubernetes, GitOps, observability, identity, storage, or AI agents
+
+## When not to use Assay
+
+- Simple one-liners better handled directly with shell or an existing OpenClaw tool
+- Interactive debugging where the agent should inspect each command step-by-step
+- Ad hoc tasks with no reusable script or workflow value
+- Cases where you need broad host access outside the configured `scriptsDir`
+
+## Tool contract
+
+Use the `assay` OpenClaw tool.
+
+### `run`
+
+Runs a Lua script from `scriptsDir`.
+
+```json
+{
+  "action": "run",
+  "script": "workflows/deploy.lua",
+  "args": {
+    "APP_NAME": "payments",
+    "TARGET_ENV": "prod"
+  }
+}
+```
+
+- `script` must be relative to `scriptsDir`
+- `args` becomes environment variables for the Assay subprocess
+- The tool returns the Assay JSON envelope
+
+### `resume`
+
+Resumes a workflow that halted for approval.
+
+```json
+{
+  "action": "resume",
+  "token": "<resumeToken>",
+  "approve": "yes"
+}
+```
+
+## Approval workflow pattern
+
+When Assay returns `status: "needs_approval"`:
+
+1. Read `requiresApproval.prompt`
+2. Summarize `requiresApproval.context` for the user
+3. Ask the user for approval if they have not already provided it
+4. Call `resume` with the returned `resumeToken`
+5. Use `approve: "yes"` to continue or `approve: "no"` to reject
+
+## Error handling pattern
+
+- `status: "ok"` means the script completed successfully
+- `status: "needs_approval"` means execution paused and expects `resume`
+- `status: "error"` means the script failed; report the error and fix the script or inputs
+- `status: "timeout"` means the workflow exceeded the configured timeout; simplify the workflow or raise the timeout
+- If stdout contains debug lines before JSON, trust the final JSON envelope
+
+## Stdlib modules quick reference
+
+### Infrastructure
+
+- `assay.k8s` - Kubernetes resources, CRDs, readiness checks, pod and rollout automation
+- `assay.argocd` - ArgoCD apps, syncs, health, projects, repositories, clusters
+- `assay.kargo` - Kargo stages, freight, promotions, warehouses, verification status
+- `assay.vault` - Vault KV secrets, policies, auth, transit, PKI, token flows
+- `assay.openbao` - OpenBao-compatible Vault API access for secrets and policies
+- `assay.prometheus` - PromQL queries, alerts, rules, targets, labels, series
+- `assay.alertmanager` - Alert silences, receivers, routes, config, alert inspection
+- `assay.loki` - LogQL queries, labels, series, tailing, log pushes
+- `assay.grafana` - Health, dashboards, datasources, folders, annotations, alert rules
+- `assay.flux` - Flux GitRepositories, Kustomizations, HelmReleases, notifications
+- `assay.traefik` - Routers, services, middlewares, entrypoints, TLS status
+- `assay.certmanager` - Certificates, issuers, ACME orders, ACME challenges
+- `assay.eso` - ExternalSecrets and SecretStore synchronization status
+- `assay.dex` - Dex OIDC discovery, JWKS, health, config validation
+- `assay.crossplane` - Providers, XRDs, compositions, managed resources
+- `assay.velero` - Backups, restores, schedules, storage locations
+- `assay.temporal` - Workflows, task queues, schedules, signals
+- `assay.harbor` - Projects, repositories, artifacts, vulnerability scanning
+
+### Services
+
+- `assay.healthcheck` - HTTP checks, JSON path assertions, latency checks, multi-check runs
+- `assay.s3` - S3-compatible object storage for AWS, R2, MinIO, and similar services
+- `assay.postgres` - PostgreSQL helper workflows for users, databases, grants, Vault integration
+- `assay.zitadel` - Zitadel identity management for projects, apps, users, policies, IdPs
+- `assay.unleash` - Feature flags, projects, environments, strategies, API tokens
+
+### AI agent and SaaS automation
+
+- `assay.openclaw` - OpenClaw tool invocation, state, diff, approval, and LLM task automation
+- `assay.github` - GitHub issues, pull requests, repos, actions, GraphQL workflows
+- `assay.gmail` - Gmail search, read, send, reply, label management with OAuth2
+- `assay.gcal` - Google Calendar event CRUD and calendar listing with OAuth2
+- `assay.oauth2` - OAuth2 token acquisition and refresh helpers for API integrations
+- `assay.email_triage` - Email classification and structured triage workflows for agent pipelines
+
+## Usage examples
+
+### GitOps verification
+
+```json
+{
+  "action": "run",
+  "script": "gitops/verify-release.lua",
+  "args": {
+    "APP": "api",
+    "STAGE": "prod"
+  }
+}
+```
+
+### Approval-gated deployment
+
+```json
+{
+  "action": "run",
+  "script": "deploy/promote.lua",
+  "args": {
+    "SERVICE": "billing"
+  }
+}
+```
+
+If it returns `needs_approval`, resume with:
+
+```json
+{
+  "action": "resume",
+  "token": "<resumeToken>",
+  "approve": "yes"
+}
+```
+
+### SaaS triage workflow
+
+```json
+{
+  "action": "run",
+  "script": "agents/email-triage.lua",
+  "args": {
+    "MAILBOX": "ops@example.com"
+  }
+}
+```

--- a/openclaw-extension/index.ts
+++ b/openclaw-extension/index.ts
@@ -1,0 +1,20 @@
+/// <reference path="./types.d.ts" />
+
+import type {
+  AnyAgentTool,
+  OpenClawPluginApi,
+  OpenClawPluginToolFactory,
+} from "openclaw/plugin-sdk/lobster";
+import { createAssayTool } from "./src/assay-tool.js";
+
+export default function register(api: OpenClawPluginApi) {
+  api.registerTool(
+    ((ctx) => {
+      if (ctx.sandboxed) {
+        return null;
+      }
+      return createAssayTool(api) as AnyAgentTool;
+    }) as OpenClawPluginToolFactory,
+    { optional: true },
+  );
+}

--- a/openclaw-extension/openclaw.plugin.json
+++ b/openclaw-extension/openclaw.plugin.json
@@ -1,0 +1,28 @@
+{
+  "id": "assay",
+  "name": "Assay Workflow Runtime",
+  "description": "Run Lua workflow scripts via the Assay runtime",
+  "configSchema": {
+    "type": "object",
+    "properties": {
+      "binaryPath": {
+        "type": "string",
+        "description": "Path to the assay binary (default: found via PATH)"
+      },
+      "timeout": {
+        "type": "number",
+        "default": 20,
+        "description": "Execution timeout in seconds"
+      },
+      "maxOutputSize": {
+        "type": "number",
+        "default": 524288,
+        "description": "Maximum output size in bytes"
+      },
+      "scriptsDir": {
+        "type": "string",
+        "description": "Directory containing Lua scripts (default: workspace root)"
+      }
+    }
+  }
+}

--- a/openclaw-extension/package.json
+++ b/openclaw-extension/package.json
@@ -1,8 +1,17 @@
 {
-  "name": "@assay/openclaw-extension",
+  "name": "@developerinlondon/assay-openclaw-extension",
   "version": "0.6.0",
   "description": "Assay Lua workflow runtime for OpenClaw — run infrastructure automation, AI agent workflows, and DevOps tasks",
+  "type": "module",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/developerinlondon/assay.git",
+    "directory": "openclaw-extension"
+  },
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com"
+  },
   "openclaw": {
     "extensions": [
       "./index.ts"
@@ -11,7 +20,14 @@
   "peerDependencies": {
     "openclaw": "*"
   },
+  "scripts": {
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
+  },
   "devDependencies": {
-    "openclaw": "*"
+    "openclaw": "*",
+    "@sinclair/typebox": "0.34.48",
+    "vitest": "^3.1.1",
+    "typescript": "^5.8.3"
   }
 }

--- a/openclaw-extension/package.json
+++ b/openclaw-extension/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@assay/openclaw-extension",
+  "version": "0.6.0",
+  "description": "Assay Lua workflow runtime for OpenClaw — run infrastructure automation, AI agent workflows, and DevOps tasks",
+  "license": "MIT",
+  "openclaw": {
+    "extensions": [
+      "./index.ts"
+    ]
+  },
+  "peerDependencies": {
+    "openclaw": "*"
+  },
+  "devDependencies": {
+    "openclaw": "*"
+  }
+}

--- a/openclaw-extension/src/assay-tool.test.ts
+++ b/openclaw-extension/src/assay-tool.test.ts
@@ -1,0 +1,289 @@
+import { EventEmitter } from "node:events";
+import path from "node:path";
+import { PassThrough } from "node:stream";
+import type { OpenClawPluginApi, OpenClawPluginToolContext } from "openclaw/plugin-sdk/lobster";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const spawnState = vi.hoisted(() => ({
+  queue: [] as Array<{ stdout: string; stderr?: string; exitCode?: number }>,
+  spawn: vi.fn(),
+}));
+
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...actual,
+    spawn: (...args: unknown[]) => spawnState.spawn(...args),
+  };
+});
+
+let createAssayTool: typeof import("./assay-tool.js").createAssayTool;
+
+function fakeApi(overrides: Partial<OpenClawPluginApi> = {}): OpenClawPluginApi {
+  return {
+    id: "assay",
+    name: "assay",
+    source: "test",
+    registrationMode: "full",
+    config: {},
+    pluginConfig: {},
+    runtime: { version: "test" },
+    logger: { info() {}, warn() {}, error() {}, debug() {} },
+    registerTool() {},
+    registerChannel() {},
+    registerGatewayMethod() {},
+    registerCli() {},
+    registerService() {},
+    registerProvider() {},
+    registerWebSearchProvider() {},
+    registerInteractiveHandler() {},
+    registerHook() {},
+    registerHttpRoute() {},
+    registerCommand() {},
+    registerContextEngine() {},
+    on() {},
+    resolvePath: (value: string) => value,
+    ...overrides,
+  } as OpenClawPluginApi;
+}
+
+function fakeCtx(overrides: Partial<OpenClawPluginToolContext> = {}): OpenClawPluginToolContext {
+  return {
+    config: {},
+    workspaceDir: "/tmp",
+    agentDir: "/tmp",
+    agentId: "main",
+    sessionKey: "main",
+    messageChannel: undefined,
+    agentAccountId: undefined,
+    sandboxed: false,
+    ...overrides,
+  } as OpenClawPluginToolContext;
+}
+
+function queueEnvelope(envelope: unknown) {
+  spawnState.queue.push({ stdout: JSON.stringify(envelope) });
+}
+
+describe("assay plugin tool", () => {
+  const originalAssayBinary = process.env.ASSAY_BINARY;
+
+  afterEach(() => {
+    if (originalAssayBinary === undefined) {
+      delete process.env.ASSAY_BINARY;
+      return;
+    }
+    process.env.ASSAY_BINARY = originalAssayBinary;
+  });
+
+  beforeEach(async () => {
+    if (!createAssayTool) {
+      ({ createAssayTool } = await import("./assay-tool.js"));
+    }
+
+    process.env.ASSAY_BINARY = "/fake/bin/assay";
+    spawnState.queue.length = 0;
+    spawnState.spawn.mockReset();
+    spawnState.spawn.mockImplementation(() => {
+      const next = spawnState.queue.shift() ?? { stdout: "" };
+      const stdout = new PassThrough();
+      const stderr = new PassThrough();
+      const child = new EventEmitter() as EventEmitter & {
+        stdout: PassThrough;
+        stderr: PassThrough;
+        kill: (signal?: string) => boolean;
+      };
+      child.stdout = stdout;
+      child.stderr = stderr;
+      child.kill = () => true;
+
+      setImmediate(() => {
+        if (next.stderr) {
+          stderr.end(next.stderr);
+        } else {
+          stderr.end();
+        }
+        stdout.end(next.stdout);
+        child.emit("exit", next.exitCode ?? 0);
+      });
+
+      return child;
+    });
+  });
+
+  it("runs assay and returns parsed envelope", async () => {
+    queueEnvelope({
+      ok: true,
+      status: "ok",
+      output: [{ hello: "world" }],
+      requiresApproval: null,
+    });
+
+    const tool = createAssayTool(fakeApi());
+    const result = await tool.execute("call-run", {
+      action: "run",
+      script: "scripts/noop.lua",
+      args: { NAME: "world" },
+    });
+
+    expect(spawnState.spawn).toHaveBeenCalledWith(
+      "/fake/bin/assay",
+      [
+        "run",
+        "--mode",
+        "tool",
+        "--timeout",
+        "20",
+        path.resolve(process.cwd(), "scripts/noop.lua"),
+      ],
+      expect.objectContaining({
+        cwd: process.cwd(),
+        windowsHide: true,
+        env: expect.objectContaining({ NAME: "world" }),
+      }),
+    );
+    expect(result.details).toMatchObject({ ok: true, status: "ok", output: [{ hello: "world" }] });
+  });
+
+  it("tolerates noisy stdout before JSON envelope", async () => {
+    const payload = { ok: true, status: "ok", output: [], requiresApproval: null };
+    spawnState.queue.push({ stdout: `noise before json\n${JSON.stringify(payload)}` });
+
+    const tool = createAssayTool(fakeApi());
+    const result = await tool.execute("call-noisy", {
+      action: "run",
+      script: "scripts/noop.lua",
+    });
+
+    expect(result.details).toMatchObject({ ok: true, status: "ok" });
+  });
+
+  it("requires action", async () => {
+    const tool = createAssayTool(fakeApi());
+    await expect(tool.execute("call-action-missing", {})).rejects.toThrow(/action required/);
+  });
+
+  it("requires script for run action", async () => {
+    const tool = createAssayTool(fakeApi());
+    await expect(
+      tool.execute("call-script-missing", {
+        action: "run",
+      }),
+    ).rejects.toThrow(/script required/);
+  });
+
+  it("requires token for resume action", async () => {
+    const tool = createAssayTool(fakeApi());
+    await expect(
+      tool.execute("call-token-missing", {
+        action: "resume",
+        approve: "yes",
+      }),
+    ).rejects.toThrow(/token required/);
+  });
+
+  it("requires approve for resume action", async () => {
+    const tool = createAssayTool(fakeApi());
+    await expect(
+      tool.execute("call-approve-missing", {
+        action: "resume",
+        token: "resume-token",
+      }),
+    ).rejects.toThrow(/approve must be 'yes' or 'no'/);
+  });
+
+  it("rejects unknown action", async () => {
+    const tool = createAssayTool(fakeApi());
+    await expect(
+      tool.execute("call-action-unknown", {
+        action: "explode",
+      }),
+    ).rejects.toThrow(/Unknown action/);
+  });
+
+  it("rejects absolute script path", async () => {
+    const tool = createAssayTool(fakeApi());
+    await expect(
+      tool.execute("call-script-absolute", {
+        action: "run",
+        script: "/etc/passwd",
+      }),
+    ).rejects.toThrow(/relative path/);
+  });
+
+  it("rejects path traversal", async () => {
+    const tool = createAssayTool(fakeApi());
+    await expect(
+      tool.execute("call-script-traversal", {
+        action: "run",
+        script: "../../etc/passwd",
+      }),
+    ).rejects.toThrow(/must stay within/);
+  });
+
+  it("rejects invalid JSON from assay", async () => {
+    spawnState.queue.push({ stdout: "nope" });
+
+    const tool = createAssayTool(fakeApi());
+    await expect(
+      tool.execute("call-invalid-json", {
+        action: "run",
+        script: "scripts/noop.lua",
+      }),
+    ).rejects.toThrow(/valid JSON/);
+  });
+
+  it("handles needs_approval envelope", async () => {
+    queueEnvelope({
+      ok: true,
+      status: "needs_approval",
+      output: { phase: "awaiting_approval" },
+      requiresApproval: {
+        prompt: "approve deployment?",
+        context: { environment: "prod" },
+        resumeToken: "resume-123",
+      },
+    });
+
+    const tool = createAssayTool(fakeApi());
+    const result = await tool.execute("call-needs-approval", {
+      action: "run",
+      script: "scripts/deploy.lua",
+    });
+
+    expect(result.details).toMatchObject({
+      ok: true,
+      status: "needs_approval",
+      requiresApproval: { resumeToken: "resume-123" },
+    });
+  });
+
+  it("handles error envelope by throwing", async () => {
+    queueEnvelope({
+      ok: false,
+      status: "error",
+      error: "deployment failed",
+    });
+
+    const tool = createAssayTool(fakeApi());
+    await expect(
+      tool.execute("call-error-envelope", {
+        action: "run",
+        script: "scripts/fail.lua",
+      }),
+    ).rejects.toThrow(/deployment failed/);
+  });
+
+  it("can be gated off in sandboxed contexts", async () => {
+    const api = fakeApi();
+    const factoryTool = (ctx: OpenClawPluginToolContext) => {
+      if (ctx.sandboxed) {
+        return null;
+      }
+      return createAssayTool(api);
+    };
+
+    expect(factoryTool(fakeCtx({ sandboxed: true }))).toBeNull();
+    expect(factoryTool(fakeCtx({ sandboxed: false }))?.name).toBe("assay");
+  });
+});

--- a/openclaw-extension/src/assay-tool.ts
+++ b/openclaw-extension/src/assay-tool.ts
@@ -1,0 +1,326 @@
+/// <reference path="../types.d.ts" />
+
+import { constants } from "node:fs";
+import { access } from "node:fs/promises";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import { Type } from "@sinclair/typebox";
+import type { OpenClawPluginApi } from "openclaw/plugin-sdk/lobster";
+
+type AssayPluginConfig = {
+  binaryPath?: unknown;
+  timeout?: unknown;
+  maxOutputSize?: unknown;
+  scriptsDir?: unknown;
+};
+
+type ToolEnvelope =
+  | {
+      ok: true;
+      status: "ok" | "needs_approval";
+      output: unknown;
+      requiresApproval: null | {
+        prompt: string;
+        context?: unknown;
+        resumeToken: string;
+      };
+      truncated?: boolean;
+    }
+  | {
+      ok: false;
+      status: "error" | "timeout";
+      error: string;
+    };
+
+function parseToolOutput(stdout: string): ToolEnvelope {
+  const trimmed = stdout.trim();
+  try {
+    return JSON.parse(trimmed) as ToolEnvelope;
+  } catch {
+    const match = trimmed.match(/(\{[\s\S]*\}|\[[\s\S]*\])\s*$/);
+    if (match) {
+      return JSON.parse(match[1]) as ToolEnvelope;
+    }
+    throw new Error("No valid JSON found in assay output");
+  }
+}
+
+function normalizeSandboxPath(input: string): string {
+  const normalized = path.normalize(input);
+  return process.platform === "win32" ? normalized.toLowerCase() : normalized;
+}
+
+function ensureRelativeScriptPath(scriptRaw: unknown): string {
+  if (typeof scriptRaw !== "string" || !scriptRaw.trim()) {
+    throw new Error("script required");
+  }
+  const script = scriptRaw.trim();
+  if (path.isAbsolute(script)) {
+    throw new Error("script must be a relative path within scriptsDir");
+  }
+  return script;
+}
+
+function resolveScriptsDir(config: AssayPluginConfig): string {
+  const raw = typeof config.scriptsDir === "string" && config.scriptsDir.trim()
+    ? config.scriptsDir.trim()
+    : process.cwd();
+  return path.isAbsolute(raw) ? raw : path.resolve(process.cwd(), raw);
+}
+
+function resolveScriptPath(scriptsDir: string, scriptRaw: unknown): string {
+  const script = ensureRelativeScriptPath(scriptRaw);
+  const resolved = path.resolve(scriptsDir, script);
+  const rel = path.relative(
+    normalizeSandboxPath(scriptsDir),
+    normalizeSandboxPath(resolved),
+  );
+  if (rel === "" || rel === ".") {
+    return resolved;
+  }
+  if (rel.startsWith("..") || path.isAbsolute(rel)) {
+    throw new Error("script must stay within scriptsDir");
+  }
+  return resolved;
+}
+
+async function isExecutable(filePath: string): Promise<boolean> {
+  try {
+    await access(filePath, constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function resolveBinaryPath(config: AssayPluginConfig): Promise<string> {
+  const configured =
+    typeof config.binaryPath === "string" && config.binaryPath.trim() ? config.binaryPath.trim() : "";
+  if (configured) {
+    return configured;
+  }
+
+  const fromEnv = typeof process.env.ASSAY_BINARY === "string" ? process.env.ASSAY_BINARY.trim() : "";
+  if (fromEnv) {
+    return fromEnv;
+  }
+
+  const pathValue = process.env.PATH ?? "";
+  const pathEntries = pathValue.split(path.delimiter).filter(Boolean);
+  const candidates = process.platform === "win32"
+    ? ["assay.exe", "assay.cmd", "assay.bat", "assay"]
+    : ["assay"];
+
+  for (const entry of pathEntries) {
+    for (const candidate of candidates) {
+      const fullPath = path.join(entry, candidate);
+      if (await isExecutable(fullPath)) {
+        return fullPath;
+      }
+    }
+  }
+
+  throw new Error("assay binary not found; set plugins.entries.assay.config.binaryPath or ASSAY_BINARY");
+}
+
+function resolveTimeoutSeconds(config: AssayPluginConfig): number {
+  const timeout = typeof config.timeout === "number" && Number.isFinite(config.timeout) ? config.timeout : 20;
+  return Math.max(1, timeout);
+}
+
+function resolveMaxOutputSize(config: AssayPluginConfig): number {
+  const size =
+    typeof config.maxOutputSize === "number" && Number.isFinite(config.maxOutputSize)
+      ? config.maxOutputSize
+      : 524_288;
+  return Math.max(1_024, Math.floor(size));
+}
+
+function resolveArgsEnv(argsRaw: unknown): Record<string, string> {
+  if (argsRaw === undefined) {
+    return {};
+  }
+  if (!argsRaw || typeof argsRaw !== "object" || Array.isArray(argsRaw)) {
+    throw new Error("args must be an object of string values");
+  }
+
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(argsRaw)) {
+    if (typeof value !== "string") {
+      throw new Error(`args.${key} must be a string`);
+    }
+    env[key] = value;
+  }
+  return env;
+}
+
+async function runAssaySubprocess(params: {
+  execPath: string;
+  argv: string[];
+  cwd: string;
+  timeoutSeconds: number;
+  maxOutputSize: number;
+  env?: Record<string, string>;
+}): Promise<{ stdout: string }> {
+  const timeoutMs = Math.max(200, Math.floor(params.timeoutSeconds * 1000) + 1000);
+  const maxOutputSize = Math.max(1_024, params.maxOutputSize);
+  const env = {
+    ...process.env,
+    ...(params.env ?? {}),
+  } as Record<string, string | undefined>;
+
+  return await new Promise<{ stdout: string }>((resolve, reject) => {
+    const child = spawn(params.execPath, params.argv, {
+      cwd: params.cwd,
+      stdio: ["ignore", "pipe", "pipe"],
+      env,
+      windowsHide: true,
+    });
+
+    let stdout = "";
+    let stdoutBytes = 0;
+    let stderr = "";
+    let settled = false;
+
+    const settle = (result: { ok: true; value: { stdout: string } } | { ok: false; error: Error }) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      if (result.ok) {
+        resolve(result.value);
+      } else {
+        reject(result.error);
+      }
+    };
+
+    const failAndTerminate = (message: string) => {
+      try {
+        child.kill("SIGKILL");
+      } finally {
+        settle({ ok: false, error: new Error(message) });
+      }
+    };
+
+    child.stdout?.setEncoding("utf8");
+    child.stderr?.setEncoding("utf8");
+
+    child.stdout?.on("data", (chunk: string) => {
+      const text = String(chunk);
+      stdoutBytes += Buffer.byteLength(text, "utf8");
+      if (stdoutBytes > maxOutputSize) {
+        failAndTerminate("assay output exceeded maxOutputSize");
+        return;
+      }
+      stdout += text;
+    });
+
+    child.stderr?.on("data", (chunk: string) => {
+      stderr += String(chunk);
+    });
+
+    const timer = setTimeout(() => {
+      failAndTerminate(`assay subprocess timed out after ${params.timeoutSeconds}s`);
+    }, timeoutMs);
+
+    child.once("error", (error: Error) => {
+      settle({ ok: false, error });
+    });
+
+    child.once("exit", (code: number | null) => {
+      if (code !== 0) {
+        settle({
+          ok: false,
+          error: new Error(`assay failed (${code ?? "?"}): ${stderr.trim() || stdout.trim()}`),
+        });
+        return;
+      }
+      settle({ ok: true, value: { stdout } });
+    });
+  });
+}
+
+function toToolResult(envelope: Extract<ToolEnvelope, { ok: true }>) {
+  return {
+    content: [{ type: "text", text: JSON.stringify(envelope, null, 2) }],
+    details: envelope,
+  };
+}
+
+export function createAssayTool(api: OpenClawPluginApi) {
+  return {
+    name: "assay",
+    label: "Assay Workflow Runtime",
+    description:
+      "Run Assay Lua workflow scripts for infrastructure automation, DevOps checks, data processing, and resumable approval flows.",
+    parameters: Type.Object({
+      action: Type.Unsafe<"run" | "resume">({ type: "string", enum: ["run", "resume"] }),
+      script: Type.Optional(Type.String({ description: "Relative Lua script path inside scriptsDir." })),
+      args: Type.Optional(Type.Record(Type.String(), Type.String())),
+      token: Type.Optional(Type.String({ description: "Resume token from a prior approval request." })),
+      approve: Type.Optional(Type.Unsafe<"yes" | "no">({ type: "string", enum: ["yes", "no"] })),
+    }),
+    async execute(_id: string, params: Record<string, unknown>) {
+      const config = (api.pluginConfig ?? {}) as AssayPluginConfig;
+      const action = typeof params.action === "string" ? params.action.trim() : "";
+      if (!action) {
+        throw new Error("action required");
+      }
+
+      const execPath = await resolveBinaryPath(config);
+      const timeoutSeconds = resolveTimeoutSeconds(config);
+      const maxOutputSize = resolveMaxOutputSize(config);
+      const scriptsDir = resolveScriptsDir(config);
+
+      let argv: string[];
+      let cwd: string;
+      let env: Record<string, string> | undefined;
+
+      if (action === "run") {
+        const scriptPath = resolveScriptPath(scriptsDir, params.script);
+        argv = ["run", "--mode", "tool", "--timeout", String(timeoutSeconds), scriptPath];
+        cwd = scriptsDir;
+        env = resolveArgsEnv(params.args);
+      } else if (action === "resume") {
+        const token = typeof params.token === "string" ? params.token.trim() : "";
+        const approve = typeof params.approve === "string" ? params.approve.trim() : "";
+        if (!token) {
+          throw new Error("token required");
+        }
+        if (approve !== "yes" && approve !== "no") {
+          throw new Error("approve must be 'yes' or 'no'");
+        }
+        argv = ["resume", "--token", token, "--approve", approve];
+        cwd = scriptsDir;
+      } else {
+        throw new Error(`Unknown action: ${action}`);
+      }
+
+      if (api.runtime?.version && api.logger?.debug) {
+        api.logger.debug(`assay plugin runtime=${api.runtime.version}`);
+      }
+
+      const { stdout } = await runAssaySubprocess({
+        execPath,
+        argv,
+        cwd,
+        timeoutSeconds,
+        maxOutputSize,
+        env,
+      });
+
+      const envelope = parseToolOutput(stdout);
+      if (!envelope.ok) {
+        throw new Error(envelope.error);
+      }
+      if (envelope.status === "needs_approval") {
+        return toToolResult(envelope);
+      }
+      if (envelope.status === "ok") {
+        return toToolResult(envelope);
+      }
+      throw new Error("Unsupported assay tool status");
+    },
+  };
+}

--- a/openclaw-extension/tsconfig.json
+++ b/openclaw-extension/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "types": ["node"]
+  },
+  "include": ["src", "index.ts", "types.d.ts"]
+}

--- a/openclaw-extension/types.d.ts
+++ b/openclaw-extension/types.d.ts
@@ -1,0 +1,88 @@
+declare module "node:fs" {
+  export const constants: {
+    X_OK: number;
+  };
+}
+
+declare module "node:fs/promises" {
+  export function access(path: string, mode?: number): Promise<void>;
+}
+
+declare module "node:path" {
+  const path: {
+    delimiter: string;
+    normalize(input: string): string;
+    isAbsolute(input: string): boolean;
+    resolve(...parts: string[]): string;
+    relative(from: string, to: string): string;
+    join(...parts: string[]): string;
+  };
+  export default path;
+}
+
+declare module "node:child_process" {
+  type Listener<T = unknown> = (value: T) => void;
+
+  export function spawn(
+    command: string,
+    args?: string[],
+    options?: {
+      cwd?: string;
+      stdio?: [string, string, string];
+      env?: Record<string, string | undefined>;
+      windowsHide?: boolean;
+    },
+  ): {
+    stdout?: {
+      setEncoding(encoding: string): void;
+      on(event: "data", listener: Listener<string>): void;
+    };
+    stderr?: {
+      setEncoding(encoding: string): void;
+      on(event: "data", listener: Listener<string>): void;
+    };
+    kill(signal?: string): void;
+    once(event: "error", listener: Listener<Error>): void;
+    once(event: "exit", listener: Listener<number | null>): void;
+  };
+}
+
+declare module "@sinclair/typebox" {
+  export const Type: {
+    Object(schema: Record<string, unknown>): unknown;
+    Optional(schema: unknown): unknown;
+    String(options?: Record<string, unknown>): unknown;
+    Number(options?: Record<string, unknown>): unknown;
+    Record(key: unknown, value: unknown): unknown;
+    Unsafe<T>(schema: Record<string, unknown>): T;
+  };
+}
+
+declare module "openclaw/plugin-sdk/lobster" {
+  export type AnyAgentTool = unknown;
+
+  export type OpenClawPluginToolContext = {
+    sandboxed?: boolean;
+  };
+
+  export type OpenClawPluginToolFactory = (
+    ctx: OpenClawPluginToolContext,
+  ) => AnyAgentTool | AnyAgentTool[] | null | undefined;
+
+  export type OpenClawPluginApi = {
+    pluginConfig?: Record<string, unknown>;
+    runtime?: { version?: string };
+    logger?: { debug?: (message: string) => void };
+    registerTool: (tool: AnyAgentTool | OpenClawPluginToolFactory, opts?: { optional?: boolean }) => void;
+  };
+}
+
+declare const process: {
+  cwd(): string;
+  env: Record<string, string | undefined>;
+  platform: string;
+};
+
+declare const Buffer: {
+  byteLength(value: string, encoding?: string): number;
+};

--- a/openclaw-extension/vitest.config.ts
+++ b/openclaw-extension/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    root: ".",
+  },
+});

--- a/site/agent-guides.html
+++ b/site/agent-guides.html
@@ -279,9 +279,9 @@ assert.not_nil(result)
 assay script.lua</code></pre>
 
     <p>
-      All 23 stdlib modules follow the same pattern: <code>require</code>, <code>client()</code>,
+      All 29 stdlib modules follow the same pattern: <code>require</code>, <code>client()</code>,
       <code>c:method()</code>. Learn one, know them all. Run <code>assay modules</code> to see the
-      full list of 40+ available modules.
+      full list of 46+ available modules.
     </p>
   </main>
 

--- a/site/index.html
+++ b/site/index.html
@@ -63,7 +63,7 @@
     </p>
 
     <h3>Lua Script Mode</h3>
-    <p>Run any Lua script with all builtins available &mdash; HTTP client/server, SSE streaming, JSON, crypto, database, and 23 embedded stdlib modules:</p>
+    <p>Run any Lua script with all builtins available &mdash; HTTP client/server, SSE streaming, JSON, crypto, database, and 29 embedded stdlib modules:</p>
     <pre><code>-- Lua mode: query Prometheus directly
 local prom = require("assay.prometheus")
 local result = prom.query("http://prom:9090", "up")

--- a/site/llms-full.txt
+++ b/site/llms-full.txt
@@ -1,8 +1,8 @@
 # Assay
 
 > Assay is a ~9 MB static binary that runs Lua scripts in Kubernetes. It replaces 50-250 MB
-> Python/Node/kubectl containers. One binary handles HTTP, database, crypto, WebSocket, and 23
-> Kubernetes-native service integrations. No `require()` for builtins — they are global.
+> Python/Node/kubectl containers. One binary handles HTTP, database, crypto, WebSocket, and 29
+> Kubernetes-native and AI agent service integrations. No `require()` for builtins — they are global.
 > Stdlib modules use `require("assay.<name>")` then `M.client(url, opts)` → `c:method()`.
 > Run `assay context <query>` to get LLM-ready method signatures for any module.
 > HTTP responses are `{status, body, headers}` tables. Errors raised via `error()` — use `pcall()`.
@@ -1062,6 +1062,243 @@ unleash.ensure_project(c, "my-project", {name = "My Project"})
 unleash.ensure_environment(c, "my-project", "production")
 c:create_feature("my-project", {name = "dark-mode", type = "release"})
 c:toggle_on("my-project", "dark-mode", "production")
+```
+
+## AI Agent & Workflow
+
+### assay.openclaw
+
+OpenClaw AI agent platform integration. Invoke tools, send messages, manage state, spawn sub-agents, approval gates, LLM tasks.
+
+```lua
+local openclaw = require("assay.openclaw")
+local c = openclaw.client()  -- auto-discovers $OPENCLAW_URL + $OPENCLAW_TOKEN
+
+-- Invoke any OpenClaw tool
+local result = c:invoke("message", "send", {target = "#general", message = "Hello!"})
+
+-- Shorthand: send message
+c:send("discord", "#alerts", "Service is down!")
+c:notify("ops-team", "Deployment complete")
+
+-- Persistent state (JSON files in ~/.openclaw/state/)
+c:state_set("last-deploy", {version = "1.2.3", time = time()})
+local prev = c:state_get("last-deploy")
+
+-- Diff detection
+local diff = c:diff("pr-state", new_snapshot)
+if diff.changed then log.info("State changed!") end
+
+-- LLM task execution
+local answer = c:llm_task("Summarize this PR", {model = "claude-sonnet"})
+
+-- Cron job management
+c:cron_add({schedule = "0 9 * * *", task = "daily-report"})
+local jobs = c:cron_list()
+
+-- Sub-agent spawning
+c:spawn("Fix the login bug", {model = "gpt-4o"})
+
+-- Approval gates (interactive TTY or structured request)
+if c:approve("Deploy to production?", context_data) then
+  -- proceed with deployment
+end
+```
+
+### assay.github
+
+GitHub REST API client. PRs, issues, actions, repositories, GraphQL. No `gh` CLI dependency.
+
+```lua
+local github = require("assay.github")
+local c = github.client()  -- uses $GITHUB_TOKEN
+
+-- Pull requests
+local pr = c:pr_view("owner/repo", 123)
+local prs = c:pr_list("owner/repo", {state = "open", per_page = 10})
+local reviews = c:pr_reviews("owner/repo", 123)
+c:pr_merge("owner/repo", 123, {merge_method = "squash"})
+
+-- Issues
+local issues = c:issue_list("owner/repo", {labels = "bug", state = "open"})
+local issue = c:issue_get("owner/repo", 42)
+c:issue_create("owner/repo", "Bug title", "Description", {labels = {"bug"}})
+c:issue_comment("owner/repo", 42, "Fixed in PR #123")
+
+-- Repository info
+local repo = c:repo_get("owner/repo")
+
+-- GitHub Actions
+local runs = c:runs_list("owner/repo", {status = "completed"})
+local run = c:run_get("owner/repo", 12345)
+
+-- GraphQL queries
+local data = c:graphql("query { viewer { login } }")
+local complex = c:graphql([[
+  query($owner: String!, $name: String!) {
+    repository(owner: $owner, name: $name) {
+      pullRequests(last: 10, states: OPEN) {
+        nodes { number title author { login } }
+      }
+    }
+  }
+]], {owner = "owner", name = "repo"})
+```
+
+### assay.gmail
+
+Gmail REST API with OAuth2 token auto-refresh. Search, read, reply, send emails.
+
+```lua
+local gmail = require("assay.gmail")
+local c = gmail.client({
+  credentials_file = "/path/to/google-oauth2-credentials.json",
+  token_file = "/path/to/saved-oauth2-token.json"
+})
+
+-- Search emails (Gmail search syntax)
+local emails = c:search("newer_than:1d is:unread", {max = 20})
+local urgent = c:search("subject:urgent OR subject:ASAP", {max = 5})
+
+-- Read a specific message
+local msg = c:get("message-id-here")
+
+-- Reply to an email (preserves thread, references)
+c:reply("message-id", {body = "Thanks for the update! The fix looks good."})
+
+-- Send new email
+c:send("user@example.com", "Project Update", [[
+Hello team,
+
+The deployment completed successfully at 3:00 PM UTC.
+
+Best regards,
+Eda
+]])
+
+-- List labels
+local labels = c:labels()
+for _, label in ipairs(labels) do
+  log.info("Label: " .. label.name .. " (" .. label.messagesTotal .. " messages)")
+end
+```
+
+### assay.gcal
+
+Google Calendar REST API with OAuth2 token auto-refresh. Events CRUD, calendar list.
+
+```lua
+local gcal = require("assay.gcal")
+local c = gcal.client({
+  credentials_file = "/path/to/google-oauth2-credentials.json",
+  token_file = "/path/to/saved-oauth2-token.json"
+})
+
+-- List upcoming events
+local events = c:events({
+  timeMin = "2026-04-05T00:00:00Z",
+  timeMax = "2026-04-12T00:00:00Z",
+  maxResults = 10
+})
+
+-- Get specific event
+local event = c:event_get("event-id-from-google")
+
+-- Create a new meeting
+local new_event = c:event_create({
+  summary = "Team standup",
+  description = "Daily sync meeting",
+  start = {dateTime = "2026-04-06T09:00:00Z", timeZone = "UTC"},
+  ["end"] = {dateTime = "2026-04-06T09:30:00Z", timeZone = "UTC"},
+  attendees = {
+    {email = "alice@company.com"},
+    {email = "bob@company.com"}
+  }
+})
+
+-- Update existing event
+c:event_update("event-id", {
+  summary = "Team standup (updated agenda)",
+  description = "Daily sync + sprint planning"
+})
+
+-- Delete event
+c:event_delete("event-id")
+
+-- List all calendars
+local calendars = c:calendars()
+for _, cal in ipairs(calendars) do
+  log.info("Calendar: " .. cal.summary .. " (" .. cal.id .. ")")
+end
+```
+
+### assay.oauth2
+
+Google OAuth2 token management. File-based credentials loading, automatic access token refresh
+via refresh_token grant, token persistence, and auth header generation. Used internally by
+gmail and gcal modules.
+
+Default credential paths: `~/.config/gog/credentials.json` (OAuth2 client credentials) and
+`~/.config/gog/token.json` (saved access/refresh tokens).
+
+- `M.from_file(credentials_path?, token_path?, opts?)` -> client -- Load OAuth2 credentials and token files. Defaults to `~/.config/gog/credentials.json` and `~/.config/gog/token.json`. Reads `installed` or `web` key from credentials JSON. `opts`: `{token_url}` to override the Google token endpoint.
+- `client:access_token()` -> string -- Return current access token
+- `client:refresh()` -> string -- Refresh access token using refresh_token grant. POSTs to `https://oauth2.googleapis.com/token` with client_id, client_secret, and refresh_token. Updates internal state with new access_token, refresh_token, expires_in, and token_type.
+- `client:save()` -> true -- Persist current token data (including refreshed access_token) back to the token file
+- `client:headers()` -> table -- Return `{Authorization = "Bearer <token>", ["Content-Type"] = "application/json"}` for use with http builtins
+
+Example:
+```lua
+local oauth2 = require("assay.oauth2")
+
+-- Load from default paths
+local auth = oauth2.from_file()
+
+-- Or specify custom paths
+local auth = oauth2.from_file("/secrets/google-creds.json", "/data/google-token.json")
+
+-- Refresh and persist
+auth:refresh()
+auth:save()
+
+-- Use with http builtins
+local resp = http.get("https://www.googleapis.com/calendar/v3/calendars/primary/events", {
+  headers = auth:headers()
+})
+```
+
+### assay.email_triage
+
+Email triage helpers for deterministic categorization or OpenClaw LLM-assisted classification.
+Sorts emails into three buckets: `needs_reply`, `needs_action`, and `fyi`.
+
+Deterministic rules:
+- `needs_action`: subject contains "action required", "urgent", or "deadline"
+- `fyi`: from address contains "noreply", "no-reply", "newsletter"; subject contains "newsletter" or "automated"; or `email.automated == true`
+- `needs_reply`: everything else (human emails that likely need a response)
+
+- `M.categorize(emails, opts?)` -> buckets -- Deterministically bucket emails by subject and sender patterns. Returns `{needs_reply = [...], needs_action = [...], fyi = [...]}`. Each email should have `from`, `subject` fields (strings). `opts` is reserved for future use.
+- `M.categorize_llm(emails, openclaw_client, opts?)` -> buckets -- Use OpenClaw LLM task for smarter bucketing. Requires an `openclaw_client` with `llm_task` method. Returns same bucket structure. `opts`: `{prompt, output_schema}` to customize the LLM classification prompt and expected JSON schema.
+
+Example:
+```lua
+local email_triage = require("assay.email_triage")
+
+-- Deterministic categorization (no LLM, no network)
+local emails = {
+  {from = "alice@company.com", subject = "Review PR #42"},
+  {from = "noreply@github.com", subject = "CI build passed"},
+  {from = "boss@company.com", subject = "Action required: quarterly report"},
+}
+local buckets = email_triage.categorize(emails)
+-- buckets.needs_reply  = [{from="alice@...", subject="Review PR #42"}]
+-- buckets.needs_action = [{from="boss@...", subject="Action required: ..."}]
+-- buckets.fyi          = [{from="noreply@...", subject="CI build passed"}]
+
+-- LLM-assisted triage via OpenClaw
+local openclaw = require("assay.openclaw")
+local oc = openclaw.client()
+local smart_buckets = email_triage.categorize_llm(emails, oc)
 ```
 
 ## Optional

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -1,8 +1,8 @@
 # Assay
 
 > Assay is a ~9 MB static binary that runs Lua scripts in Kubernetes. It replaces 50-250 MB
-> Python/Node/kubectl containers. One binary handles HTTP, database, crypto, WebSocket, and 23
-> Kubernetes-native service integrations. No `require()` for builtins — they are global.
+> Python/Node/kubectl containers. One binary handles HTTP, database, crypto, WebSocket, and 29
+> Kubernetes-native and AI agent service integrations. No `require()` for builtins — they are global.
 > Stdlib modules use `require("assay.<name>")` then `M.client(url, opts)` → `c:method()`.
 > Run `assay context <query>` to get LLM-ready method signatures for any module.
 > HTTP responses are `{status, body, headers}` tables. Errors raised via `error()` — use `pcall()`.
@@ -65,6 +65,14 @@
 ## Feature Flags & Utilities
 - [assay.unleash](https://assay.rs/modules.html#unleash): Unleash feature flags, environments, strategies
 - [assay.healthcheck](https://assay.rs/modules.html#healthcheck): HTTP health checks, JSON path, latency
+
+## AI Agent & Workflow
+- [assay.openclaw](https://assay.rs/modules.html#openclaw): OpenClaw AI agent platform — invoke tools, state, diff, approve, LLM tasks, cron, sub-agents
+- [assay.github](https://assay.rs/modules.html#github): GitHub REST API — PRs, issues, actions, GraphQL (no gh CLI)
+- [assay.gmail](https://assay.rs/modules.html#gmail): Gmail REST API with OAuth2 — search, read, reply, send
+- [assay.gcal](https://assay.rs/modules.html#gcal): Google Calendar REST API with OAuth2 — events CRUD, calendar list
+- [assay.oauth2](https://assay.rs/modules.html#oauth2): Google OAuth2 token management — file-based credentials, auto-refresh, persistence
+- [assay.email_triage](https://assay.rs/modules.html#email_triage): Email triage — deterministic rules + LLM-assisted classification
 
 ## Optional
 - [Crates.io](https://crates.io/crates/assay-lua): Use Assay as a Rust crate in your own projects

--- a/site/modules.html
+++ b/site/modules.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Assay — Module Reference</title>
-  <meta name="description" content="Complete reference for all 40+ Assay modules — 17 Rust builtins and 23 embedded Lua stdlib modules, zero dependencies.">
+  <meta name="description" content="Complete reference for all 46+ Assay modules — 17 Rust builtins and 29 embedded Lua stdlib modules, zero dependencies.">
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -24,7 +24,7 @@
   <main>
     <h1>Module Reference</h1>
     <p style="font-size: 1.15rem; color: var(--text-light); margin-bottom: 1.5rem;">
-      40+ built-in modules, zero dependencies. Use <code>assay context &lt;query&gt;</code> for LLM-ready docs on any module.
+      46+ built-in modules, zero dependencies. Use <code>assay context &lt;query&gt;</code> for LLM-ready docs on any module.
     </p>
 
     <pre><code>assay modules                    # list all modules
@@ -242,12 +242,12 @@ assay context "grafana health"   # get detailed docs for LLM</code></pre>
     </table>
 
     <!-- ============================================================ -->
-    <!-- STDLIB MODULES (23 modules)                                  -->
+    <!-- STDLIB MODULES (29 modules)                                  -->
     <!-- ============================================================ -->
 
     <h2>Stdlib Modules</h2>
     <p>
-      23 embedded Lua modules loaded via <code>require("assay.&lt;name&gt;")</code>.
+      29 embedded Lua modules loaded via <code>require("assay.&lt;name&gt;")</code>.
       All follow the client pattern: <code>M.client(url, opts)</code> &rarr; client object &rarr; <code>c:method()</code>.
     </p>
 
@@ -475,6 +475,216 @@ assay context "grafana health"   # get detailed docs for LLM</code></pre>
           <td><code>require("assay.unleash")</code></td>
           <td>Feature flags, environments</td>
           <td><code>unleash.client(url, opts)</code></td>
+        </tr>
+      </tbody>
+    </table>
+
+    <!-- ============================================================ -->
+    <!-- AI AGENT & WORKFLOW                                          -->
+    <!-- ============================================================ -->
+
+    <h2 id="ai-agent">AI Agent &amp; Workflow</h2>
+    <p>Integrate with AI agent platforms, GitHub, Gmail, and Google Calendar — all via native HTTP, zero shell dependencies.</p>
+
+    <h3 id="openclaw"><code>assay.openclaw</code></h3>
+    <p>OpenClaw AI agent platform integration. Invoke tools, send messages, manage state, spawn sub-agents, approval gates, LLM tasks.</p>
+    <pre><code>local openclaw = require("assay.openclaw")
+local c = openclaw.client()  -- auto-discovers $OPENCLAW_URL + $OPENCLAW_TOKEN
+
+-- Invoke any OpenClaw tool
+local result = c:invoke("message", "send", { target = "#general", message = "Hello!" })
+
+-- Shorthand: send message
+c:send("discord", "#alerts", "Service is down!")
+c:notify("ops-team", "Deployment complete")
+
+-- Persistent state
+c:state_set("last-deploy", { version = "1.2.3", time = time() })
+local prev = c:state_get("last-deploy")
+
+-- Diff detection
+local diff = c:diff("pr-state", new_snapshot)
+if diff.changed then log.info("State changed!") end
+
+-- LLM task
+local answer = c:llm_task("Summarize this PR", { model = "claude-sonnet" })
+
+-- Cron jobs
+c:cron_add({ schedule = "0 9 * * *", task = "daily-report" })
+
+-- Sub-agents
+c:spawn("Fix the login bug", { model = "gpt-4o" })</code></pre>
+
+    <h3 id="github"><code>assay.github</code></h3>
+    <p>GitHub REST API client. PRs, issues, actions, repositories, GraphQL. No <code>gh</code> CLI dependency.</p>
+    <pre><code>local github = require("assay.github")
+local c = github.client()  -- uses $GITHUB_TOKEN
+
+-- Pull requests
+local pr = c:pr_view("owner/repo", 123)
+local prs = c:pr_list("owner/repo", { state = "open" })
+local reviews = c:pr_reviews("owner/repo", 123)
+c:pr_merge("owner/repo", 123, { merge_method = "squash" })
+
+-- Issues
+local issues = c:issue_list("owner/repo", { labels = "bug", state = "open" })
+local issue = c:issue_get("owner/repo", 42)
+c:issue_create("owner/repo", "Bug title", "Description", { labels = {"bug"} })
+c:issue_comment("owner/repo", 42, "Fixed in PR #123")
+
+-- Actions
+local runs = c:runs_list("owner/repo", { status = "completed" })
+local run = c:run_get("owner/repo", 12345)
+
+-- GraphQL
+local data = c:graphql("query { viewer { login } }")</code></pre>
+
+    <h3 id="gmail"><code>assay.gmail</code></h3>
+    <p>Gmail REST API with OAuth2 token auto-refresh. Search, read, reply, send emails.</p>
+    <pre><code>local gmail = require("assay.gmail")
+local c = gmail.client({
+  credentials_file = "/path/to/credentials.json",
+  token_file = "/path/to/token.json",
+})
+
+-- Search emails
+local emails = c:search("newer_than:1d is:unread", { max = 20 })
+
+-- Read a message
+local msg = c:get("message-id-here")
+
+-- Reply to an email
+c:reply("message-id", { body = "Thanks for the update!" })
+
+-- Send new email
+c:send("user@example.com", "Subject", "Email body")
+
+-- List labels
+local labels = c:labels()</code></pre>
+
+    <h3 id="gcal"><code>assay.gcal</code></h3>
+    <p>Google Calendar REST API with OAuth2 token auto-refresh. Events CRUD, calendar list.</p>
+    <pre><code>local gcal = require("assay.gcal")
+local c = gcal.client({
+  credentials_file = "/path/to/credentials.json",
+  token_file = "/path/to/token.json",
+})
+
+-- List upcoming events
+local events = c:events({ timeMin = "2026-04-05T00:00:00Z", maxResults = 10 })
+
+-- Get specific event
+local event = c:event_get("event-id")
+
+-- Create event
+c:event_create({
+  summary = "Team standup",
+  start = { dateTime = "2026-04-06T09:00:00Z" },
+  ["end"] = { dateTime = "2026-04-06T09:30:00Z" },
+})
+
+-- Update / delete
+c:event_update("event-id", updated_event)
+c:event_delete("event-id")
+
+-- List all calendars
+local calendars = c:calendars()</code></pre>
+
+    <h3 id="oauth2"><code>assay.oauth2</code></h3>
+    <p>Google OAuth2 token management. File-based credentials loading, automatic access token refresh, token persistence.</p>
+    <pre><code>local oauth2 = require("assay.oauth2")
+
+-- Load credentials and token from default paths
+-- (~/.config/gog/credentials.json and ~/.config/gog/token.json)
+local auth = oauth2.from_file()
+
+-- Or specify custom paths
+local auth = oauth2.from_file("/path/to/credentials.json", "/path/to/token.json")
+
+-- Refresh access token
+auth:refresh()
+
+-- Persist updated token back to file
+auth:save()
+
+-- Get auth headers for API calls
+local headers = auth:headers()
+-- Returns: {Authorization = "Bearer ...", ["Content-Type"] = "application/json"}
+
+-- Use with http builtins
+local resp = http.get("https://www.googleapis.com/calendar/v3/calendars/primary/events", {
+  headers = auth:headers()
+})</code></pre>
+
+    <h3 id="email_triage"><code>assay.email_triage</code></h3>
+    <p>Email classification and triage. Deterministic rule-based categorization or OpenClaw LLM-assisted classification into action, reply, and FYI buckets.</p>
+    <pre><code>local email_triage = require("assay.email_triage")
+local gmail = require("assay.gmail")
+
+local gc = gmail.client({
+  credentials_file = "/path/to/credentials.json",
+  token_file = "/path/to/token.json",
+})
+
+-- Fetch recent emails
+local emails = gc:search("newer_than:1d", { max = 50 })
+
+-- Deterministic categorization (no LLM needed)
+local buckets = email_triage.categorize(emails)
+log.info("Needs reply: " .. #buckets.needs_reply)
+log.info("Needs action: " .. #buckets.needs_action)
+log.info("FYI: " .. #buckets.fyi)
+
+-- LLM-assisted triage via OpenClaw (smarter classification)
+local openclaw = require("assay.openclaw")
+local oc = openclaw.client()
+local smart_buckets = email_triage.categorize_llm(emails, oc)</code></pre>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Module</th>
+          <th>require()</th>
+          <th>Description</th>
+          <th>Client Pattern</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>assay.openclaw</code></td>
+          <td><code>require("assay.openclaw")</code></td>
+          <td>AI agent tools, state, approve, LLM</td>
+          <td><code>openclaw.client(url?, opts?)</code></td>
+        </tr>
+        <tr>
+          <td><code>assay.github</code></td>
+          <td><code>require("assay.github")</code></td>
+          <td>PRs, issues, actions, GraphQL</td>
+          <td><code>github.client(opts?)</code></td>
+        </tr>
+        <tr>
+          <td><code>assay.gmail</code></td>
+          <td><code>require("assay.gmail")</code></td>
+          <td>Email search, read, reply, send</td>
+          <td><code>gmail.client(opts)</code></td>
+        </tr>
+        <tr>
+          <td><code>assay.gcal</code></td>
+          <td><code>require("assay.gcal")</code></td>
+          <td>Calendar events CRUD</td>
+          <td><code>gcal.client(opts)</code></td>
+        </tr>
+        <tr>
+          <td><code>assay.oauth2</code></td>
+          <td><code>require("assay.oauth2")</code></td>
+          <td>OAuth2 token management, auto-refresh</td>
+          <td><code>oauth2.from_file(creds?, token?)</code></td>
+        </tr>
+        <tr>
+          <td><code>assay.email_triage</code></td>
+          <td><code>require("assay.email_triage")</code></td>
+          <td>Email classification, triage buckets</td>
+          <td><code>email_triage.categorize(emails)</code></td>
         </tr>
       </tbody>
     </table>

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -5,8 +5,8 @@
 //! 2. Global  — `$ASSAY_MODULES_PATH` or `~/.assay/modules/`
 //! 3. BuiltIn — embedded stdlib + hardcoded Rust builtins
 
-use include_dir::{include_dir, Dir};
 use crate::search::{SearchEngine, SearchResult};
+use include_dir::{Dir, include_dir};
 
 use crate::metadata::{self, ModuleMetadata};
 #[cfg(not(feature = "db"))]
@@ -41,22 +41,47 @@ const BUILTINS: &[(&str, &str, &[&str])] = &[
     (
         "http",
         "HTTP client and server: get, post, put, patch, delete, serve",
-        &["http", "client", "server", "request", "response", "headers", "endpoint", "api", "webhook", "rest"],
+        &[
+            "http", "client", "server", "request", "response", "headers", "endpoint", "api",
+            "webhook", "rest",
+        ],
     ),
     (
         "json",
         "JSON serialization: parse and encode",
-        &["json", "serialization", "deserialize", "stringify", "parse", "encode", "format"],
+        &[
+            "json",
+            "serialization",
+            "deserialize",
+            "stringify",
+            "parse",
+            "encode",
+            "format",
+        ],
     ),
     (
         "yaml",
         "YAML serialization: parse and encode",
-        &["yaml", "serialization", "deserialize", "parse", "encode", "format"],
+        &[
+            "yaml",
+            "serialization",
+            "deserialize",
+            "parse",
+            "encode",
+            "format",
+        ],
     ),
     (
         "toml",
         "TOML serialization: parse and encode",
-        &["toml", "serialization", "deserialize", "parse", "encode", "configuration"],
+        &[
+            "toml",
+            "serialization",
+            "deserialize",
+            "parse",
+            "encode",
+            "configuration",
+        ],
     ),
     (
         "fs",
@@ -66,7 +91,20 @@ const BUILTINS: &[(&str, &str, &[&str])] = &[
     (
         "crypto",
         "Cryptography: jwt_sign, hash, hmac, random",
-        &["crypto", "jwt", "signature", "hash", "hmac", "encryption", "random", "security", "password", "signing", "rsa", "sha256"],
+        &[
+            "crypto",
+            "jwt",
+            "signature",
+            "hash",
+            "hmac",
+            "encryption",
+            "random",
+            "security",
+            "password",
+            "signing",
+            "rsa",
+            "sha256",
+        ],
     ),
     (
         "base64",
@@ -76,37 +114,88 @@ const BUILTINS: &[(&str, &str, &[&str])] = &[
     (
         "regex",
         "Regular expressions: match, find, find_all, replace",
-        &["regex", "pattern", "match", "find", "replace", "regular-expression", "regexp"],
+        &[
+            "regex",
+            "pattern",
+            "match",
+            "find",
+            "replace",
+            "regular-expression",
+            "regexp",
+        ],
     ),
     (
         "db",
         "Database: connect, query, execute, close (Postgres, MySQL, SQLite)",
-        &["db", "database", "sql", "postgres", "mysql", "sqlite", "connection", "query", "execute"],
+        &[
+            "db",
+            "database",
+            "sql",
+            "postgres",
+            "mysql",
+            "sqlite",
+            "connection",
+            "query",
+            "execute",
+        ],
     ),
     (
         "ws",
         "WebSocket: connect, send, recv, close",
-        &["ws", "websocket", "connection", "message", "streaming", "realtime", "socket"],
+        &[
+            "ws",
+            "websocket",
+            "connection",
+            "message",
+            "streaming",
+            "realtime",
+            "socket",
+        ],
     ),
     (
         "template",
         "Jinja2-compatible templates: render file or string",
-        &["template", "jinja2", "rendering", "string-template", "mustache", "render"],
+        &[
+            "template",
+            "jinja2",
+            "rendering",
+            "string-template",
+            "mustache",
+            "render",
+        ],
     ),
     (
         "async",
         "Async tasks: spawn, spawn_interval, await, cancel",
-        &["async", "asynchronous", "task", "coroutine", "concurrent", "spawn", "interval"],
+        &[
+            "async",
+            "asynchronous",
+            "task",
+            "coroutine",
+            "concurrent",
+            "spawn",
+            "interval",
+        ],
     ),
     (
         "assert",
         "Assertions: eq, gt, lt, contains, not_nil, matches",
-        &["assert", "assertion", "test", "validation", "comparison", "check", "verify"],
+        &[
+            "assert",
+            "assertion",
+            "test",
+            "validation",
+            "comparison",
+            "check",
+            "verify",
+        ],
     ),
     (
         "log",
         "Logging: info, warn, error",
-        &["log", "logging", "output", "debug", "error", "warning", "info", "trace"],
+        &[
+            "log", "logging", "output", "debug", "error", "warning", "info", "trace",
+        ],
     ),
     (
         "env",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 pub mod lua;
-pub mod search;
 pub mod metadata;
+pub mod search;
 
 pub mod context;
 pub mod discovery;

--- a/src/lua/builtins/core.rs
+++ b/src/lua/builtins/core.rs
@@ -140,7 +140,9 @@ pub fn register_fs(lua: &Lua) -> mlua::Result<()> {
         };
         if is_dir {
             std::fs::remove_dir_all(&path).map_err(|e| {
-                mlua::Error::runtime(format!("fs.remove: failed to remove directory {path:?}: {e}"))
+                mlua::Error::runtime(format!(
+                    "fs.remove: failed to remove directory {path:?}: {e}"
+                ))
             })
         } else {
             std::fs::remove_file(&path).map_err(|e| {
@@ -150,37 +152,37 @@ pub fn register_fs(lua: &Lua) -> mlua::Result<()> {
     })?;
     fs_table.set("remove", remove_fn)?;
 
-    let list_fn = lua.create_function(|lua, path: String| {
-        let entries = lua.create_table()?;
-        for (i, entry) in (1..).zip(std::fs::read_dir(&path).map_err(|e| {
-            mlua::Error::runtime(format!("fs.list: failed to list {path:?}: {e}"))
-        })?) {
-            let entry = entry.map_err(|e| {
-                mlua::Error::runtime(format!("fs.list: error reading entry in {path:?}: {e}"))
-            })?;
-            let info = lua.create_table()?;
-            let name = entry.file_name().to_string_lossy().to_string();
-            info.set("name", name)?;
-            let file_type = entry.file_type().map_err(|e| {
-                mlua::Error::runtime(format!("fs.list: failed to get file type: {e}"))
-            })?;
-            if file_type.is_dir() {
-                info.set("type", "directory")?;
-            } else if file_type.is_symlink() {
-                info.set("type", "symlink")?;
-            } else {
-                info.set("type", "file")?;
+    let list_fn =
+        lua.create_function(|lua, path: String| {
+            let entries = lua.create_table()?;
+            for (i, entry) in (1..).zip(std::fs::read_dir(&path).map_err(|e| {
+                mlua::Error::runtime(format!("fs.list: failed to list {path:?}: {e}"))
+            })?) {
+                let entry = entry.map_err(|e| {
+                    mlua::Error::runtime(format!("fs.list: error reading entry in {path:?}: {e}"))
+                })?;
+                let info = lua.create_table()?;
+                let name = entry.file_name().to_string_lossy().to_string();
+                info.set("name", name)?;
+                let file_type = entry.file_type().map_err(|e| {
+                    mlua::Error::runtime(format!("fs.list: failed to get file type: {e}"))
+                })?;
+                if file_type.is_dir() {
+                    info.set("type", "directory")?;
+                } else if file_type.is_symlink() {
+                    info.set("type", "symlink")?;
+                } else {
+                    info.set("type", "file")?;
+                }
+                entries.set(i, info)?;
             }
-            entries.set(i, info)?;
-        }
-        Ok(entries)
-    })?;
+            Ok(entries)
+        })?;
     fs_table.set("list", list_fn)?;
 
     let stat_fn = lua.create_function(|lua, path: String| {
-        let metadata = std::fs::metadata(&path).map_err(|e| {
-            mlua::Error::runtime(format!("fs.stat: failed to stat {path:?}: {e}"))
-        })?;
+        let metadata = std::fs::metadata(&path)
+            .map_err(|e| mlua::Error::runtime(format!("fs.stat: failed to stat {path:?}: {e}")))?;
         // Use symlink_metadata separately to correctly detect symlinks,
         // since std::fs::metadata follows symlinks (is_symlink always false).
         let is_symlink = std::fs::symlink_metadata(&path)
@@ -206,13 +208,13 @@ pub fn register_fs(lua: &Lua) -> mlua::Result<()> {
     fs_table.set("stat", stat_fn)?;
 
     let mkdir_fn = lua.create_function(|_, path: String| {
-        std::fs::create_dir_all(&path).map_err(|e| {
-            mlua::Error::runtime(format!("fs.mkdir: failed to create {path:?}: {e}"))
-        })
+        std::fs::create_dir_all(&path)
+            .map_err(|e| mlua::Error::runtime(format!("fs.mkdir: failed to create {path:?}: {e}")))
     })?;
     fs_table.set("mkdir", mkdir_fn)?;
 
-    let exists_fn = lua.create_function(|_, path: String| Ok(std::path::Path::new(&path).exists()))?;
+    let exists_fn =
+        lua.create_function(|_, path: String| Ok(std::path::Path::new(&path).exists()))?;
     fs_table.set("exists", exists_fn)?;
 
     // fs.copy(src, dst) — copy file, returns bytes copied
@@ -227,7 +229,9 @@ pub fn register_fs(lua: &Lua) -> mlua::Result<()> {
     // fs.rename(src, dst) — atomic rename
     let rename_fn = lua.create_function(|_, (src, dst): (String, String)| {
         std::fs::rename(&src, &dst).map_err(|e| {
-            mlua::Error::runtime(format!("fs.rename: failed to rename {src:?} to {dst:?}: {e}"))
+            mlua::Error::runtime(format!(
+                "fs.rename: failed to rename {src:?} to {dst:?}: {e}"
+            ))
         })
     })?;
     fs_table.set("rename", rename_fn)?;
@@ -239,9 +243,8 @@ pub fn register_fs(lua: &Lua) -> mlua::Result<()> {
         })?;
         let results = lua.create_table()?;
         for (i, entry) in (1..).zip(paths) {
-            let path = entry.map_err(|e| {
-                mlua::Error::runtime(format!("fs.glob: error reading entry: {e}"))
-            })?;
+            let path = entry
+                .map_err(|e| mlua::Error::runtime(format!("fs.glob: error reading entry: {e}")))?;
             results.set(i, path.to_string_lossy().to_string())?;
         }
         Ok(results)
@@ -267,9 +270,8 @@ pub fn register_fs(lua: &Lua) -> mlua::Result<()> {
     // fs.chmod(path, mode) — set file permissions (octal integer, e.g. 493 = 0o755)
     let chmod_fn = lua.create_function(|_, (path, mode): (String, u32)| {
         let perms = std::fs::Permissions::from_mode(mode);
-        std::fs::set_permissions(&path, perms).map_err(|e| {
-            mlua::Error::runtime(format!("fs.chmod: failed to chmod {path:?}: {e}"))
-        })
+        std::fs::set_permissions(&path, perms)
+            .map_err(|e| mlua::Error::runtime(format!("fs.chmod: failed to chmod {path:?}: {e}")))
     })?;
     fs_table.set("chmod", chmod_fn)?;
 
@@ -328,9 +330,7 @@ pub fn register_fs(lua: &Lua) -> mlua::Result<()> {
                 }
                 results.set(*i, info)?;
                 *i += 1;
-                if file_type.is_dir()
-                    && (max_depth.is_none() || depth < max_depth.unwrap())
-                {
+                if file_type.is_dir() && (max_depth.is_none() || depth < max_depth.unwrap()) {
                     walk(base, &entry.path(), results, lua, i, depth + 1, max_depth)?;
                 }
             }

--- a/src/lua/builtins/http.rs
+++ b/src/lua/builtins/http.rs
@@ -13,9 +13,9 @@ use hyper::service::service_fn;
 use hyper::{Request, Response, StatusCode};
 use mlua::{Lua, Table, UserData, Value};
 #[cfg(feature = "server")]
-use std::collections::HashMap;
-#[cfg(feature = "server")]
 use std::cell::RefCell;
+#[cfg(feature = "server")]
+use std::collections::HashMap;
 #[cfg(feature = "server")]
 use std::pin::Pin;
 #[cfg(feature = "server")]
@@ -40,9 +40,7 @@ pub fn register_http(lua: &Lua, client: reqwest::Client) -> mlua::Result<()> {
         let func = lua.create_async_function(move |lua, args: mlua::MultiValue| {
             let client = method_client.clone();
             let method_name = method_name.clone();
-            async move {
-                execute_http_request(&lua, &client, &method_name, args).await
-            }
+            async move { execute_http_request(&lua, &client, &method_name, args).await }
         })?;
         http_table.set(method, func)?;
     }
@@ -72,9 +70,7 @@ pub fn register_http(lua: &Lua, client: reqwest::Client) -> mlua::Result<()> {
                     ))
                 })?;
                 let cert = reqwest::Certificate::from_pem(&pem).map_err(|e| {
-                    mlua::Error::runtime(format!(
-                        "http.client: invalid PEM in {ca_path:?}: {e}"
-                    ))
+                    mlua::Error::runtime(format!("http.client: invalid PEM in {ca_path:?}: {e}"))
                 })?;
                 builder = builder.add_root_certificate(cert);
             }
@@ -188,8 +184,11 @@ pub fn register_http(lua: &Lua, client: reqwest::Client) -> mlua::Result<()> {
             .map_err(|e| mlua::Error::runtime(format!("http.serve: bind failed: {e}")))?;
 
         // Expose the actual bound port so callers using port 0 can discover it
-        let actual_port = listener.local_addr()
-            .map_err(|e| mlua::Error::runtime(format!("http.serve: failed to get local addr: {e}")))?
+        let actual_port = listener
+            .local_addr()
+            .map_err(|e| {
+                mlua::Error::runtime(format!("http.serve: failed to get local addr: {e}"))
+            })?
             .port();
         lua.globals().set("_SERVER_PORT", actual_port)?;
 
@@ -252,9 +251,7 @@ async fn execute_http_request(
             Some(Value::Table(t)) => {
                 let json_val = lua_table_to_json(&t)?;
                 let serialized = serde_json::to_string(&json_val).map_err(|e| {
-                    mlua::Error::runtime(format!(
-                        "http.{method_name}: JSON encode failed: {e}"
-                    ))
+                    mlua::Error::runtime(format!("http.{method_name}: JSON encode failed: {e}"))
                 })?;
                 (serialized, true)
             }
@@ -316,15 +313,14 @@ async fn execute_http_request(
         }
     }
 
-    let resp = req.send().await.map_err(|e| {
-        mlua::Error::runtime(format!("http.{method_name} failed: {e}"))
-    })?;
+    let resp = req
+        .send()
+        .await
+        .map_err(|e| mlua::Error::runtime(format!("http.{method_name} failed: {e}")))?;
     let status = resp.status().as_u16();
     let resp_headers = resp.headers().clone();
     let body = resp.text().await.map_err(|e| {
-        mlua::Error::runtime(format!(
-            "http.{method_name}: reading body failed: {e}"
-        ))
+        mlua::Error::runtime(format!("http.{method_name}: reading body failed: {e}"))
     })?;
 
     let result = lua.create_table()?;
@@ -587,20 +583,19 @@ fn lua_response_to_http(
     let mut builder =
         Response::builder().status(StatusCode::from_u16(status).unwrap_or(StatusCode::OK));
 
-    let has_content_type = if let Ok(Some(headers_table)) =
-        resp_table.get::<Option<Table>>("headers")
-    {
-        let mut found_ct = false;
-        for (k, v) in headers_table.pairs::<String, String>().flatten() {
-            if k.eq_ignore_ascii_case("content-type") {
-                found_ct = true;
+    let has_content_type =
+        if let Ok(Some(headers_table)) = resp_table.get::<Option<Table>>("headers") {
+            let mut found_ct = false;
+            for (k, v) in headers_table.pairs::<String, String>().flatten() {
+                if k.eq_ignore_ascii_case("content-type") {
+                    found_ct = true;
+                }
+                builder = builder.header(k, v);
             }
-            builder = builder.header(k, v);
-        }
-        found_ct
-    } else {
-        false
-    };
+            found_ct
+        } else {
+            false
+        };
 
     let body_bytes = if let Ok(Some(json_table)) = resp_table.get::<Option<Table>>("json") {
         let json_val =
@@ -622,7 +617,5 @@ fn lua_response_to_http(
         Bytes::new()
     };
 
-    Ok(builder
-        .body(Either::Left(Full::new(body_bytes)))
-        .unwrap())
+    Ok(builder.body(Either::Left(Full::new(body_bytes))).unwrap())
 }

--- a/src/lua/builtins/mod.rs
+++ b/src/lua/builtins/mod.rs
@@ -1,12 +1,12 @@
 mod assert;
 mod core;
 mod crypto;
-mod disk;
 #[cfg(feature = "db")]
 mod db;
+mod disk;
 mod http;
-mod os_info;
 mod json;
+mod os_info;
 mod process;
 mod serialization;
 mod shell;

--- a/src/lua/builtins/process.rs
+++ b/src/lua/builtins/process.rs
@@ -77,11 +77,7 @@ fn list_processes() -> Result<Vec<(i64, String, Option<String>)>, String> {
             continue;
         }
         // Extract just the binary name from the full path (e.g. /usr/sbin/syslogd -> syslogd)
-        let name = comm
-            .rsplit('/')
-            .next()
-            .unwrap_or(&comm)
-            .to_string();
+        let name = comm.rsplit('/').next().unwrap_or(&comm).to_string();
         result.push((pid, name, Some(comm)));
     }
     Ok(result)
@@ -100,8 +96,7 @@ pub fn register_process(lua: &Lua) -> mlua::Result<()> {
 
     // process.list() — returns table of {pid, name, cmdline?}
     let list_fn = lua.create_function(|lua, ()| {
-        let proc_list =
-            list_processes().map_err(mlua::Error::runtime)?;
+        let proc_list = list_processes().map_err(mlua::Error::runtime)?;
 
         let procs = lua.create_table()?;
         for (i, (pid, name, cmdline)) in proc_list.into_iter().enumerate() {
@@ -119,9 +114,7 @@ pub fn register_process(lua: &Lua) -> mlua::Result<()> {
     process_table.set("list", list_fn)?;
 
     // process.is_running(name) — check if a process with given name exists
-    let is_running_fn = lua.create_function(|_, name: String| {
-        Ok(is_process_running(&name))
-    })?;
+    let is_running_fn = lua.create_function(|_, name: String| Ok(is_process_running(&name)))?;
     process_table.set("is_running", is_running_fn)?;
 
     // process.kill(pid, signal?) — send signal to process (default SIGTERM = 15)

--- a/src/lua/mod.rs
+++ b/src/lua/mod.rs
@@ -25,7 +25,10 @@ pub fn create_vm_with_lib_path(client: reqwest::Client, lib_path: String) -> Res
     create_vm_with_paths(client, Some(lib_path))
 }
 
-pub fn create_vm_with_paths(client: reqwest::Client, global_modules_path: Option<String>) -> Result<Lua> {
+pub fn create_vm_with_paths(
+    client: reqwest::Client,
+    global_modules_path: Option<String>,
+) -> Result<Lua> {
     let libs = StdLib::ALL_SAFE;
     let lua = Lua::new_with(libs, LuaOptions::default()).map_err(lua_err)?;
     lua.set_memory_limit(64 * 1024 * 1024).map_err(lua_err)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,11 +5,21 @@ mod output;
 mod runner;
 
 use clap::{Parser, Subcommand};
+use mlua::LuaSerdeExt;
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use std::fs;
 use std::path::PathBuf;
+use std::process::Command;
 use std::process::ExitCode;
 use std::time::Duration;
 use tracing::{error, info};
 use tracing_subscriber::EnvFilter;
+
+const DEFAULT_TOOL_TIMEOUT_SECS: u64 = 20;
+const DEFAULT_RESUME_TTL_SECS: u64 = 3600;
+const TOOL_STDOUT_CAP_BYTES: usize = 512 * 1024;
+const APPROVAL_REQUEST_PREFIX: &str = "__assay_approval_request__:";
 
 pub fn build_http_client() -> reqwest::Client {
     reqwest::Client::builder()
@@ -62,7 +72,74 @@ enum Commands {
     Run {
         /// Path to .yaml or .lua file
         file: PathBuf,
+        #[arg(long, value_parser = ["tool", "script"])]
+        mode: Option<String>,
+        #[arg(long, default_value = "20")]
+        timeout: Option<u64>,
     },
+    Resume {
+        #[arg(long)]
+        token: String,
+        #[arg(long, value_parser = ["yes", "no"])]
+        approve: String,
+        #[arg(long, default_value = "3600")]
+        resume_ttl: Option<u64>,
+    },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ScriptMode {
+    Script,
+    Tool,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct RunOptions {
+    mode: ScriptMode,
+    timeout_secs: u64,
+}
+
+impl Default for RunOptions {
+    fn default() -> Self {
+        Self {
+            mode: resolve_script_mode(None),
+            timeout_secs: DEFAULT_TOOL_TIMEOUT_SECS,
+        }
+    }
+}
+
+#[derive(Serialize)]
+struct ToolSuccessEnvelope {
+    ok: bool,
+    status: &'static str,
+    output: JsonValue,
+    #[serde(rename = "requiresApproval")]
+    requires_approval: Option<JsonValue>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    truncated: Option<bool>,
+}
+
+#[derive(Serialize)]
+struct ToolErrorEnvelope {
+    ok: bool,
+    status: &'static str,
+    error: String,
+}
+
+#[derive(Deserialize)]
+struct ApprovalRequestPayload {
+    prompt: String,
+    #[serde(default)]
+    context: JsonValue,
+}
+
+#[derive(Deserialize, Serialize)]
+struct ResumeState {
+    script_path: PathBuf,
+    approval_prompt: String,
+    approval_context: JsonValue,
+    created_at: u64,
+    ttl_secs: u64,
 }
 
 #[tokio::main]
@@ -87,17 +164,32 @@ async fn main() -> ExitCode {
             if let Some(code) = eval {
                 run_lua_inline(&code).await
             } else if let Some(path) = file {
-                run_lua_script(&path).await
+                run_lua_script(&path, RunOptions::default()).await
             } else {
                 eprintln!("error: exec requires either -e <code> or a file path");
                 ExitCode::from(1)
             }
         }
         Some(Commands::Modules) => run_modules(),
-        Some(Commands::Run { file }) => dispatch_file(&file).await,
+        Some(Commands::Run {
+            file,
+            mode,
+            timeout,
+        }) => {
+            let options = RunOptions {
+                mode: resolve_script_mode(mode.as_deref()),
+                timeout_secs: timeout.unwrap_or(DEFAULT_TOOL_TIMEOUT_SECS),
+            };
+            dispatch_file(&file, options).await
+        }
+        Some(Commands::Resume {
+            token,
+            approve,
+            resume_ttl,
+        }) => resume_tool_execution(&token, &approve, resume_ttl).await,
         None => {
             if let Some(ref file) = cli.file {
-                dispatch_file(file).await
+                dispatch_file(file, RunOptions::default()).await
             } else {
                 use clap::CommandFactory;
                 Cli::command().print_help().ok();
@@ -108,12 +200,23 @@ async fn main() -> ExitCode {
     }
 }
 
-async fn dispatch_file(file: &std::path::Path) -> ExitCode {
+fn resolve_script_mode(cli_mode: Option<&str>) -> ScriptMode {
+    match cli_mode
+        .map(std::borrow::ToOwned::to_owned)
+        .or_else(|| std::env::var("ASSAY_MODE").ok())
+        .as_deref()
+    {
+        Some("tool") => ScriptMode::Tool,
+        _ => ScriptMode::Script,
+    }
+}
+
+async fn dispatch_file(file: &std::path::Path, options: RunOptions) -> ExitCode {
     let ext = file.extension().and_then(|e| e.to_str()).unwrap_or("");
 
     match ext {
         "yaml" | "yml" => run_yaml_checks(file).await,
-        "lua" => run_lua_script(file).await,
+        "lua" => run_lua_script(file, options).await,
         other => {
             eprintln!(
                 "error: unsupported file extension {other:?} (expected .yaml, .yml, or .lua)"
@@ -145,9 +248,7 @@ async fn run_yaml_checks(path: &std::path::Path) -> ExitCode {
     result.print()
 }
 
-async fn run_lua_script(path: &std::path::Path) -> ExitCode {
-    info!(script = %path.display(), "starting assay (script mode)");
-
+async fn run_lua_script(path: &std::path::Path, options: RunOptions) -> ExitCode {
     let script = match std::fs::read_to_string(path) {
         Ok(s) => s,
         Err(e) => {
@@ -155,6 +256,17 @@ async fn run_lua_script(path: &std::path::Path) -> ExitCode {
             return ExitCode::from(1);
         }
     };
+
+    let script = lua::async_bridge::strip_shebang(&script);
+
+    match options.mode {
+        ScriptMode::Script => run_lua_script_mode(path, script).await,
+        ScriptMode::Tool => run_lua_tool_mode(path, script, options.timeout_secs).await,
+    }
+}
+
+async fn run_lua_script_mode(path: &std::path::Path, script: &str) -> ExitCode {
+    info!(script = %path.display(), "starting assay (script mode)");
 
     let client = build_http_client();
 
@@ -165,8 +277,6 @@ async fn run_lua_script(path: &std::path::Path) -> ExitCode {
             return ExitCode::from(1);
         }
     };
-
-    let script = lua::async_bridge::strip_shebang(&script);
 
     let local = tokio::task::LocalSet::new();
     let result = local
@@ -187,6 +297,147 @@ async fn run_lua_script(path: &std::path::Path) -> ExitCode {
     }
 }
 
+async fn run_lua_tool_mode(path: &std::path::Path, script: &str, timeout_secs: u64) -> ExitCode {
+    info!(script = %path.display(), timeout_secs, "starting assay (tool mode)");
+    let tool_script = format!("env.set(\"ASSAY_MODE\", \"tool\")\n{script}");
+
+    let client = build_http_client();
+
+    let vm = match lua::create_vm(client) {
+        Ok(vm) => vm,
+        Err(e) => {
+            emit_tool_error("error", format!("creating Lua VM: {e:#}"));
+            return ExitCode::SUCCESS;
+        }
+    };
+
+    let local = tokio::task::LocalSet::new();
+    let execution = local.run_until(async {
+        vm.load(&tool_script)
+            .set_name(format!("@{}", path.display()))
+            .eval_async::<mlua::Value>()
+            .await
+    });
+
+    let result = tokio::time::timeout(Duration::from_secs(timeout_secs), execution).await;
+
+    match result {
+        Ok(Ok(value)) => match lua_value_to_json(&vm, value) {
+            Ok(output) => {
+                emit_tool_success(output);
+                ExitCode::SUCCESS
+            }
+            Err(e) => {
+                emit_tool_error("error", format!("serializing Lua result: {e}"));
+                ExitCode::SUCCESS
+            }
+        },
+        Ok(Err(e)) => {
+            if let Some(request) = extract_approval_request(&e) {
+                match persist_resume_state(path, request) {
+                    Ok(requires_approval) => emit_tool_needs_approval(requires_approval),
+                    Err(err) => emit_tool_error("error", err),
+                }
+            } else {
+                emit_tool_error("error", format_lua_error(&e));
+            }
+            ExitCode::SUCCESS
+        }
+        Err(_) => {
+            emit_tool_error(
+                "timeout",
+                format!("execution timed out after {timeout_secs}s"),
+            );
+            ExitCode::SUCCESS
+        }
+    }
+}
+
+async fn resume_tool_execution(token: &str, approve: &str, resume_ttl: Option<u64>) -> ExitCode {
+    let state_dir = match resolve_state_dir() {
+        Ok(dir) => dir,
+        Err(err) => {
+            emit_tool_error("error", err);
+            return ExitCode::SUCCESS;
+        }
+    };
+
+    let state_path = state_dir.join("resume").join(format!("{token}.json"));
+    if !state_path.exists() {
+        emit_tool_error("error", "invalid resume token".to_string());
+        return ExitCode::SUCCESS;
+    }
+
+    let state = match fs::read_to_string(&state_path) {
+        Ok(content) => match serde_json::from_str::<ResumeState>(&content) {
+            Ok(state) => state,
+            Err(err) => {
+                emit_tool_error("error", format!("parsing resume state: {err}"));
+                return ExitCode::SUCCESS;
+            }
+        },
+        Err(err) => {
+            emit_tool_error("error", format!("reading resume state: {err}"));
+            return ExitCode::SUCCESS;
+        }
+    };
+
+    let now = unix_timestamp_now();
+    let ttl_secs = resume_ttl.unwrap_or(state.ttl_secs);
+    if state.created_at.saturating_add(ttl_secs) < now {
+        emit_tool_error("error", "resume token expired".to_string());
+        return ExitCode::SUCCESS;
+    }
+
+    let current_exe = match std::env::current_exe() {
+        Ok(path) => path,
+        Err(err) => {
+            emit_tool_error("error", format!("locating assay binary: {err}"));
+            return ExitCode::SUCCESS;
+        }
+    };
+
+    let output = match Command::new(current_exe)
+        .args([
+            "run",
+            "--mode",
+            "tool",
+            state.script_path.to_string_lossy().as_ref(),
+        ])
+        .env("ASSAY_MODE", "tool")
+        .env("ASSAY_APPROVAL_RESULT", approve)
+        .env("ASSAY_STATE_DIR", &state_dir)
+        .output()
+    {
+        Ok(output) => output,
+        Err(err) => {
+            emit_tool_error("error", format!("spawning resume execution: {err}"));
+            return ExitCode::SUCCESS;
+        }
+    };
+
+    if !output.stderr.is_empty() {
+        eprint!("{}", String::from_utf8_lossy(&output.stderr));
+    }
+    if !output.stdout.is_empty() {
+        print!("{}", String::from_utf8_lossy(&output.stdout));
+    }
+
+    let resumed_status = serde_json::from_slice::<JsonValue>(&output.stdout)
+        .ok()
+        .and_then(|json| json.get("status").cloned())
+        .and_then(|status| status.as_str().map(str::to_owned));
+    let should_cleanup =
+        output.status.success() && resumed_status.as_deref() != Some("needs_approval");
+
+    if should_cleanup && let Err(err) = fs::remove_file(&state_path) {
+        emit_tool_error("error", format!("cleaning up resume state: {err}"));
+        return ExitCode::SUCCESS;
+    }
+
+    ExitCode::SUCCESS
+}
+
 async fn run_lua_inline(code: &str) -> ExitCode {
     info!("starting assay (inline eval mode)");
 
@@ -204,12 +455,7 @@ async fn run_lua_inline(code: &str) -> ExitCode {
 
     let local = tokio::task::LocalSet::new();
     let result = local
-        .run_until(async {
-            vm.load(script)
-                .set_name("@<eval>")
-                .exec_async()
-                .await
-        })
+        .run_until(async { vm.load(script).set_name("@<eval>").exec_async().await })
         .await;
 
     match result {
@@ -236,8 +482,176 @@ fn format_lua_error(err: &mlua::Error) -> String {
     }
 }
 
+fn lua_value_to_json(lua: &mlua::Lua, value: mlua::Value) -> Result<JsonValue, mlua::Error> {
+    lua.from_value(value)
+}
+
+fn extract_approval_request(err: &mlua::Error) -> Option<ApprovalRequestPayload> {
+    let message = format_lua_error(err);
+    let start = message.find(APPROVAL_REQUEST_PREFIX)?;
+    let payload = &message[start + APPROVAL_REQUEST_PREFIX.len()..];
+    let json_payload = payload
+        .split_once('\n')
+        .map(|(json, _)| json)
+        .unwrap_or(payload);
+    serde_json::from_str(json_payload).ok()
+}
+
+fn persist_resume_state(
+    script_path: &std::path::Path,
+    request: ApprovalRequestPayload,
+) -> Result<JsonValue, String> {
+    let state_dir = resolve_state_dir()?;
+    let resume_dir = state_dir.join("resume");
+    fs::create_dir_all(&resume_dir)
+        .map_err(|err| format!("creating resume state directory: {err}"))?;
+
+    let token = format!("{:032x}", rand::random::<u128>());
+    let resolved_script_path = if script_path.is_absolute() {
+        script_path.to_path_buf()
+    } else {
+        match script_path.canonicalize() {
+            Ok(path) => path,
+            Err(_) => script_path.to_path_buf(),
+        }
+    };
+    let state = ResumeState {
+        script_path: resolved_script_path,
+        approval_prompt: request.prompt.clone(),
+        approval_context: request.context.clone(),
+        created_at: unix_timestamp_now(),
+        ttl_secs: DEFAULT_RESUME_TTL_SECS,
+    };
+
+    let serialized =
+        serde_json::to_vec(&state).map_err(|err| format!("serializing resume state: {err}"))?;
+    fs::write(resume_dir.join(format!("{token}.json")), serialized)
+        .map_err(|err| format!("writing resume state: {err}"))?;
+
+    Ok(serde_json::json!({
+        "prompt": request.prompt,
+        "context": request.context,
+        "resumeToken": token,
+    }))
+}
+
+fn resolve_state_dir() -> Result<PathBuf, String> {
+    if let Ok(dir) = std::env::var("ASSAY_STATE_DIR") {
+        return Ok(PathBuf::from(dir));
+    }
+    if let Ok(dir) = std::env::var("OPENCLAW_STATE_DIR") {
+        return Ok(PathBuf::from(dir));
+    }
+
+    match std::env::var("HOME") {
+        Ok(home) => Ok(PathBuf::from(home).join(".assay").join("state")),
+        Err(_) => Err("resolving state directory: HOME is not set".to_string()),
+    }
+}
+
+fn unix_timestamp_now() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+}
+
+fn emit_tool_success(output: JsonValue) {
+    let mut envelope = ToolSuccessEnvelope {
+        ok: true,
+        status: "ok",
+        output,
+        requires_approval: None,
+        truncated: None,
+    };
+
+    if let Ok(serialized) = serde_json::to_vec(&envelope)
+        && serialized.len() > TOOL_STDOUT_CAP_BYTES
+    {
+        envelope = truncate_tool_envelope(envelope);
+    }
+
+    match serde_json::to_string(&envelope) {
+        Ok(serialized) => print!("{serialized}"),
+        Err(e) => emit_tool_error("error", format!("serializing tool envelope: {e}")),
+    }
+}
+
+fn emit_tool_needs_approval(requires_approval: JsonValue) {
+    let envelope = ToolSuccessEnvelope {
+        ok: true,
+        status: "needs_approval",
+        output: JsonValue::Null,
+        requires_approval: Some(requires_approval),
+        truncated: None,
+    };
+
+    match serde_json::to_string(&envelope) {
+        Ok(serialized) => print!("{serialized}"),
+        Err(err) => emit_tool_error("error", format!("serializing tool envelope: {err}")),
+    }
+}
+
+fn emit_tool_error(status: &'static str, error_message: String) {
+    let envelope = ToolErrorEnvelope {
+        ok: false,
+        status,
+        error: error_message,
+    };
+
+    match serde_json::to_string(&envelope) {
+        Ok(serialized) => print!("{serialized}"),
+        Err(e) => print!(
+            "{{\"ok\":false,\"status\":\"error\",\"error\":\"serializing tool envelope: {e}\"}}"
+        ),
+    }
+}
+
+fn truncate_tool_envelope(mut envelope: ToolSuccessEnvelope) -> ToolSuccessEnvelope {
+    let serialized_output =
+        serde_json::to_string(&envelope.output).unwrap_or_else(|_| "null".to_string());
+    let boundaries: Vec<usize> = serialized_output
+        .char_indices()
+        .map(|(idx, _)| idx)
+        .chain(std::iter::once(serialized_output.len()))
+        .collect();
+
+    let suffix = if serialized_output.is_empty() {
+        ""
+    } else {
+        "..."
+    };
+    let mut low = 0usize;
+    let mut high = boundaries.len().saturating_sub(1);
+    let mut best = JsonValue::String(suffix.to_string());
+
+    while low <= high {
+        let mid = low + (high - low) / 2;
+        let candidate = format!("{}{}", &serialized_output[..boundaries[mid]], suffix);
+        envelope.output = JsonValue::String(candidate.clone());
+        envelope.truncated = Some(true);
+
+        match serde_json::to_vec(&envelope) {
+            Ok(serialized) if serialized.len() <= TOOL_STDOUT_CAP_BYTES => {
+                best = JsonValue::String(candidate);
+                low = mid.saturating_add(1);
+            }
+            _ => {
+                if mid == 0 {
+                    break;
+                }
+                high = mid - 1;
+            }
+        }
+    }
+
+    envelope.output = best;
+    envelope.truncated = Some(true);
+    envelope
+}
+
 fn run_modules() -> ExitCode {
-    use assay::discovery::{discover_modules, ModuleSource};
+    use assay::discovery::{ModuleSource, discover_modules};
 
     let modules = discover_modules();
 
@@ -261,14 +675,17 @@ fn run_modules() -> ExitCode {
             ModuleSource::Project => "project",
             ModuleSource::Global => "global",
         };
-        println!("{:<30} {:<10} {}", m.module_name, source_label, m.metadata.description);
+        println!(
+            "{:<30} {:<10} {}",
+            m.module_name, source_label, m.metadata.description
+        );
     }
 
     ExitCode::SUCCESS
 }
 
 fn run_context(query: &str, limit: usize) -> ExitCode {
-    use assay::context::{format_context, ModuleContextEntry, QuickRefEntry};
+    use assay::context::{ModuleContextEntry, QuickRefEntry, format_context};
     use assay::discovery::{discover_modules, search_modules};
 
     // Run on a dedicated thread to avoid tokio runtime nesting.

--- a/stdlib/email_triage.lua
+++ b/stdlib/email_triage.lua
@@ -1,0 +1,93 @@
+--- @module assay.email_triage
+--- @description Email triage helpers for deterministic categorization or OpenClaw-assisted classification into action, reply, and FYI buckets.
+--- @keywords email, triage, gmail, inbox, classify, categorize, openclaw, llm, workflow
+--- @quickref email_triage.categorize(emails, opts?) -> buckets | Deterministically bucket emails by subject and sender
+--- @quickref email_triage.categorize_llm(emails, openclaw_client, opts?) -> buckets | Use OpenClaw LLM task for smarter bucketing
+
+local M = {}
+
+local function empty_buckets()
+  return {
+    needs_reply = {},
+    needs_action = {},
+    fyi = {},
+  }
+end
+
+local function is_automated(email)
+  local from = (email.from or ""):lower()
+  local subject = (email.subject or ""):lower()
+  return email.automated == true
+    or from:match("noreply") ~= nil
+    or from:match("no%-reply") ~= nil
+    or from:match("newsletter") ~= nil
+    or subject:match("newsletter") ~= nil
+    or subject:match("automated") ~= nil
+  end
+
+local function needs_action(email)
+  local subject = (email.subject or ""):lower()
+  return subject:match("action required") ~= nil
+    or subject:match("urgent") ~= nil
+    or subject:match("deadline") ~= nil
+end
+
+local function normalize(result)
+  local buckets = result.categories or result.result or result
+  if type(buckets) ~= "table" then
+    error("email_triage: invalid LLM response")
+  end
+  buckets.needs_reply = buckets.needs_reply or {}
+  buckets.needs_action = buckets.needs_action or {}
+  buckets.fyi = buckets.fyi or {}
+  return buckets
+end
+
+function M.categorize(emails, opts)
+  opts = opts or {}
+  local buckets = empty_buckets()
+  for _, email in ipairs(emails or {}) do
+    if needs_action(email) then
+      buckets.needs_action[#buckets.needs_action + 1] = email
+    elseif not is_automated(email) then
+      buckets.needs_reply[#buckets.needs_reply + 1] = email
+    else
+      buckets.fyi[#buckets.fyi + 1] = email
+    end
+  end
+  return buckets
+end
+
+function M.categorize_llm(emails, openclaw_client, opts)
+  opts = opts or {}
+  if not openclaw_client or not openclaw_client.llm_task then
+    error("email_triage: openclaw_client with llm_task is required")
+  end
+
+  local prompt = opts.prompt or [[
+Classify the provided email artifacts into exactly three buckets: needs_reply, needs_action, and fyi.
+
+- needs_reply: human emails that likely need a response
+- needs_action: emails that require urgent or explicit action
+- fyi: newsletters, noreply mail, automated mail, or informational updates
+
+Return only the bucketed emails.
+]]
+
+  local result = openclaw_client:llm_task(prompt, {
+    artifacts = emails or {},
+    output_schema = opts.output_schema or {
+      type = "object",
+      properties = {
+        needs_reply = { type = "array" },
+        needs_action = { type = "array" },
+        fyi = { type = "array" },
+      },
+      required = { "needs_reply", "needs_action", "fyi" },
+    },
+  })
+
+  return normalize(result)
+end
+
+return M

--- a/stdlib/gcal.lua
+++ b/stdlib/gcal.lua
@@ -1,0 +1,141 @@
+--- @module assay.gcal
+--- @description Google Calendar REST API client with OAuth2 token refresh. Events CRUD, calendar list.
+--- @keywords google, calendar, gcal, events, oauth2, schedule, meeting, create, update, delete
+--- @quickref c:events(opts?) -> [event] | List calendar events
+--- @quickref c:event_get(event_id) -> event | Get event by ID
+--- @quickref c:event_create(event) -> event | Create a calendar event
+--- @quickref c:event_update(event_id, event) -> event | Update an event
+--- @quickref c:event_delete(event_id) -> true | Delete an event
+--- @quickref c:calendars() -> [calendar] | List all calendars
+
+local M = {}
+local oauth2 = require("assay.oauth2")
+
+local GCAL_API = "https://www.googleapis.com"
+local TOKEN_URL = "https://oauth2.googleapis.com/token"
+
+function M.client(opts)
+  opts = opts or {}
+
+  local credentials_file = opts.credentials_file
+  local token_file = opts.token_file
+  local token_url = opts.token_url or TOKEN_URL
+
+  if not credentials_file then
+    error("gcal: credentials_file is required")
+  end
+  if not token_file then
+    error("gcal: token_file is required")
+  end
+
+  local auth = oauth2.from_file(credentials_file, token_file, {
+    token_url = token_url,
+  })
+
+  local c = {
+    _oauth2 = auth,
+    _api_base = opts.api_base or GCAL_API,
+  }
+
+  local function headers(self)
+    return self._oauth2:headers()
+  end
+
+  local function refresh_auth(self)
+    self._oauth2:refresh()
+    self._oauth2:save()
+  end
+
+  local function api_get(self, path_str)
+    local resp = http.get(self._api_base .. path_str, { headers = headers(self) })
+    if resp.status == 401 then
+      refresh_auth(self)
+      resp = http.get(self._api_base .. path_str, { headers = headers(self) })
+    end
+    if resp.status == 404 then return nil end
+    if resp.status ~= 200 then
+      error("gcal: GET " .. path_str .. " HTTP " .. resp.status .. ": " .. resp.body)
+    end
+    return json.parse(resp.body)
+  end
+
+  local function api_post(self, path_str, payload)
+    local resp = http.post(self._api_base .. path_str, payload, { headers = headers(self) })
+    if resp.status == 401 then
+      refresh_auth(self)
+      resp = http.post(self._api_base .. path_str, payload, { headers = headers(self) })
+    end
+    if resp.status ~= 200 and resp.status ~= 201 then
+      error("gcal: POST " .. path_str .. " HTTP " .. resp.status .. ": " .. resp.body)
+    end
+    return json.parse(resp.body)
+  end
+
+  local function api_put(self, path_str, payload)
+    local resp = http.put(self._api_base .. path_str, payload, { headers = headers(self) })
+    if resp.status == 401 then
+      refresh_auth(self)
+      resp = http.put(self._api_base .. path_str, payload, { headers = headers(self) })
+    end
+    if resp.status ~= 200 then
+      error("gcal: PUT " .. path_str .. " HTTP " .. resp.status .. ": " .. resp.body)
+    end
+    return json.parse(resp.body)
+  end
+
+  local function api_delete(self, path_str)
+    local resp = http.delete(self._api_base .. path_str, { headers = headers(self) })
+    if resp.status == 401 then
+      refresh_auth(self)
+      resp = http.delete(self._api_base .. path_str, { headers = headers(self) })
+    end
+    if resp.status ~= 200 and resp.status ~= 204 then
+      error("gcal: DELETE " .. path_str .. " HTTP " .. resp.status .. ": " .. resp.body)
+    end
+    return true
+  end
+
+  function c:events(events_opts)
+    events_opts = events_opts or {}
+    local params = {}
+    if events_opts.timeMin then params[#params + 1] = "timeMin=" .. events_opts.timeMin end
+    if events_opts.timeMax then params[#params + 1] = "timeMax=" .. events_opts.timeMax end
+    if events_opts.maxResults then params[#params + 1] = "maxResults=" .. events_opts.maxResults end
+    if events_opts.q then params[#params + 1] = "q=" .. events_opts.q end
+    local qs = ""
+    if #params > 0 then qs = "?" .. table.concat(params, "&") end
+    local result = api_get(self, "/calendar/v3/calendars/primary/events" .. qs)
+    if result and result.items then
+      return result.items
+    end
+    return {}
+  end
+
+  function c:event_get(event_id)
+    return api_get(self, "/calendar/v3/calendars/primary/events/" .. event_id)
+  end
+
+  function c:event_create(event)
+    return api_post(self, "/calendar/v3/calendars/primary/events", event)
+  end
+
+  function c:event_update(event_id, event)
+    return api_put(self, "/calendar/v3/calendars/primary/events/" .. event_id, event)
+  end
+
+  function c:event_delete(event_id)
+    return api_delete(self, "/calendar/v3/calendars/primary/events/" .. event_id)
+  end
+
+  function c:calendars()
+    local result = api_get(self, "/calendar/v3/users/me/calendarList")
+    if result and result.items then
+      return result.items
+    end
+    return {}
+  end
+
+  return c
+end
+
+return M

--- a/stdlib/github.lua
+++ b/stdlib/github.lua
@@ -1,0 +1,179 @@
+--- @module assay.github
+--- @description GitHub REST API client. PRs, issues, actions, repositories, GraphQL. No gh CLI dependency.
+--- @keywords github, pr, pull-request, issue, actions, runs, graphql, repository, merge, review, comment
+--- @quickref c:pr_view(repo, number) -> pr | Get pull request details
+--- @quickref c:pr_list(repo, opts?) -> [pr] | List pull requests
+--- @quickref c:pr_reviews(repo, number) -> [review] | List PR reviews
+--- @quickref c:pr_merge(repo, number, opts?) -> result | Merge a pull request
+--- @quickref c:issue_list(repo, opts?) -> [issue] | List issues
+--- @quickref c:issue_get(repo, number) -> issue | Get issue details
+--- @quickref c:issue_create(repo, title, body, opts?) -> issue | Create an issue
+--- @quickref c:issue_comment(repo, number, body) -> comment | Add issue comment
+--- @quickref c:repo_get(repo) -> repository | Get repository details
+--- @quickref c:runs_list(repo, opts?) -> {workflow_runs} | List workflow runs
+--- @quickref c:run_get(repo, run_id) -> run | Get workflow run details
+--- @quickref c:graphql(query, variables?) -> data | Execute GraphQL query
+
+local M = {}
+
+function M.client(opts)
+  opts = opts or {}
+  local token = opts.token or env.get("GITHUB_TOKEN")
+  local base_url = opts.base_url or "https://api.github.com"
+
+  local c = {
+    base_url = base_url:gsub("/+$", ""),
+    token = token,
+  }
+
+  local function headers(self)
+    local h = {
+      ["Content-Type"] = "application/json",
+      ["Accept"] = "application/vnd.github+json",
+    }
+    if self.token then
+      h["Authorization"] = "Bearer " .. self.token
+    end
+    return h
+  end
+
+  local function parse_repo(repo)
+    local owner, name = repo:match("^([^/]+)/(.+)$")
+    if not owner then
+      error("github: invalid repo format, expected 'owner/repo': " .. repo)
+    end
+    return owner, name
+  end
+
+  local function api_get(self, path_str)
+    local resp = http.get(self.base_url .. path_str, { headers = headers(self) })
+    if resp.status == 404 then return nil end
+    if resp.status ~= 200 then
+      error("github: GET " .. path_str .. " HTTP " .. resp.status .. ": " .. resp.body)
+    end
+    return json.parse(resp.body)
+  end
+
+  local function api_post(self, path_str, payload)
+    local resp = http.post(self.base_url .. path_str, payload, { headers = headers(self) })
+    if resp.status ~= 200 and resp.status ~= 201 then
+      error("github: POST " .. path_str .. " HTTP " .. resp.status .. ": " .. resp.body)
+    end
+    return json.parse(resp.body)
+  end
+
+  local function api_put(self, path_str, payload)
+    local resp = http.put(self.base_url .. path_str, payload or {}, { headers = headers(self) })
+    if resp.status ~= 200 and resp.status ~= 204 then
+      error("github: PUT " .. path_str .. " HTTP " .. resp.status .. ": " .. resp.body)
+    end
+    if resp.body and resp.body ~= "" then
+      return json.parse(resp.body)
+    end
+    return true
+  end
+
+  function c:pr_view(repo, number)
+    local owner, name = parse_repo(repo)
+    return api_get(self, "/repos/" .. owner .. "/" .. name .. "/pulls/" .. number)
+  end
+
+  function c:pr_list(repo, pr_opts)
+    pr_opts = pr_opts or {}
+    local owner, name = parse_repo(repo)
+    local params = {}
+    if pr_opts.state then params[#params + 1] = "state=" .. pr_opts.state end
+    if pr_opts.sort then params[#params + 1] = "sort=" .. pr_opts.sort end
+    if pr_opts.direction then params[#params + 1] = "direction=" .. pr_opts.direction end
+    if pr_opts.per_page then params[#params + 1] = "per_page=" .. pr_opts.per_page end
+    local qs = ""
+    if #params > 0 then qs = "?" .. table.concat(params, "&") end
+    return api_get(self, "/repos/" .. owner .. "/" .. name .. "/pulls" .. qs)
+  end
+
+  function c:pr_reviews(repo, number)
+    local owner, name = parse_repo(repo)
+    return api_get(self, "/repos/" .. owner .. "/" .. name .. "/pulls/" .. number .. "/reviews")
+  end
+
+  function c:pr_merge(repo, number, merge_opts)
+    merge_opts = merge_opts or {}
+    local owner, name = parse_repo(repo)
+    local payload = {}
+    if merge_opts.merge_method then payload.merge_method = merge_opts.merge_method end
+    if merge_opts.commit_title then payload.commit_title = merge_opts.commit_title end
+    if merge_opts.commit_message then payload.commit_message = merge_opts.commit_message end
+    return api_put(self, "/repos/" .. owner .. "/" .. name .. "/pulls/" .. number .. "/merge", payload)
+  end
+
+  function c:issue_list(repo, issue_opts)
+    issue_opts = issue_opts or {}
+    local owner, name = parse_repo(repo)
+    local params = {}
+    if issue_opts.state then params[#params + 1] = "state=" .. issue_opts.state end
+    if issue_opts.labels then params[#params + 1] = "labels=" .. issue_opts.labels end
+    if issue_opts.sort then params[#params + 1] = "sort=" .. issue_opts.sort end
+    if issue_opts.direction then params[#params + 1] = "direction=" .. issue_opts.direction end
+    if issue_opts.per_page then params[#params + 1] = "per_page=" .. issue_opts.per_page end
+    local qs = ""
+    if #params > 0 then qs = "?" .. table.concat(params, "&") end
+    return api_get(self, "/repos/" .. owner .. "/" .. name .. "/issues" .. qs)
+  end
+
+  function c:issue_get(repo, number)
+    local owner, name = parse_repo(repo)
+    return api_get(self, "/repos/" .. owner .. "/" .. name .. "/issues/" .. number)
+  end
+
+  function c:issue_create(repo, title, body, create_opts)
+    create_opts = create_opts or {}
+    local owner, name = parse_repo(repo)
+    local payload = {
+      title = title,
+      body = body,
+    }
+    if create_opts.labels then payload.labels = create_opts.labels end
+    if create_opts.assignees then payload.assignees = create_opts.assignees end
+    if create_opts.milestone then payload.milestone = create_opts.milestone end
+    return api_post(self, "/repos/" .. owner .. "/" .. name .. "/issues", payload)
+  end
+
+  function c:issue_comment(repo, number, body)
+    local owner, name = parse_repo(repo)
+    return api_post(self, "/repos/" .. owner .. "/" .. name .. "/issues/" .. number .. "/comments", {
+      body = body,
+    })
+  end
+
+  function c:repo_get(repo)
+    local owner, name = parse_repo(repo)
+    return api_get(self, "/repos/" .. owner .. "/" .. name)
+  end
+
+  function c:runs_list(repo, runs_opts)
+    runs_opts = runs_opts or {}
+    local owner, name = parse_repo(repo)
+    local params = {}
+    if runs_opts.status then params[#params + 1] = "status=" .. runs_opts.status end
+    if runs_opts.branch then params[#params + 1] = "branch=" .. runs_opts.branch end
+    if runs_opts.per_page then params[#params + 1] = "per_page=" .. runs_opts.per_page end
+    local qs = ""
+    if #params > 0 then qs = "?" .. table.concat(params, "&") end
+    return api_get(self, "/repos/" .. owner .. "/" .. name .. "/actions/runs" .. qs)
+  end
+
+  function c:run_get(repo, run_id)
+    local owner, name = parse_repo(repo)
+    return api_get(self, "/repos/" .. owner .. "/" .. name .. "/actions/runs/" .. run_id)
+  end
+
+  function c:graphql(query, variables)
+    local payload = { query = query }
+    if variables then payload.variables = variables end
+    return api_post(self, "/graphql", payload)
+  end
+
+  return c
+end
+
+return M

--- a/stdlib/gmail.lua
+++ b/stdlib/gmail.lua
@@ -1,0 +1,174 @@
+--- @module assay.gmail
+--- @description Gmail REST API client with OAuth2 token refresh. Search, read, reply, send emails, manage labels.
+--- @keywords gmail, email, oauth2, google, search, send, reply, labels, message, thread
+--- @quickref c:search(query, opts?) -> [message] | Search emails by query
+--- @quickref c:get(message_id, opts?) -> message | Get email message by ID
+--- @quickref c:reply(message_id, opts) -> message | Reply to an email
+--- @quickref c:send(to, subject, body) -> message | Send a new email
+--- @quickref c:labels() -> [label] | List all labels
+
+local M = {}
+local oauth2 = require("assay.oauth2")
+
+local GMAIL_API = "https://gmail.googleapis.com"
+local TOKEN_URL = "https://oauth2.googleapis.com/token"
+
+function M.client(opts)
+  opts = opts or {}
+
+  local credentials_file = opts.credentials_file
+  local token_file = opts.token_file
+  local token_url = opts.token_url or TOKEN_URL
+
+  if not credentials_file then
+    error("gmail: credentials_file is required")
+  end
+  if not token_file then
+    error("gmail: token_file is required")
+  end
+
+  local auth = oauth2.from_file(credentials_file, token_file, {
+    token_url = token_url,
+  })
+
+  local c = {
+    _oauth2 = auth,
+    _api_base = opts.api_base or GMAIL_API,
+  }
+
+  local function headers(self)
+    return self._oauth2:headers()
+  end
+
+  local function refresh_auth(self)
+    self._oauth2:refresh()
+    self._oauth2:save()
+  end
+
+  local function api_get(self, path_str)
+    local resp = http.get(self._api_base .. path_str, { headers = headers(self) })
+    if resp.status == 401 then
+      -- Token expired, refresh and retry
+      refresh_auth(self)
+      resp = http.get(self._api_base .. path_str, { headers = headers(self) })
+    end
+    if resp.status == 404 then return nil end
+    if resp.status ~= 200 then
+      error("gmail: GET " .. path_str .. " HTTP " .. resp.status .. ": " .. resp.body)
+    end
+    return json.parse(resp.body)
+  end
+
+  local function api_post(self, path_str, payload)
+    local resp = http.post(self._api_base .. path_str, payload, { headers = headers(self) })
+    if resp.status == 401 then
+      refresh_auth(self)
+      resp = http.post(self._api_base .. path_str, payload, { headers = headers(self) })
+    end
+    if resp.status ~= 200 and resp.status ~= 201 then
+      error("gmail: POST " .. path_str .. " HTTP " .. resp.status .. ": " .. resp.body)
+    end
+    return json.parse(resp.body)
+  end
+
+  function c:search(query, search_opts)
+    search_opts = search_opts or {}
+    local max = search_opts.max or 10
+    local params = "q=" .. query .. "&maxResults=" .. max
+    local list_resp = api_get(self, "/gmail/v1/users/me/messages?" .. params)
+    if not list_resp or not list_resp.messages then
+      return {}
+    end
+    local messages = {}
+    for _, msg in ipairs(list_resp.messages) do
+      local full = api_get(self, "/gmail/v1/users/me/messages/" .. msg.id .. "?format=full")
+      if full then
+        messages[#messages + 1] = full
+      end
+    end
+    return messages
+  end
+
+  function c:get(message_id, get_opts)
+    get_opts = get_opts or {}
+    local format = get_opts.format or "full"
+    return api_get(self, "/gmail/v1/users/me/messages/" .. message_id .. "?format=" .. format)
+  end
+
+  function c:reply(message_id, reply_opts)
+    reply_opts = reply_opts or {}
+    local original = api_get(self, "/gmail/v1/users/me/messages/" .. message_id .. "?format=full")
+    if not original then
+      error("gmail: message not found: " .. message_id)
+    end
+
+    -- Extract headers from original
+    local from_header = ""
+    local subject = ""
+    local message_id_header = ""
+    local references = ""
+    if original.payload and original.payload.headers then
+      for _, h in ipairs(original.payload.headers) do
+        if h.name == "From" then from_header = h.value end
+        if h.name == "Subject" then subject = h.value end
+        if h.name == "Message-Id" or h.name == "Message-ID" then message_id_header = h.value end
+        if h.name == "References" then references = h.value end
+      end
+    end
+
+    if not subject:match("^Re:") then
+      subject = "Re: " .. subject
+    end
+
+    if references ~= "" then
+      references = references .. " " .. message_id_header
+    else
+      references = message_id_header
+    end
+
+    local body = reply_opts.body or ""
+    local raw_message = "To: " .. from_header .. "\r\n"
+      .. "Subject: " .. subject .. "\r\n"
+      .. "In-Reply-To: " .. message_id_header .. "\r\n"
+      .. "References: " .. references .. "\r\n"
+      .. "Content-Type: text/plain; charset=utf-8\r\n"
+      .. "\r\n"
+      .. body
+
+    local encoded = base64.encode(raw_message)
+    -- URL-safe base64
+    encoded = encoded:gsub("+", "-"):gsub("/", "_"):gsub("=+$", "")
+
+    return api_post(self, "/gmail/v1/users/me/messages/send", {
+      raw = encoded,
+      threadId = original.threadId,
+    })
+  end
+
+  function c:send(to, subject, body)
+    local raw_message = "To: " .. to .. "\r\n"
+      .. "Subject: " .. subject .. "\r\n"
+      .. "Content-Type: text/plain; charset=utf-8\r\n"
+      .. "\r\n"
+      .. body
+
+    local encoded = base64.encode(raw_message)
+    encoded = encoded:gsub("+", "-"):gsub("/", "_"):gsub("=+$", "")
+
+    return api_post(self, "/gmail/v1/users/me/messages/send", {
+      raw = encoded,
+    })
+  end
+
+  function c:labels()
+    local result = api_get(self, "/gmail/v1/users/me/labels")
+    if result and result.labels then
+      return result.labels
+    end
+    return {}
+  end
+
+  return c
+end
+
+return M

--- a/stdlib/oauth2.lua
+++ b/stdlib/oauth2.lua
@@ -1,0 +1,91 @@
+--- @module assay.oauth2
+--- @description Google OAuth2 helper for loading credentials, refreshing access tokens, persisting token files, and building auth headers.
+--- @keywords oauth2, google, auth, token, refresh, credentials, bearer, gmail, gcal
+--- @quickref oauth2.from_file(credentials_path?, token_path?, opts?) -> client | Load OAuth2 credentials and token files
+--- @quickref client:access_token() -> string | Return current access token
+--- @quickref client:refresh() -> string | Refresh access token using refresh_token grant
+--- @quickref client:save() -> true | Persist token data back to token file
+--- @quickref client:headers() -> {Authorization, Content-Type} | Return JSON auth headers
+
+local M = {}
+
+local DEFAULT_CREDENTIALS = "~/.config/gog/credentials.json"
+local DEFAULT_TOKEN = "~/.config/gog/token.json"
+local DEFAULT_TOKEN_URL = "https://oauth2.googleapis.com/token"
+
+local function expand_path(path)
+  local home = env.get("HOME") or ""
+  return path:gsub("^~", home)
+end
+
+local function load_json_file(path)
+  local content = fs.read(path)
+  if not content or content == "" then
+    error("oauth2: failed to read file: " .. path)
+  end
+  return json.parse(content)
+end
+
+function M.from_file(credentials_path, token_path, opts)
+  opts = opts or {}
+
+  local resolved_credentials = expand_path(credentials_path or DEFAULT_CREDENTIALS)
+  local resolved_token = expand_path(token_path or DEFAULT_TOKEN)
+  local creds_data = load_json_file(resolved_credentials)
+  local token_data = load_json_file(resolved_token)
+  local creds = creds_data.installed or creds_data.web or creds_data
+
+  local client = {
+    _credentials = creds,
+    _token_data = token_data,
+    _token_file = resolved_token,
+    _token_url = opts.token_url or DEFAULT_TOKEN_URL,
+    _access_token = token_data.access_token,
+  }
+
+  function client:access_token()
+    return self._access_token
+  end
+
+  function client:refresh()
+    local resp = http.post(self._token_url, {
+      grant_type = "refresh_token",
+      refresh_token = self._token_data.refresh_token,
+      client_id = self._credentials.client_id,
+      client_secret = self._credentials.client_secret,
+    })
+    if resp.status ~= 200 then
+      error("oauth2: token refresh failed HTTP " .. resp.status .. ": " .. resp.body)
+    end
+
+    local result = json.parse(resp.body)
+    self._access_token = result.access_token
+    self._token_data.access_token = result.access_token
+    if result.refresh_token then
+      self._token_data.refresh_token = result.refresh_token
+    end
+    if result.expires_in then
+      self._token_data.expires_in = result.expires_in
+    end
+    if result.token_type then
+      self._token_data.token_type = result.token_type
+    end
+    return self._access_token
+  end
+
+  function client:save()
+    fs.write(self._token_file, json.encode(self._token_data))
+    return true
+  end
+
+  function client:headers()
+    return {
+      ["Authorization"] = "Bearer " .. self:access_token(),
+      ["Content-Type"] = "application/json",
+    }
+  end
+
+  return client
+end
+
+return M

--- a/stdlib/openclaw.lua
+++ b/stdlib/openclaw.lua
@@ -1,0 +1,177 @@
+--- @module assay.openclaw
+--- @description OpenClaw AI agent platform integration. Invoke tools, send messages, manage state, spawn sub-agents, approval gates, LLM tasks.
+--- @keywords openclaw, clawd, agent, ai, workflow, invoke, state, diff, approve, llm, cron, spawn, message, notify
+--- @quickref c:invoke(tool, action, args) -> result | Invoke an OpenClaw tool action
+--- @quickref c:send(channel, target, message) -> result | Send a message via channel
+--- @quickref c:notify(target, message) -> result | Send notification to target
+--- @quickref c:cron_add(job) -> result | Add a cron job
+--- @quickref c:cron_list() -> [job] | List cron jobs
+--- @quickref c:spawn(task, opts?) -> result | Spawn a sub-agent session
+--- @quickref c:state_get(key) -> value|nil | Read state value by key
+--- @quickref c:state_set(key, value) -> true | Write state value by key
+--- @quickref c:diff(key, new_value) -> {changed, before, after} | Compare and store state
+--- @quickref c:approve(prompt, context?) -> bool | Request approval gate
+--- @quickref c:llm_task(prompt, opts?) -> result | Execute an LLM task
+
+local M = {}
+
+function M.client(url, opts)
+  opts = opts or {}
+
+  -- Auto-discover URL from env vars
+  if not url then
+    url = env.get("OPENCLAW_URL") or env.get("CLAWD_URL")
+    if not url then
+      error("openclaw: url required (set $OPENCLAW_URL or $CLAWD_URL)")
+    end
+  end
+
+  local token = opts.token
+  if not token then
+    token = env.get("OPENCLAW_TOKEN") or env.get("CLAWD_TOKEN")
+  end
+
+  local state_dir = opts.state_dir
+  if not state_dir then
+    state_dir = env.get("ASSAY_STATE_DIR") or env.get("OPENCLAW_STATE_DIR")
+    if not state_dir then
+      local home = env.get("HOME") or "/tmp"
+      state_dir = home .. "/.assay/state"
+    end
+  end
+
+  local c = {
+    url = url:gsub("/+$", ""),
+    token = token,
+    state_dir = state_dir,
+  }
+
+  local function headers(self)
+    local h = { ["Content-Type"] = "application/json" }
+    if self.token then
+      h["Authorization"] = "Bearer " .. self.token
+    end
+    return h
+  end
+
+  local function api_post(self, path_str, payload)
+    local resp = http.post(self.url .. path_str, payload, { headers = headers(self) })
+    if resp.status ~= 200 and resp.status ~= 201 then
+      error("openclaw: POST " .. path_str .. " HTTP " .. resp.status .. ": " .. resp.body)
+    end
+    return json.parse(resp.body)
+  end
+
+  function c:invoke(tool, action, args)
+    return api_post(self, "/tools/invoke", {
+      tool = tool,
+      action = action,
+      args = args or {},
+    })
+  end
+
+  function c:send(channel, target, message)
+    return self:invoke("message", "send", {
+      channel = channel,
+      target = target,
+      message = message,
+    })
+  end
+
+  function c:notify(target, message)
+    return self:invoke("message", "send", {
+      target = target,
+      message = message,
+    })
+  end
+
+  function c:cron_add(job)
+    return self:invoke("cron", "add", { job = job })
+  end
+
+  function c:cron_list()
+    return self:invoke("cron", "list", {})
+  end
+
+  function c:spawn(task, spawn_opts)
+    spawn_opts = spawn_opts or {}
+    local args = { task = task }
+    if spawn_opts.model then args.model = spawn_opts.model end
+    if spawn_opts.timeout then args.timeout = spawn_opts.timeout end
+    return self:invoke("sessions_spawn", "invoke", args)
+  end
+
+  function c:state_get(key)
+    local path = self.state_dir .. "/" .. key .. ".json"
+    if not fs.exists(path) then return nil end
+    local content = fs.read(path)
+    if not content or content == "" then return nil end
+    return json.parse(content)
+  end
+
+  function c:state_set(key, value)
+    local path = self.state_dir .. "/" .. key .. ".json"
+    local dir = self.state_dir
+    if not fs.exists(dir) then
+      fs.mkdir(dir)
+    end
+    fs.write(path, json.encode(value))
+    return true
+  end
+
+  function c:diff(key, new_value)
+    local before = self:state_get(key)
+    self:state_set(key, new_value)
+    local changed = json.encode(before) ~= json.encode(new_value)
+    return {
+      changed = changed,
+      before = before,
+      after = new_value,
+    }
+  end
+
+  function c:approve(prompt, context)
+    local approval_result = env.get("ASSAY_APPROVAL_RESULT")
+    if approval_result then
+      return approval_result == "yes"
+    end
+
+    local mode = env.get("ASSAY_MODE")
+    if mode == "tool" then
+      error("__assay_approval_request__:" .. json.encode({
+        prompt = prompt,
+        context = context,
+      }))
+    end
+
+    local interactive = env.get("OPENCLAW_INTERACTIVE") or env.get("TTY")
+    if interactive then
+      log.info("Approval required: " .. prompt)
+      if context then
+        log.info("Context: " .. json.encode(context))
+      end
+      return false
+    end
+
+    error("openclaw: approval_required: " .. json.encode({
+      type = "approval_request",
+      prompt = prompt,
+      context = context,
+    }))
+  end
+
+  function c:llm_task(prompt, llm_opts)
+    llm_opts = llm_opts or {}
+    local args = { prompt = prompt }
+    if llm_opts.model then args.model = llm_opts.model end
+    if llm_opts.artifacts then args.artifacts = llm_opts.artifacts end
+    if llm_opts.output_schema then args.output_schema = llm_opts.output_schema end
+    if llm_opts.temperature then args.temperature = llm_opts.temperature end
+    if llm_opts.max_output_tokens then args.max_output_tokens = llm_opts.max_output_tokens end
+    return self:invoke("llm-task", "invoke", args)
+  end
+
+  return c
+end
+
+return M

--- a/tests/cli_subcommands.rs
+++ b/tests/cli_subcommands.rs
@@ -118,7 +118,6 @@ fn version_flag_works() {
     );
 }
 
-
 #[test]
 fn backward_compat_yaml_file() {
     let output = assay_bin()
@@ -147,10 +146,7 @@ fn backward_compat_toml_file() {
 
 #[test]
 fn unsupported_extension_fails() {
-    let output = assay_bin()
-        .arg("nonexistent.txt")
-        .output()
-        .unwrap();
+    let output = assay_bin().arg("nonexistent.txt").output().unwrap();
     assert!(
         !output.status.success(),
         "unsupported extension should exit non-zero"

--- a/tests/context.rs
+++ b/tests/context.rs
@@ -1,4 +1,4 @@
-use assay::context::{format_context, ModuleContextEntry, QuickRefEntry};
+use assay::context::{ModuleContextEntry, QuickRefEntry, format_context};
 
 #[test]
 fn test_format_single_module() {

--- a/tests/context_cmd.rs
+++ b/tests/context_cmd.rs
@@ -36,5 +36,8 @@ fn test_context_limit_flag() {
         .args(["context", "a", "--limit", "2"])
         .output()
         .unwrap();
-    assert!(output.status.success(), "context with --limit should exit 0");
+    assert!(
+        output.status.success(),
+        "context with --limit should exit 0"
+    );
 }

--- a/tests/crypto.rs
+++ b/tests/crypto.rs
@@ -211,7 +211,8 @@ async fn test_invalid_length() {
 
 #[tokio::test]
 async fn test_hmac_sha256_basic() {
-    let result: String = eval_lua(r#"return crypto.hmac("Jefe", "what do ya want for nothing?", "sha256")"#).await;
+    let result: String =
+        eval_lua(r#"return crypto.hmac("Jefe", "what do ya want for nothing?", "sha256")"#).await;
     assert_eq!(
         result,
         "5bdcc146bf60754e6a042426089575c75a003f089d2739839dec58b964ec3843"

--- a/tests/discovery.rs
+++ b/tests/discovery.rs
@@ -1,4 +1,4 @@
-use assay::discovery::{build_index, discover_modules, search_modules, ModuleSource};
+use assay::discovery::{ModuleSource, build_index, discover_modules, search_modules};
 
 use std::collections::HashSet;
 
@@ -258,9 +258,13 @@ fn test_search_keyword_docker_finds_harbor() {
 #[test]
 fn test_search_regression_grafana_is_first() {
     let results = search_modules("grafana", 5);
-    assert!(!results.is_empty(), "search for 'grafana' should return results");
+    assert!(
+        !results.is_empty(),
+        "search for 'grafana' should return results"
+    );
     assert_eq!(
-        results[0].id, "assay.grafana",
+        results[0].id,
+        "assay.grafana",
         "search for 'grafana' should return assay.grafana first, got: {:?}",
         results.iter().map(|r| r.id.as_str()).collect::<Vec<_>>()
     );
@@ -279,9 +283,13 @@ fn test_search_regression_vault_in_results() {
 #[test]
 fn test_search_regression_prometheus_is_first() {
     let results = search_modules("prometheus", 5);
-    assert!(!results.is_empty(), "search for 'prometheus' should return results");
+    assert!(
+        !results.is_empty(),
+        "search for 'prometheus' should return results"
+    );
     assert_eq!(
-        results[0].id, "assay.prometheus",
+        results[0].id,
+        "assay.prometheus",
         "search for 'prometheus' should return assay.prometheus first, got: {:?}",
         results.iter().map(|r| r.id.as_str()).collect::<Vec<_>>()
     );

--- a/tests/fs.rs
+++ b/tests/fs.rs
@@ -118,7 +118,10 @@ async fn test_fs_mkdir_and_remove() {
         fs.remove("{}")
         assert.eq(fs.exists("{}"), false)
         "#,
-        dir.display(), dir.display(), dir.display(), dir.display()
+        dir.display(),
+        dir.display(),
+        dir.display(),
+        dir.display()
     );
     run_lua(&script).await.unwrap();
     let _ = std::fs::remove_dir_all(&dir);

--- a/tests/stdlib_email_triage.rs
+++ b/tests/stdlib_email_triage.rs
@@ -1,0 +1,72 @@
+mod common;
+
+use common::run_lua;
+
+#[tokio::test]
+async fn test_require_email_triage() {
+    let script = r#"
+        local mod = require("assay.email_triage")
+        assert.not_nil(mod)
+        assert.not_nil(mod.categorize)
+        assert.not_nil(mod.categorize_llm)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_categorize_needs_action() {
+    let script = r#"
+        local triage = require("assay.email_triage")
+        local result = triage.categorize({
+            { from = "ceo@example.com", subject = "Action required: budget sign-off" },
+            { from = "pm@example.com", subject = "URGENT deadline changed" },
+        })
+        assert.eq(#result.needs_action, 2)
+        assert.eq(#result.needs_reply, 0)
+        assert.eq(#result.fyi, 0)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_categorize_needs_reply() {
+    let script = r#"
+        local triage = require("assay.email_triage")
+        local result = triage.categorize({
+            { from = "alice@example.com", subject = "Can we meet tomorrow?" },
+            { from = "bob@example.com", subject = "Question about rollout" },
+        })
+        assert.eq(#result.needs_reply, 2)
+        assert.eq(result.needs_reply[1].from, "alice@example.com")
+        assert.eq(#result.needs_action, 0)
+        assert.eq(#result.fyi, 0)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_categorize_fyi() {
+    let script = r#"
+        local triage = require("assay.email_triage")
+        local result = triage.categorize({
+            { from = "noreply@example.com", subject = "Your weekly report" },
+            { from = "alerts@example.com", subject = "Automated deployment notice", automated = true },
+        })
+        assert.eq(#result.fyi, 2)
+        assert.eq(#result.needs_reply, 0)
+        assert.eq(#result.needs_action, 0)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_categorize_empty() {
+    let script = r#"
+        local triage = require("assay.email_triage")
+        local result = triage.categorize({})
+        assert.eq(#result.needs_reply, 0)
+        assert.eq(#result.needs_action, 0)
+        assert.eq(#result.fyi, 0)
+    "#;
+    run_lua(script).await.unwrap();
+}

--- a/tests/stdlib_gcal.rs
+++ b/tests/stdlib_gcal.rs
@@ -1,0 +1,324 @@
+mod common;
+
+use common::run_lua;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[tokio::test]
+async fn test_require_gcal() {
+    let script = r#"
+        local mod = require("assay.gcal")
+        assert.not_nil(mod)
+        assert.not_nil(mod.client)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_gcal_events() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/calendar/v3/calendars/primary/events"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "kind": "calendar#events",
+            "items": [
+                {
+                    "id": "evt-1",
+                    "summary": "Team standup",
+                    "start": { "dateTime": "2026-04-05T09:00:00Z" },
+                    "end": { "dateTime": "2026-04-05T09:30:00Z" }
+                },
+                {
+                    "id": "evt-2",
+                    "summary": "Lunch",
+                    "start": { "dateTime": "2026-04-05T12:00:00Z" },
+                    "end": { "dateTime": "2026-04-05T13:00:00Z" }
+                }
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local gcal = require("assay.gcal")
+        local tmpdir = fs.tempdir()
+        fs.write(tmpdir .. "/creds.json", json.encode({{
+            client_id = "id", client_secret = "secret",
+        }}))
+        fs.write(tmpdir .. "/token.json", json.encode({{
+            access_token = "tok", refresh_token = "ref",
+        }}))
+        local c = gcal.client({{
+            credentials_file = tmpdir .. "/creds.json",
+            token_file = tmpdir .. "/token.json",
+            api_base = "{}",
+        }})
+        local events = c:events()
+        assert.eq(#events, 2)
+        assert.eq(events[1].id, "evt-1")
+        assert.eq(events[1].summary, "Team standup")
+        assert.eq(events[2].summary, "Lunch")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_gcal_event_create() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/calendar/v3/calendars/primary/events"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "new-evt",
+            "summary": "New Meeting",
+            "status": "confirmed",
+            "start": { "dateTime": "2026-04-06T10:00:00Z" },
+            "end": { "dateTime": "2026-04-06T11:00:00Z" }
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local gcal = require("assay.gcal")
+        local tmpdir = fs.tempdir()
+        fs.write(tmpdir .. "/creds.json", json.encode({{
+            client_id = "id", client_secret = "secret",
+        }}))
+        fs.write(tmpdir .. "/token.json", json.encode({{
+            access_token = "tok", refresh_token = "ref",
+        }}))
+        local c = gcal.client({{
+            credentials_file = tmpdir .. "/creds.json",
+            token_file = tmpdir .. "/token.json",
+            api_base = "{}",
+        }})
+        local evt = c:event_create({{
+            summary = "New Meeting",
+            start = {{ dateTime = "2026-04-06T10:00:00Z" }},
+            ["end"] = {{ dateTime = "2026-04-06T11:00:00Z" }},
+        }})
+        assert.eq(evt.id, "new-evt")
+        assert.eq(evt.summary, "New Meeting")
+        assert.eq(evt.status, "confirmed")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_gcal_event_get() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/calendar/v3/calendars/primary/events/evt-123"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "evt-123",
+            "summary": "Sprint Planning",
+            "description": "Q2 planning session",
+            "status": "confirmed",
+            "start": { "dateTime": "2026-04-07T14:00:00Z" },
+            "end": { "dateTime": "2026-04-07T15:00:00Z" },
+            "attendees": [
+                { "email": "alice@example.com", "responseStatus": "accepted" }
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local gcal = require("assay.gcal")
+        local tmpdir = fs.tempdir()
+        fs.write(tmpdir .. "/creds.json", json.encode({{
+            client_id = "id", client_secret = "secret",
+        }}))
+        fs.write(tmpdir .. "/token.json", json.encode({{
+            access_token = "tok", refresh_token = "ref",
+        }}))
+        local c = gcal.client({{
+            credentials_file = tmpdir .. "/creds.json",
+            token_file = tmpdir .. "/token.json",
+            api_base = "{}",
+        }})
+        local evt = c:event_get("evt-123")
+        assert.eq(evt.id, "evt-123")
+        assert.eq(evt.summary, "Sprint Planning")
+        assert.eq(evt.description, "Q2 planning session")
+        assert.eq(#evt.attendees, 1)
+        assert.eq(evt.attendees[1].email, "alice@example.com")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_gcal_event_update() {
+    let server = MockServer::start().await;
+    Mock::given(method("PUT"))
+        .and(path("/calendar/v3/calendars/primary/events/evt-123"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "evt-123",
+            "summary": "Updated Planning",
+            "status": "confirmed"
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local gcal = require("assay.gcal")
+        local tmpdir = fs.tempdir()
+        fs.write(tmpdir .. "/creds.json", json.encode({{
+            client_id = "id", client_secret = "secret",
+        }}))
+        fs.write(tmpdir .. "/token.json", json.encode({{
+            access_token = "tok", refresh_token = "ref",
+        }}))
+        local c = gcal.client({{
+            credentials_file = tmpdir .. "/creds.json",
+            token_file = tmpdir .. "/token.json",
+            api_base = "{}",
+        }})
+        local evt = c:event_update("evt-123", {{ summary = "Updated Planning" }})
+        assert.eq(evt.id, "evt-123")
+        assert.eq(evt.summary, "Updated Planning")
+        assert.eq(evt.status, "confirmed")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_gcal_calendars() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/calendar/v3/users/me/calendarList"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "kind": "calendar#calendarList",
+            "items": [
+                { "id": "primary", "summary": "My Calendar", "primary": true },
+                { "id": "holidays", "summary": "UK Holidays", "primary": false }
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local gcal = require("assay.gcal")
+        local tmpdir = fs.tempdir()
+        fs.write(tmpdir .. "/creds.json", json.encode({{
+            client_id = "id", client_secret = "secret",
+        }}))
+        fs.write(tmpdir .. "/token.json", json.encode({{
+            access_token = "tok", refresh_token = "ref",
+        }}))
+        local c = gcal.client({{
+            credentials_file = tmpdir .. "/creds.json",
+            token_file = tmpdir .. "/token.json",
+            api_base = "{}",
+        }})
+        local cals = c:calendars()
+        assert.eq(#cals, 2)
+        assert.eq(cals[1].summary, "My Calendar")
+        assert.eq(cals[1].primary, true)
+        assert.eq(cals[2].summary, "UK Holidays")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_gcal_event_delete() {
+    let server = MockServer::start().await;
+    Mock::given(method("DELETE"))
+        .and(path("/calendar/v3/calendars/primary/events/evt-del"))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local gcal = require("assay.gcal")
+        local tmpdir = fs.tempdir()
+        fs.write(tmpdir .. "/creds.json", json.encode({{
+            client_id = "id", client_secret = "secret",
+        }}))
+        fs.write(tmpdir .. "/token.json", json.encode({{
+            access_token = "tok", refresh_token = "ref",
+        }}))
+        local c = gcal.client({{
+            credentials_file = tmpdir .. "/creds.json",
+            token_file = tmpdir .. "/token.json",
+            api_base = "{}",
+        }})
+        local result = c:event_delete("evt-del")
+        assert.eq(result, true)
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_gcal_token_refresh_on_401() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/calendar/v3/users/me/calendarList"))
+        .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+            "error": { "code": 401, "message": "Invalid Credentials" }
+        })))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "access_token": "new-access-token"
+        })))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/calendar/v3/users/me/calendarList"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "items": [
+                { "id": "primary", "summary": "My Calendar", "primary": true }
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local gcal = require("assay.gcal")
+        local tmpdir = fs.tempdir()
+        fs.write(tmpdir .. "/creds.json", json.encode({{
+            client_id = "id", client_secret = "secret",
+        }}))
+        fs.write(tmpdir .. "/token.json", json.encode({{
+            access_token = "expired-token", refresh_token = "refresh-tok",
+        }}))
+        local c = gcal.client({{
+            credentials_file = tmpdir .. "/creds.json",
+            token_file = tmpdir .. "/token.json",
+            api_base = "{}",
+            token_url = "{}/token",
+        }})
+        local cals = c:calendars()
+        assert.eq(#cals, 1)
+        assert.eq(cals[1].summary, "My Calendar")
+        "#,
+        server.uri(),
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}

--- a/tests/stdlib_github.rs
+++ b/tests/stdlib_github.rs
@@ -1,0 +1,378 @@
+mod common;
+
+use common::run_lua;
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[tokio::test]
+async fn test_require_github() {
+    let script = r#"
+        local mod = require("assay.github")
+        assert.not_nil(mod)
+        assert.not_nil(mod.client)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_github_pr_view() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/repos/octocat/hello-world/pulls/42"))
+        .and(header("Authorization", "Bearer ghp_test123"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "number": 42,
+            "title": "Fix bug",
+            "state": "open",
+            "user": { "login": "octocat" },
+            "mergeable": true
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local github = require("assay.github")
+        local c = github.client({{ token = "ghp_test123", base_url = "{}" }})
+        local pr = c:pr_view("octocat/hello-world", 42)
+        assert.eq(pr.number, 42)
+        assert.eq(pr.title, "Fix bug")
+        assert.eq(pr.state, "open")
+        assert.eq(pr.user.login, "octocat")
+        assert.eq(pr.mergeable, true)
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_github_pr_list() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/repos/octocat/hello-world/pulls"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+            { "number": 1, "title": "First PR", "state": "open" },
+            { "number": 2, "title": "Second PR", "state": "closed" }
+        ])))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local github = require("assay.github")
+        local c = github.client({{ base_url = "{}" }})
+        local prs = c:pr_list("octocat/hello-world")
+        assert.eq(#prs, 2)
+        assert.eq(prs[1].number, 1)
+        assert.eq(prs[1].title, "First PR")
+        assert.eq(prs[2].state, "closed")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_github_pr_reviews() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/repos/octocat/hello-world/pulls/42/reviews"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+            { "id": 1, "state": "APPROVED", "user": { "login": "alice" } },
+            { "id": 2, "state": "COMMENTED", "user": { "login": "bob" } }
+        ])))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local github = require("assay.github")
+        local c = github.client({{ base_url = "{}" }})
+        local reviews = c:pr_reviews("octocat/hello-world", 42)
+        assert.eq(#reviews, 2)
+        assert.eq(reviews[1].state, "APPROVED")
+        assert.eq(reviews[2].user.login, "bob")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_github_pr_merge() {
+    let server = MockServer::start().await;
+    Mock::given(method("PUT"))
+        .and(path("/repos/octocat/hello-world/pulls/42/merge"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "merged": true,
+            "sha": "abc123"
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local github = require("assay.github")
+        local c = github.client({{ token = "ghp_test", base_url = "{}" }})
+        local result = c:pr_merge("octocat/hello-world", 42, {{ merge_method = "squash" }})
+        assert.eq(result.merged, true)
+        assert.eq(result.sha, "abc123")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_github_issue_list() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/repos/octocat/hello-world/issues"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+            { "number": 10, "title": "Bug report", "state": "open", "labels": [{"name": "bug"}] },
+            { "number": 11, "title": "Feature request", "state": "open", "labels": [{"name": "enhancement"}] }
+        ])))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local github = require("assay.github")
+        local c = github.client({{ base_url = "{}" }})
+        local issues = c:issue_list("octocat/hello-world")
+        assert.eq(#issues, 2)
+        assert.eq(issues[1].number, 10)
+        assert.eq(issues[1].title, "Bug report")
+        assert.eq(issues[1].labels[1].name, "bug")
+        assert.eq(issues[2].title, "Feature request")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_github_issue_get() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/repos/octocat/hello-world/issues/10"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "number": 10,
+            "title": "Bug report",
+            "state": "open",
+            "user": { "login": "reporter" }
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local github = require("assay.github")
+        local c = github.client({{ base_url = "{}" }})
+        local issue = c:issue_get("octocat/hello-world", 10)
+        assert.eq(issue.number, 10)
+        assert.eq(issue.title, "Bug report")
+        assert.eq(issue.user.login, "reporter")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_github_issue_create() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/repos/octocat/hello-world/issues"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+            "number": 42,
+            "title": "New issue",
+            "body": "Description here",
+            "state": "open",
+            "html_url": "https://github.com/octocat/hello-world/issues/42"
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local github = require("assay.github")
+        local c = github.client({{ token = "ghp_test", base_url = "{}" }})
+        local issue = c:issue_create("octocat/hello-world", "New issue", "Description here", {{
+            labels = {{"bug", "urgent"}},
+        }})
+        assert.eq(issue.number, 42)
+        assert.eq(issue.title, "New issue")
+        assert.eq(issue.state, "open")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_github_issue_comment() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/repos/octocat/hello-world/issues/10/comments"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+            "id": 500,
+            "body": "Looking into this now"
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local github = require("assay.github")
+        local c = github.client({{ token = "ghp_test", base_url = "{}" }})
+        local comment = c:issue_comment("octocat/hello-world", 10, "Looking into this now")
+        assert.eq(comment.id, 500)
+        assert.eq(comment.body, "Looking into this now")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_github_graphql() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/graphql"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "data": {
+                "repository": {
+                    "name": "hello-world",
+                    "stargazerCount": 100
+                }
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local github = require("assay.github")
+        local c = github.client({{ token = "ghp_test", base_url = "{}" }})
+        local result = c:graphql("query {{ repository(owner: \"octocat\", name: \"hello-world\") {{ name stargazerCount }} }}")
+        assert.eq(result.data.repository.name, "hello-world")
+        assert.eq(result.data.repository.stargazerCount, 100)
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_github_repo_get() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/repos/octocat/hello-world"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "full_name": "octocat/hello-world",
+            "description": "My first repository",
+            "stargazers_count": 80,
+            "language": "Lua",
+            "default_branch": "main"
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local github = require("assay.github")
+        local c = github.client({{ base_url = "{}" }})
+        local repo = c:repo_get("octocat/hello-world")
+        assert.eq(repo.full_name, "octocat/hello-world")
+        assert.eq(repo.stargazers_count, 80)
+        assert.eq(repo.language, "Lua")
+        assert.eq(repo.default_branch, "main")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_github_runs_list() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/repos/octocat/hello-world/actions/runs"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "total_count": 2,
+            "workflow_runs": [
+                { "id": 100, "name": "CI", "status": "completed", "conclusion": "success" },
+                { "id": 101, "name": "CI", "status": "in_progress", "conclusion": null }
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local github = require("assay.github")
+        local c = github.client({{ base_url = "{}" }})
+        local result = c:runs_list("octocat/hello-world")
+        assert.eq(result.total_count, 2)
+        assert.eq(#result.workflow_runs, 2)
+        assert.eq(result.workflow_runs[1].id, 100)
+        assert.eq(result.workflow_runs[1].conclusion, "success")
+        assert.eq(result.workflow_runs[2].status, "in_progress")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_github_run_get() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/repos/octocat/hello-world/actions/runs/100"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": 100,
+            "name": "CI",
+            "status": "completed",
+            "conclusion": "success"
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local github = require("assay.github")
+        local c = github.client({{ base_url = "{}" }})
+        local run = c:run_get("octocat/hello-world", 100)
+        assert.eq(run.id, 100)
+        assert.eq(run.status, "completed")
+        assert.eq(run.conclusion, "success")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_github_pr_404_returns_nil() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/repos/octocat/hello-world/pulls/999"))
+        .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+            "message": "Not Found"
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local github = require("assay.github")
+        local c = github.client({{ base_url = "{}" }})
+        local pr = c:pr_view("octocat/hello-world", 999)
+        assert.eq(pr, nil)
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}

--- a/tests/stdlib_gmail.rs
+++ b/tests/stdlib_gmail.rs
@@ -1,0 +1,334 @@
+mod common;
+
+use common::run_lua;
+use wiremock::matchers::{method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[tokio::test]
+async fn test_require_gmail() {
+    let script = r#"
+        local mod = require("assay.gmail")
+        assert.not_nil(mod)
+        assert.not_nil(mod.client)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_gmail_search() {
+    let server = MockServer::start().await;
+
+    // Mock the message list endpoint
+    Mock::given(method("GET"))
+        .and(path("/gmail/v1/users/me/messages"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "messages": [
+                { "id": "msg-1", "threadId": "thread-1" },
+                { "id": "msg-2", "threadId": "thread-2" }
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    // Mock individual message fetches
+    Mock::given(method("GET"))
+        .and(path("/gmail/v1/users/me/messages/msg-1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "msg-1",
+            "threadId": "thread-1",
+            "snippet": "Hello from test",
+            "payload": {
+                "headers": [
+                    { "name": "From", "value": "alice@example.com" },
+                    { "name": "Subject", "value": "Test email 1" }
+                ]
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/gmail/v1/users/me/messages/msg-2"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "msg-2",
+            "threadId": "thread-2",
+            "snippet": "Another test",
+            "payload": {
+                "headers": [
+                    { "name": "From", "value": "bob@example.com" },
+                    { "name": "Subject", "value": "Test email 2" }
+                ]
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local gmail = require("assay.gmail")
+        local tmpdir = fs.tempdir()
+
+        -- Write mock credentials
+        fs.write(tmpdir .. "/creds.json", json.encode({{
+            client_id = "test-id",
+            client_secret = "test-secret",
+        }}))
+        fs.write(tmpdir .. "/token.json", json.encode({{
+            access_token = "valid-token",
+            refresh_token = "refresh-tok",
+        }}))
+
+        local c = gmail.client({{
+            credentials_file = tmpdir .. "/creds.json",
+            token_file = tmpdir .. "/token.json",
+            api_base = "{}",
+        }})
+        local messages = c:search("from:alice")
+        assert.eq(#messages, 2)
+        assert.eq(messages[1].id, "msg-1")
+        assert.eq(messages[1].snippet, "Hello from test")
+        assert.eq(messages[2].id, "msg-2")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_gmail_get() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/gmail/v1/users/me/messages/msg-abc"))
+        .and(query_param("format", "full"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "msg-abc",
+            "threadId": "thread-1",
+            "snippet": "Important message",
+            "payload": {
+                "mimeType": "text/plain",
+                "body": { "data": "SGVsbG8gV29ybGQ=" },
+                "headers": [
+                    { "name": "Subject", "value": "Important" }
+                ]
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local gmail = require("assay.gmail")
+        local tmpdir = fs.tempdir()
+        fs.write(tmpdir .. "/creds.json", json.encode({{
+            client_id = "id", client_secret = "secret",
+        }}))
+        fs.write(tmpdir .. "/token.json", json.encode({{
+            access_token = "tok", refresh_token = "ref",
+        }}))
+        local c = gmail.client({{
+            credentials_file = tmpdir .. "/creds.json",
+            token_file = tmpdir .. "/token.json",
+            api_base = "{}",
+        }})
+        local msg = c:get("msg-abc")
+        assert.eq(msg.id, "msg-abc")
+        assert.eq(msg.snippet, "Important message")
+        assert.eq(msg.payload.mimeType, "text/plain")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_gmail_send() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/gmail/v1/users/me/messages/send"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "sent-msg-1",
+            "threadId": "new-thread",
+            "labelIds": ["SENT"]
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local gmail = require("assay.gmail")
+        local tmpdir = fs.tempdir()
+        fs.write(tmpdir .. "/creds.json", json.encode({{
+            client_id = "id", client_secret = "secret",
+        }}))
+        fs.write(tmpdir .. "/token.json", json.encode({{
+            access_token = "tok", refresh_token = "ref",
+        }}))
+        local c = gmail.client({{
+            credentials_file = tmpdir .. "/creds.json",
+            token_file = tmpdir .. "/token.json",
+            api_base = "{}",
+        }})
+        local result = c:send("user@example.com", "Test Subject", "Hello there!")
+        assert.eq(result.id, "sent-msg-1")
+        assert.eq(result.labelIds[1], "SENT")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_gmail_reply() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/gmail/v1/users/me/messages/msg-1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "msg-1",
+            "threadId": "thread-1",
+            "payload": {
+                "headers": [
+                    { "name": "From", "value": "alice@example.com" },
+                    { "name": "Subject", "value": "Status update" },
+                    { "name": "Message-Id", "value": "<msg-1@example.com>" }
+                ]
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/gmail/v1/users/me/messages/send"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "reply-1",
+            "threadId": "thread-1"
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local gmail = require("assay.gmail")
+        local tmpdir = fs.tempdir()
+        fs.write(tmpdir .. "/creds.json", json.encode({{
+            client_id = "id", client_secret = "secret",
+        }}))
+        fs.write(tmpdir .. "/token.json", json.encode({{
+            access_token = "tok", refresh_token = "ref",
+        }}))
+        local c = gmail.client({{
+            credentials_file = tmpdir .. "/creds.json",
+            token_file = tmpdir .. "/token.json",
+            api_base = "{}",
+        }})
+        local result = c:reply("msg-1", {{ body = "Thanks!" }})
+        assert.eq(result.id, "reply-1")
+        assert.eq(result.threadId, "thread-1")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_gmail_labels() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/gmail/v1/users/me/labels"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "labels": [
+                { "id": "INBOX", "name": "INBOX", "type": "system" },
+                { "id": "SENT", "name": "SENT", "type": "system" },
+                { "id": "Label_1", "name": "Work", "type": "user" }
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local gmail = require("assay.gmail")
+        local tmpdir = fs.tempdir()
+        fs.write(tmpdir .. "/creds.json", json.encode({{
+            client_id = "id", client_secret = "secret",
+        }}))
+        fs.write(tmpdir .. "/token.json", json.encode({{
+            access_token = "tok", refresh_token = "ref",
+        }}))
+        local c = gmail.client({{
+            credentials_file = tmpdir .. "/creds.json",
+            token_file = tmpdir .. "/token.json",
+            api_base = "{}",
+        }})
+        local labels = c:labels()
+        assert.eq(#labels, 3)
+        assert.eq(labels[1].name, "INBOX")
+        assert.eq(labels[3].name, "Work")
+        assert.eq(labels[3].type, "user")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_gmail_token_refresh() {
+    let server = MockServer::start().await;
+
+    // First call returns 401
+    Mock::given(method("GET"))
+        .and(path("/gmail/v1/users/me/labels"))
+        .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+            "error": { "code": 401, "message": "Invalid Credentials" }
+        })))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+
+    // Token refresh endpoint
+    Mock::given(method("POST"))
+        .and(path("/token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "access_token": "new-access-token",
+            "token_type": "Bearer",
+            "expires_in": 3600
+        })))
+        .mount(&server)
+        .await;
+
+    // Second call with new token succeeds
+    Mock::given(method("GET"))
+        .and(path("/gmail/v1/users/me/labels"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "labels": [
+                { "id": "INBOX", "name": "INBOX", "type": "system" }
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local gmail = require("assay.gmail")
+        local tmpdir = fs.tempdir()
+        fs.write(tmpdir .. "/creds.json", json.encode({{
+            client_id = "id", client_secret = "secret",
+        }}))
+        fs.write(tmpdir .. "/token.json", json.encode({{
+            access_token = "expired-token", refresh_token = "refresh-tok",
+        }}))
+        local c = gmail.client({{
+            credentials_file = tmpdir .. "/creds.json",
+            token_file = tmpdir .. "/token.json",
+            api_base = "{}",
+            token_url = "{}/token",
+        }})
+        local labels = c:labels()
+        assert.eq(#labels, 1)
+        assert.eq(labels[1].name, "INBOX")
+        "#,
+        server.uri(),
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}

--- a/tests/stdlib_oauth2.rs
+++ b/tests/stdlib_oauth2.rs
@@ -1,0 +1,163 @@
+mod common;
+
+use common::run_lua;
+use wiremock::matchers::{body_json, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[tokio::test]
+async fn test_require_oauth2() {
+    let script = r#"
+        local mod = require("assay.oauth2")
+        assert.not_nil(mod)
+        assert.not_nil(mod.from_file)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_oauth2_from_file() {
+    let script = r#"
+        local oauth2 = require("assay.oauth2")
+        local tmpdir = fs.tempdir()
+        fs.write(tmpdir .. "/credentials.json", json.encode({
+            installed = {
+                client_id = "test-client",
+                client_secret = "test-secret",
+            }
+        }))
+        fs.write(tmpdir .. "/token.json", json.encode({
+            access_token = "token-123",
+            refresh_token = "refresh-123",
+        }))
+
+        local client = oauth2.from_file(tmpdir .. "/credentials.json", tmpdir .. "/token.json")
+        assert.eq(client._credentials.client_id, "test-client")
+        assert.eq(client._token_data.refresh_token, "refresh-123")
+        assert.eq(client._token_file, tmpdir .. "/token.json")
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_oauth2_access_token() {
+    let script = r#"
+        local oauth2 = require("assay.oauth2")
+        local tmpdir = fs.tempdir()
+        fs.write(tmpdir .. "/credentials.json", json.encode({
+            client_id = "test-client",
+            client_secret = "test-secret",
+        }))
+        fs.write(tmpdir .. "/token.json", json.encode({
+            access_token = "token-abc",
+            refresh_token = "refresh-abc",
+        }))
+
+        local client = oauth2.from_file(tmpdir .. "/credentials.json", tmpdir .. "/token.json")
+        assert.eq(client:access_token(), "token-abc")
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_oauth2_refresh() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/token"))
+        .and(body_json(serde_json::json!({
+            "grant_type": "refresh_token",
+            "refresh_token": "refresh-xyz",
+            "client_id": "test-client",
+            "client_secret": "test-secret"
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "access_token": "fresh-token",
+            "refresh_token": "refresh-next"
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local oauth2 = require("assay.oauth2")
+        local tmpdir = fs.tempdir()
+        fs.write(tmpdir .. "/credentials.json", json.encode({{
+            client_id = "test-client",
+            client_secret = "test-secret",
+        }}))
+        fs.write(tmpdir .. "/token.json", json.encode({{
+            access_token = "stale-token",
+            refresh_token = "refresh-xyz",
+        }}))
+
+        local client = oauth2.from_file(tmpdir .. "/credentials.json", tmpdir .. "/token.json", {{
+            token_url = "{}/token",
+        }})
+        local refreshed = client:refresh()
+        assert.eq(refreshed, "fresh-token")
+        assert.eq(client:access_token(), "fresh-token")
+        assert.eq(client._token_data.refresh_token, "refresh-next")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_oauth2_refresh_401() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/token"))
+        .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+            "error": "invalid_grant"
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local oauth2 = require("assay.oauth2")
+        local tmpdir = fs.tempdir()
+        fs.write(tmpdir .. "/credentials.json", json.encode({{
+            client_id = "test-client",
+            client_secret = "test-secret",
+        }}))
+        fs.write(tmpdir .. "/token.json", json.encode({{
+            access_token = "stale-token",
+            refresh_token = "refresh-xyz",
+        }}))
+
+        local client = oauth2.from_file(tmpdir .. "/credentials.json", tmpdir .. "/token.json", {{
+            token_url = "{}/token",
+        }})
+        local ok, err = pcall(function()
+            client:refresh()
+        end)
+        assert.eq(ok, false)
+        assert.contains(err, "oauth2: token refresh failed HTTP 401")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_oauth2_headers() {
+    let script = r#"
+        local oauth2 = require("assay.oauth2")
+        local tmpdir = fs.tempdir()
+        fs.write(tmpdir .. "/credentials.json", json.encode({
+            client_id = "test-client",
+            client_secret = "test-secret",
+        }))
+        fs.write(tmpdir .. "/token.json", json.encode({
+            access_token = "header-token",
+            refresh_token = "refresh-abc",
+        }))
+
+        local client = oauth2.from_file(tmpdir .. "/credentials.json", tmpdir .. "/token.json")
+        local headers = client:headers()
+        assert.eq(headers["Authorization"], "Bearer header-token")
+        assert.eq(headers["Content-Type"], "application/json")
+    "#;
+    run_lua(script).await.unwrap();
+}

--- a/tests/stdlib_openclaw.rs
+++ b/tests/stdlib_openclaw.rs
@@ -1,0 +1,297 @@
+mod common;
+
+use common::run_lua;
+use wiremock::matchers::{body_json, header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[tokio::test]
+async fn test_require_openclaw() {
+    let script = r#"
+        local mod = require("assay.openclaw")
+        assert.not_nil(mod)
+        assert.not_nil(mod.client)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_openclaw_invoke() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/tools/invoke"))
+        .and(header("Authorization", "Bearer test-token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "result": "ok",
+            "output": "tool executed"
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local openclaw = require("assay.openclaw")
+        local c = openclaw.client("{}", {{ token = "test-token" }})
+        local result = c:invoke("mytool", "run", {{ key = "value" }})
+        assert.eq(result.result, "ok")
+        assert.eq(result.output, "tool executed")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_openclaw_send() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/tools/invoke"))
+        .and(body_json(serde_json::json!({
+            "tool": "message",
+            "action": "send",
+            "args": {
+                "channel": "slack",
+                "target": "#alerts",
+                "message": "hello world"
+            }
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "sent": true
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r##"
+        local openclaw = require("assay.openclaw")
+        local c = openclaw.client("{}", {{ token = "t" }})
+        local result = c:send("slack", "#alerts", "hello world")
+        assert.eq(result.sent, true)
+        "##,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_openclaw_notify() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/tools/invoke"))
+        .and(body_json(serde_json::json!({
+            "tool": "message",
+            "action": "send",
+            "args": {
+                "target": "ops",
+                "message": "deploy finished"
+            }
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "queued": true
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local openclaw = require("assay.openclaw")
+        local c = openclaw.client("{}", {{ token = "t" }})
+        local result = c:notify("ops", "deploy finished")
+        assert.eq(result.queued, true)
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_openclaw_state_get_set() {
+    let script = r#"
+        local openclaw = require("assay.openclaw")
+        local tmpdir = fs.tempdir()
+        local c = openclaw.client("http://localhost:1", { token = "t", state_dir = tmpdir })
+
+        -- state_get returns nil for missing key
+        local val = c:state_get("nonexistent")
+        assert.eq(val, nil)
+
+        -- state_set and state_get round-trip
+        c:state_set("mykey", { count = 42, name = "test" })
+        local got = c:state_get("mykey")
+        assert.eq(got.count, 42)
+        assert.eq(got.name, "test")
+
+        -- overwrite
+        c:state_set("mykey", { count = 99 })
+        local got2 = c:state_get("mykey")
+        assert.eq(got2.count, 99)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_openclaw_diff() {
+    let script = r#"
+        local openclaw = require("assay.openclaw")
+        local tmpdir = fs.tempdir()
+        local c = openclaw.client("http://localhost:1", { token = "t", state_dir = tmpdir })
+
+        -- First diff: before is nil, after is new value
+        local d = c:diff("counter", { value = 1 })
+        assert.eq(d.changed, true)
+        assert.eq(d.before, nil)
+        assert.eq(d.after.value, 1)
+
+        -- Same value: no change
+        local d2 = c:diff("counter", { value = 1 })
+        assert.eq(d2.changed, false)
+        assert.eq(d2.before.value, 1)
+        assert.eq(d2.after.value, 1)
+
+        -- Different value: changed
+        local d3 = c:diff("counter", { value = 2 })
+        assert.eq(d3.changed, true)
+        assert.eq(d3.before.value, 1)
+        assert.eq(d3.after.value, 2)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_openclaw_llm_task() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/tools/invoke"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "response": "The answer is 42",
+            "model": "claude-sonnet"
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local openclaw = require("assay.openclaw")
+        local c = openclaw.client("{}", {{ token = "t" }})
+        local result = c:llm_task("What is the meaning of life?", {{
+            model = "claude-sonnet",
+            temperature = 0.5,
+        }})
+        assert.eq(result.response, "The answer is 42")
+        assert.eq(result.model, "claude-sonnet")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_openclaw_cron_add() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/tools/invoke"))
+        .and(body_json(serde_json::json!({
+            "tool": "cron",
+            "action": "add",
+            "args": {
+                "job": {
+                    "schedule": "0 * * * *",
+                    "task": "health-check"
+                }
+            }
+        })))
+        .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+            "id": "cron-1",
+            "created": true
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local openclaw = require("assay.openclaw")
+        local c = openclaw.client("{}", {{ token = "t" }})
+        local result = c:cron_add({{ schedule = "0 * * * *", task = "health-check" }})
+        assert.eq(result.id, "cron-1")
+        assert.eq(result.created, true)
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_openclaw_cron_list() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/tools/invoke"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "jobs": [
+                { "id": "job-1", "schedule": "0 * * * *", "task": "health-check" },
+                { "id": "job-2", "schedule": "0 0 * * *", "task": "daily-report" }
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local openclaw = require("assay.openclaw")
+        local c = openclaw.client("{}", {{ token = "t" }})
+        local result = c:cron_list()
+        assert.eq(#result.jobs, 2)
+        assert.eq(result.jobs[1].id, "job-1")
+        assert.eq(result.jobs[2].task, "daily-report")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_openclaw_spawn() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/tools/invoke"))
+        .and(body_json(serde_json::json!({
+            "tool": "sessions_spawn",
+            "action": "invoke",
+            "args": {
+                "task": "draft summary",
+                "model": "claude-sonnet",
+                "timeout": 30
+            }
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "session_id": "ses-123",
+            "status": "started"
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local openclaw = require("assay.openclaw")
+        local c = openclaw.client("{}", {{ token = "t" }})
+        local result = c:spawn("draft summary", {{ model = "claude-sonnet", timeout = 30 }})
+        assert.eq(result.session_id, "ses-123")
+        assert.eq(result.status, "started")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_openclaw_approve_noninteractive_errors() {
+    let script = r#"
+        local openclaw = require("assay.openclaw")
+        local c = openclaw.client("http://localhost:1", { token = "t" })
+        local ok, err = pcall(function()
+            c:approve("Deploy now?", { env = "prod" })
+        end)
+        assert.eq(ok, false)
+        assert.contains(err, "openclaw: approval_required:")
+        assert.contains(err, '"prompt":"Deploy now?"')
+    "#;
+    run_lua(script).await.unwrap();
+}

--- a/tests/stdlib_postgres.rs
+++ b/tests/stdlib_postgres.rs
@@ -17,54 +17,67 @@ async fn test_require_postgres() {
 
 #[tokio::test]
 async fn test_postgres_quote_ident_simple() {
-    let result: String = eval_lua(r#"
+    let result: String = eval_lua(
+        r#"
         local pg = require("assay.postgres")
         return pg._quote_ident("users")
-    "#).await;
+    "#,
+    )
+    .await;
     assert_eq!(result, "\"users\"");
 }
 
 #[tokio::test]
 async fn test_postgres_quote_ident_with_quotes() {
-    let result: String = eval_lua(r#"
+    let result: String = eval_lua(
+        r#"
         local pg = require("assay.postgres")
         return pg._quote_ident('my"table')
-    "#).await;
+    "#,
+    )
+    .await;
     assert_eq!(result, "\"my\"\"table\"");
 }
 
 #[tokio::test]
 async fn test_postgres_quote_literal_simple() {
-    let result: String = eval_lua(r#"
+    let result: String = eval_lua(
+        r#"
         local pg = require("assay.postgres")
         return pg._quote_literal("hello")
-    "#).await;
+    "#,
+    )
+    .await;
     assert_eq!(result, "'hello'");
 }
 
 #[tokio::test]
 async fn test_postgres_quote_literal_with_quotes() {
-    let result: String = eval_lua(r#"
+    let result: String = eval_lua(
+        r#"
         local pg = require("assay.postgres")
         return pg._quote_literal("it's")
-    "#).await;
+    "#,
+    )
+    .await;
     assert_eq!(result, "'it''s'");
 }
 
 #[tokio::test]
 async fn test_postgres_client_from_vault_missing_secret() {
-    use wiremock::{MockServer, Mock, ResponseTemplate};
     use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     let mock_server = MockServer::start().await;
-    
+
     Mock::given(method("GET"))
         .and(path("/v1/secrets/data/db/postgres"))
         .respond_with(ResponseTemplate::new(404))
         .mount(&mock_server)
         .await;
 
-    let script = format!(r#"
+    let script = format!(
+        r#"
         local vault = require("assay.vault")
         local pg = require("assay.postgres")
         
@@ -76,7 +89,9 @@ async fn test_postgres_client_from_vault_missing_secret() {
         
         assert.eq(ok, false, "client_from_vault should fail when secret is missing")
         assert.not_nil(err, "error message should be present")
-    "#, mock_server.uri());
-    
+    "#,
+        mock_server.uri()
+    );
+
     run_lua_local(&script).await.unwrap();
 }

--- a/tests/stdlib_unleash.rs
+++ b/tests/stdlib_unleash.rs
@@ -424,7 +424,9 @@ async fn test_unleash_archive_feature() {
 async fn test_unleash_toggle_on() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))
-        .and(path("/api/admin/projects/simons/features/dark-mode/environments/development/on"))
+        .and(path(
+            "/api/admin/projects/simons/features/dark-mode/environments/development/on",
+        ))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
         .mount(&server)
         .await;
@@ -444,7 +446,9 @@ async fn test_unleash_toggle_on() {
 async fn test_unleash_toggle_off() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))
-        .and(path("/api/admin/projects/simons/features/dark-mode/environments/production/off"))
+        .and(path(
+            "/api/admin/projects/simons/features/dark-mode/environments/production/off",
+        ))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
         .mount(&server)
         .await;
@@ -464,7 +468,9 @@ async fn test_unleash_toggle_off() {
 async fn test_unleash_strategies() {
     let server = MockServer::start().await;
     Mock::given(method("GET"))
-        .and(path("/api/admin/projects/simons/features/dark-mode/environments/development/strategies"))
+        .and(path(
+            "/api/admin/projects/simons/features/dark-mode/environments/development/strategies",
+        ))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
             {"id": "strategy-1", "name": "default", "parameters": {}},
             {"id": "strategy-2", "name": "userWithId", "parameters": {"userIds": "user1,user2"}}
@@ -490,7 +496,9 @@ async fn test_unleash_strategies() {
 async fn test_unleash_add_strategy() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))
-        .and(path("/api/admin/projects/simons/features/dark-mode/environments/development/strategies"))
+        .and(path(
+            "/api/admin/projects/simons/features/dark-mode/environments/development/strategies",
+        ))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
             "id": "strategy-3",
             "name": "flexibleRollout",
@@ -604,7 +612,9 @@ async fn test_unleash_wait_success() {
     let server = MockServer::start().await;
     Mock::given(method("GET"))
         .and(path("/health"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"health": "GOOD"})))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({"health": "GOOD"})),
+        )
         .mount(&server)
         .await;
 

--- a/tests/stdlib_vault.rs
+++ b/tests/stdlib_vault.rs
@@ -1078,7 +1078,9 @@ async fn test_vault_wait_success() {
     let server = MockServer::start().await;
     Mock::given(method("GET"))
         .and(path("/v1/sys/health"))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"initialized": true})))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({"initialized": true})),
+        )
         .mount(&server)
         .await;
 

--- a/tests/tool_mode.rs
+++ b/tests/tool_mode.rs
@@ -1,0 +1,418 @@
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+static SCRIPT_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn assay_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_assay"))
+}
+
+fn write_script(name: &str, content: &str) -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let seq = SCRIPT_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!("assay-tool-mode-{nonce}-{seq}"));
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join(name);
+    std::fs::write(&path, content).unwrap();
+    path
+}
+
+fn temp_dir(prefix: &str) -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let seq = SCRIPT_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!("{prefix}-{nonce}-{seq}"));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn run_tool_mode(script_path: &Path) -> std::process::Output {
+    Command::new(assay_binary())
+        .args(["run", "--mode", "tool", script_path.to_str().unwrap()])
+        .output()
+        .unwrap()
+}
+
+fn run_tool_mode_with_state_dir(script_path: &Path, state_dir: &Path) -> std::process::Output {
+    Command::new(assay_binary())
+        .args(["run", "--mode", "tool", script_path.to_str().unwrap()])
+        .env("ASSAY_STATE_DIR", state_dir)
+        .output()
+        .unwrap()
+}
+
+fn run_normal_mode(script_path: &Path) -> std::process::Output {
+    Command::new(assay_binary())
+        .args(["run", script_path.to_str().unwrap()])
+        .output()
+        .unwrap()
+}
+
+fn run_resume(token: &str, approve: &str, state_dir: &Path) -> std::process::Output {
+    Command::new(assay_binary())
+        .args(["resume", "--token", token, "--approve", approve])
+        .env("ASSAY_STATE_DIR", state_dir)
+        .output()
+        .unwrap()
+}
+
+fn approval_script() -> PathBuf {
+    write_script(
+        "approval.lua",
+        r#"
+        local oc = require("assay.openclaw")
+        local c = oc.client("http://localhost:1", { token = "t" })
+        local approved = c:approve("Deploy?", { env = "prod" })
+        if approved then
+          return { status = "deployed" }
+        else
+          return { status = "rejected" }
+        end
+        "#,
+    )
+}
+
+fn extract_resume_token(json: &Value) -> String {
+    json["requiresApproval"]["resumeToken"]
+        .as_str()
+        .unwrap()
+        .to_string()
+}
+
+fn resume_state_path(state_dir: &Path, token: &str) -> PathBuf {
+    state_dir.join("resume").join(format!("{token}.json"))
+}
+
+fn stdout_json(output: &std::process::Output) -> Value {
+    serde_json::from_slice(&output.stdout).unwrap()
+}
+
+#[test]
+fn test_tool_mode_success() {
+    let script = write_script(
+        "success.lua",
+        r#"return { message = "ok", values = {1, 2, 3} }"#,
+    );
+
+    let output = run_tool_mode(&script);
+    assert!(output.status.success());
+
+    let json = stdout_json(&output);
+    assert_eq!(json["ok"], Value::Bool(true));
+    assert_eq!(json["status"], Value::String("ok".into()));
+    assert_eq!(json["requiresApproval"], Value::Null);
+    assert_eq!(json["output"]["message"], Value::String("ok".into()));
+    assert_eq!(json["output"]["values"], serde_json::json!([1, 2, 3]));
+}
+
+#[test]
+fn test_tool_mode_error() {
+    let script = write_script("error.lua", r#"error("boom")"#);
+
+    let output = run_tool_mode(&script);
+    assert!(
+        output.status.success(),
+        "tool mode should exit zero on envelope"
+    );
+
+    let json = stdout_json(&output);
+    assert_eq!(json["ok"], Value::Bool(false));
+    assert_eq!(json["status"], Value::String("error".into()));
+    assert!(json["error"].as_str().unwrap().contains("boom"));
+}
+
+#[test]
+fn test_tool_mode_nil_return() {
+    let script = write_script("nil.lua", "local x = 1\n");
+
+    let output = run_tool_mode(&script);
+    assert!(output.status.success());
+
+    let json = stdout_json(&output);
+    assert_eq!(json["ok"], Value::Bool(true));
+    assert_eq!(json["output"], Value::Null);
+}
+
+#[test]
+fn test_tool_mode_string_return() {
+    let script = write_script("string.lua", r#"return "hello from tool mode""#);
+
+    let output = run_tool_mode(&script);
+    assert!(output.status.success());
+
+    let json = stdout_json(&output);
+    assert_eq!(json["output"], Value::String("hello from tool mode".into()));
+}
+
+#[test]
+fn test_tool_mode_env_var() {
+    let script = write_script("env.lua", "return { enabled = true }");
+
+    let output = Command::new(assay_binary())
+        .args(["run", script.to_str().unwrap()])
+        .env("ASSAY_MODE", "tool")
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    let json = stdout_json(&output);
+    assert_eq!(json["ok"], Value::Bool(true));
+    assert_eq!(json["output"]["enabled"], Value::Bool(true));
+}
+
+#[test]
+fn test_tool_mode_stderr_separation() {
+    let script = write_script(
+        "stderr.lua",
+        r#"
+        log.info("logged to stderr")
+        return { ok = true }
+        "#,
+    );
+
+    let output = run_tool_mode(&script);
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stdout.contains("\"output\""),
+        "stdout should contain only envelope: {stdout}"
+    );
+    assert!(
+        !stdout.contains("logged to stderr"),
+        "stdout should not contain logs: {stdout}"
+    );
+    assert!(
+        stderr.contains("logged to stderr"),
+        "stderr should contain logs: {stderr}"
+    );
+}
+
+#[test]
+fn test_tool_mode_timeout() {
+    let script = write_script("timeout.lua", "sleep(30)\n");
+
+    let output = Command::new(assay_binary())
+        .args([
+            "run",
+            "--mode",
+            "tool",
+            "--timeout",
+            "2",
+            script.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "timeout envelope should still exit zero"
+    );
+
+    let json = stdout_json(&output);
+    assert_eq!(json["ok"], Value::Bool(false));
+    assert_eq!(json["status"], Value::String("timeout".into()));
+    assert_eq!(
+        json["error"],
+        Value::String("execution timed out after 2s".into())
+    );
+}
+
+#[test]
+fn test_tool_mode_truncates_large_output() {
+    let payload = "a".repeat(600_000);
+    let script = write_script("truncate.lua", &format!(r#"return "{payload}""#));
+
+    let output = run_tool_mode(&script);
+    assert!(output.status.success());
+    assert!(
+        output.stdout.len() <= 524_288,
+        "stdout should stay under cap"
+    );
+
+    let json = stdout_json(&output);
+    assert_eq!(json["ok"], Value::Bool(true));
+    assert_eq!(json["truncated"], Value::Bool(true));
+    assert!(json["output"].as_str().unwrap().len() < payload.len());
+}
+
+#[test]
+fn test_tool_mode_approval_halt() {
+    let state_dir = temp_dir("assay-resume-state");
+    let script = approval_script();
+
+    let output = run_tool_mode_with_state_dir(&script, &state_dir);
+    assert!(output.status.success());
+
+    let json = stdout_json(&output);
+    assert_eq!(json["ok"], Value::Bool(true));
+    assert_eq!(json["status"], Value::String("needs_approval".into()));
+    assert_eq!(json["output"], Value::Null);
+    assert_eq!(
+        json["requiresApproval"]["prompt"],
+        Value::String("Deploy?".into())
+    );
+    assert_eq!(
+        json["requiresApproval"]["context"],
+        serde_json::json!({ "env": "prod" })
+    );
+
+    let token = extract_resume_token(&json);
+    assert_eq!(token.len(), 32);
+    assert!(token.chars().all(|ch| ch.is_ascii_hexdigit()));
+    assert!(resume_state_path(&state_dir, &token).exists());
+}
+
+#[test]
+fn test_resume_approve_yes() {
+    let state_dir = temp_dir("assay-resume-state");
+    let script = approval_script();
+
+    let first = run_tool_mode_with_state_dir(&script, &state_dir);
+    assert!(first.status.success());
+    let first_json = stdout_json(&first);
+    let token = extract_resume_token(&first_json);
+
+    let resumed = run_resume(&token, "yes", &state_dir);
+    assert!(resumed.status.success());
+
+    let json = stdout_json(&resumed);
+    assert_eq!(json["ok"], Value::Bool(true));
+    assert_eq!(json["status"], Value::String("ok".into()));
+    assert_eq!(json["output"]["status"], Value::String("deployed".into()));
+}
+
+#[test]
+fn test_resume_approve_no() {
+    let state_dir = temp_dir("assay-resume-state");
+    let script = approval_script();
+
+    let first = run_tool_mode_with_state_dir(&script, &state_dir);
+    assert!(first.status.success());
+    let first_json = stdout_json(&first);
+    let token = extract_resume_token(&first_json);
+
+    let resumed = run_resume(&token, "no", &state_dir);
+    assert!(resumed.status.success());
+
+    let json = stdout_json(&resumed);
+    assert_eq!(json["ok"], Value::Bool(true));
+    assert_eq!(json["status"], Value::String("ok".into()));
+    assert_eq!(json["output"]["status"], Value::String("rejected".into()));
+}
+
+#[test]
+fn test_resume_expired_token() {
+    let state_dir = temp_dir("assay-resume-state");
+    let script = approval_script();
+    let token = "expiredtokenexpiredtokenexpired12";
+    let resume_dir = state_dir.join("resume");
+    std::fs::create_dir_all(&resume_dir).unwrap();
+    std::fs::write(
+        resume_state_path(&state_dir, token),
+        serde_json::json!({
+            "script_path": script,
+            "approval_prompt": "Deploy?",
+            "approval_context": { "env": "prod" },
+            "created_at": 0,
+            "ttl_secs": 1
+        })
+        .to_string(),
+    )
+    .unwrap();
+
+    let output = run_resume(token, "yes", &state_dir);
+    assert!(output.status.success());
+
+    let json = stdout_json(&output);
+    assert_eq!(json["ok"], Value::Bool(false));
+    assert_eq!(json["status"], Value::String("error".into()));
+    assert!(json["error"].as_str().unwrap().contains("expired"));
+}
+
+#[test]
+fn test_resume_invalid_token() {
+    let state_dir = temp_dir("assay-resume-state");
+
+    let output = run_resume("missing-token", "yes", &state_dir);
+    assert!(output.status.success());
+
+    let json = stdout_json(&output);
+    assert_eq!(json["ok"], Value::Bool(false));
+    assert_eq!(json["status"], Value::String("error".into()));
+    assert!(
+        json["error"]
+            .as_str()
+            .unwrap()
+            .contains("invalid resume token")
+    );
+}
+
+#[test]
+fn test_resume_cleanup() {
+    let state_dir = temp_dir("assay-resume-state");
+    let script = approval_script();
+
+    let first = run_tool_mode_with_state_dir(&script, &state_dir);
+    assert!(first.status.success());
+    let first_json = stdout_json(&first);
+    let token = extract_resume_token(&first_json);
+    let state_path = resume_state_path(&state_dir, &token);
+    assert!(state_path.exists());
+
+    let resumed = run_resume(&token, "yes", &state_dir);
+    assert!(resumed.status.success());
+    assert!(!state_path.exists());
+}
+
+#[test]
+fn test_tool_mode_normal_mode() {
+    let script = write_script(
+        "normal.lua",
+        r#"
+        log.info("plain mode")
+        return { ignored = true }
+        "#,
+    );
+
+    let output = Command::new(assay_binary())
+        .args(["run", script.to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stdout.trim().is_empty(),
+        "normal mode should not emit JSON envelope: {stdout}"
+    );
+    assert!(
+        stderr.contains("plain mode"),
+        "normal mode log should remain on stderr: {stderr}"
+    );
+}
+
+#[test]
+fn test_approval_non_tool_mode() {
+    let script = approval_script();
+
+    let output = run_normal_mode(&script);
+    assert!(!output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stdout.trim().is_empty(),
+        "normal mode should not emit JSON envelope: {stdout}"
+    );
+    assert!(stderr.contains("openclaw: approval_required:"));
+}


### PR DESCRIPTION
## Summary

Complete OpenClaw integration making Assay a full Lobster replacement. Adds 6 new stdlib modules, tool mode for structured JSON output, a resume/halt mechanism for approval gates, and a standalone OpenClaw TypeScript extension.

## What changed

### New stdlib modules (23 → 29 modules)
- `assay.openclaw` — Invoke tools, state management, diff, approval gates, LLM tasks
- `assay.github` — PRs, issues, actions, repos, GraphQL (HTTP-native)
- `assay.gmail` — Search, read, reply, send with OAuth2 auto-refresh
- `assay.gcal` — Events CRUD, calendar list with OAuth2 auto-refresh
- `assay.oauth2` — Shared Google OAuth2 token management
- `assay.email_triage` — Deterministic + LLM-assisted email classification

### Tool mode (`--mode tool`)
- `assay run --mode tool script.lua` emits JSON envelope on stdout
- `ASSAY_MODE=tool` env var support
- Stdout size cap (512KB), configurable timeout, stderr separation
- Matches Lobster's envelope protocol for drop-in compatibility

### Resume mechanism
- `assay resume --token X --approve yes|no` for approval gate workflows
- State persisted to `~/.assay/state/resume/` with configurable TTL
- Re-run pattern matching Lobster's existing protocol

### OpenClaw extension (`openclaw-extension/`)
- Standalone npm package: `@assay/openclaw-extension`
- Spawns assay binary, parses JSON envelopes, handles approval flow
- SKILL.md documents all 29 modules for LLM agents
- Install: `openclaw plugins install @assay/openclaw-extension`

### All modules are shell-free
Every new module uses HTTP APIs natively — no `shell.exec("gh ...")` or `shell.exec("gog ...")`.

## Stats
- 55 files changed, +5438 / -301
- 6 new Lua modules, 7 new test files, 5 example scripts
- 7 TypeScript files (extension)
- 10 doc files updated

## Testing
- `cargo clippy --tests -- -D warnings` — 0 warnings
- `cargo test` — 65 test suites, 0 failures