### PR TITLE
fix: include temporal in default features (v0.7.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to Assay are documented here.
 
+## [0.7.1] - 2026-04-06
+
+### Changed
+
+- **Temporal included by default**: The `temporal` feature is now part of the default build.
+  The standard Docker image and binary include native gRPC workflow support out of the box.
+  Binary size increases from ~6.8 MB to ~8.7 MB.
+
 ## [0.7.0] - 2026-04-06
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-lua"
-version = "0.7.0"
+version = "0.7.1"
 categories = ["command-line-utilities", "development-tools::testing"]
 edition = "2024"
 homepage = "https://assay.rs"
@@ -19,7 +19,7 @@ name = "assay"
 path = "src/lib.rs"
 
 [features]
-default = ["db", "server", "cli"]
+default = ["db", "server", "cli", "temporal"]
 db = ["dep:sqlx"]
 server = ["dep:http-body-util", "dep:hyper", "dep:hyper-util"]
 cli = ["dep:clap", "dep:tracing-subscriber"]


### PR DESCRIPTION
## Summary

- Add `temporal` to the default feature set in Cargo.toml
- The standard Docker image and binary now include native gRPC workflow support
- Binary size: ~8.7 MB (from ~6.8 MB) — acceptable tradeoff for having Temporal built-in
- Bump version to 0.7.1

## Test plan

- [x] `cargo clippy` — zero warnings
- [x] `cargo test` — all tests pass (temporal tests now run by default)
- [ ] CI passes