### PR TITLE
fix: include temporal in default features (v0.7.1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,11 @@ jobs:
         with:
           key: ${{ matrix.target }}
 
+      - name: Install protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Clippy (warnings = errors)
         run: cargo clippy --tests --target ${{ matrix.target }} -- -D warnings
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,7 @@ on:
       - main
     paths:
       - "site/**"
+      - "CHANGELOG.md"
       - "wrangler.toml"
 
 concurrency:
@@ -36,6 +37,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Build changelog from CHANGELOG.md
+        run: |
+          npx marked -i CHANGELOG.md -o /tmp/changelog-body.html
+          sed -i '1,/<\/p>/{/<h1>/d;/<\/h1>/d;/^All notable/d;/<p>All notable/,/<\/p>/d}' /tmp/changelog-body.html
+          sed -i '/__CHANGELOG_CONTENT__/{
+            r /tmp/changelog-body.html
+            d
+          }' site/changelog.html
 
       - name: Stamp version into site
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,11 @@ jobs:
         with:
           key: release-${{ matrix.target }}
 
+      - name: Install protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Install dependencies
         if: matrix.deps != ''
         run: ${{ matrix.deps }}
@@ -82,6 +87,11 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: dtolnay/rust-toolchain@stable
+
+      - name: Install protoc
+        uses: arduino/setup-protoc@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish to crates.io
         env:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,11 +19,11 @@ Use cases:
 
 - **Standalone scripting** — system automation, CI/CD tasks, file processing
 - **Embedded runtime** — other Rust services embed assay as a library (`pub mod lua`)
-- **Kubernetes Jobs** — replaces 50–250 MB Python/Node/kubectl containers (~6 MB image)
+- **Kubernetes Jobs** — replaces 50–250 MB Python/Node/kubectl containers (~8 MB image)
 - **Infrastructure automation** — GitOps hooks, health checks, service configuration
 
 - **Repo**: [github.com/developerinlondon/assay](https://github.com/developerinlondon/assay)
-- **Image**: `ghcr.io/developerinlondon/assay:latest` (~6 MB compressed)
+- **Image**: `ghcr.io/developerinlondon/assay:latest` (~8 MB compressed)
 - **Crate**: [crates.io/crates/assay-lua](https://crates.io/crates/assay-lua)
 - **Stack**: Rust (2024 edition), Tokio, Lua 5.5 (mlua), reqwest, clap, axum
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,11 +19,11 @@ Use cases:
 
 - **Standalone scripting** — system automation, CI/CD tasks, file processing
 - **Embedded runtime** — other Rust services embed assay as a library (`pub mod lua`)
-- **Kubernetes Jobs** — replaces 50–250 MB Python/Node/kubectl containers (~8 MB image)
+- **Kubernetes Jobs** — replaces 50–250 MB Python/Node/kubectl containers (~9 MB image)
 - **Infrastructure automation** — GitOps hooks, health checks, service configuration
 
 - **Repo**: [github.com/developerinlondon/assay](https://github.com/developerinlondon/assay)
-- **Image**: `ghcr.io/developerinlondon/assay:latest` (~8 MB compressed)
+- **Image**: `ghcr.io/developerinlondon/assay:latest` (~9 MB compressed)
 - **Crate**: [crates.io/crates/assay-lua](https://crates.io/crates/assay-lua)
 - **Stack**: Rust (2024 edition), Tokio, Lua 5.5 (mlua), reqwest, clap, axum
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to Assay are documented here.
 
+## [0.7.1] - 2026-04-06
+
+### Changed
+
+- **Temporal included by default**: The `temporal` feature is now part of the default build.
+  The standard Docker image and binary include native gRPC workflow support out of the box.
+- **CI/Release/Docker**: Added `protoc` installation to all build environments for gRPC
+  proto compilation.
+
 ## [0.7.0] - 2026-04-06
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-lua"
-version = "0.7.0"
+version = "0.7.1"
 categories = ["command-line-utilities", "development-tools::testing"]
 edition = "2024"
 homepage = "https://assay.rs"
@@ -19,7 +19,7 @@ name = "assay"
 path = "src/lib.rs"
 
 [features]
-default = ["db", "server", "cli"]
+default = ["db", "server", "cli", "temporal"]
 db = ["dep:sqlx"]
 server = ["dep:http-body-util", "dep:hyper", "dep:hyper-util"]
 cli = ["dep:clap", "dep:tracing-subscriber"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Builder
 FROM rust:1.92-slim AS builder
-RUN apt-get update && apt-get install -y musl-tools cmake make g++ && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y musl-tools cmake make g++ protobuf-compiler && rm -rf /var/lib/apt/lists/*
 RUN rustup target add x86_64-unknown-linux-musl
 WORKDIR /app
 COPY Cargo.toml Cargo.lock ./

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Container image size comparison (compressed pull):
 +-----------------------------------------------------------------------+
 | Docker image size comparison (compressed pull)                        |
 |                                                                       |
-| Assay            ## 6 MB                                              |
+| Assay            ### 8 MB                                              |
 | Python alpine    ###### 17 MB                                         |
 | bitnami/kubectl  ############ 35 MB                                   |
 | Python slim      ############### 43 MB                                |
@@ -46,7 +46,7 @@ Container image size comparison (compressed pull):
 
 | Runtime         | Compressed |   On-disk | vs Assay | Cold Start | K8s-native |
 | --------------- | ---------: | --------: | :------: | ---------: | :--------: |
-| **Assay**       |   **6 MB** | **13 MB** |  **1x**  |   **5 ms** |  **Yes**   |
+| **Assay**       |   **8 MB** | **15 MB** |  **1x**  |   **5 ms** |  **Yes**   |
 | Python alpine   |      17 MB |     50 MB |    3x    |     300 ms |     No     |
 | bitnami/kubectl |      35 MB |     90 MB |    6x    |     200 ms |  Partial   |
 | Python slim     |      43 MB |    130 MB |    9x    |     300 ms |     No     |

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Container image size comparison (compressed pull):
 +-----------------------------------------------------------------------+
 | Docker image size comparison (compressed pull)                        |
 |                                                                       |
-| Assay            ### 8 MB                                              |
+| Assay            ### 9 MB                                              |
 | Python alpine    ###### 17 MB                                         |
 | bitnami/kubectl  ############ 35 MB                                   |
 | Python slim      ############### 43 MB                                |
@@ -46,7 +46,7 @@ Container image size comparison (compressed pull):
 
 | Runtime         | Compressed |   On-disk | vs Assay | Cold Start | K8s-native |
 | --------------- | ---------: | --------: | :------: | ---------: | :--------: |
-| **Assay**       |   **8 MB** | **15 MB** |  **1x**  |   **5 ms** |  **Yes**   |
+| **Assay**       |   **9 MB** | **15 MB** |  **1x**  |   **5 ms** |  **Yes**   |
 | Python alpine   |      17 MB |     50 MB |    3x    |     300 ms |     No     |
 | bitnami/kubectl |      35 MB |     90 MB |    6x    |     200 ms |  Partial   |
 | Python slim     |      43 MB |    130 MB |    9x    |     300 ms |     No     |

--- a/SKILL.md
+++ b/SKILL.md
@@ -12,7 +12,7 @@ Assay is a single ~9 MB static binary that runs Lua scripts in Kubernetes. It re
 Python/Node/kubectl containers in K8s Jobs. One binary, two modes: run a `.lua` script directly, or
 run a `.yaml` check config with retry/backoff/structured output.
 
-The image is `ghcr.io/developerinlondon/assay:latest` (~6 MB compressed). Install locally with
+The image is `ghcr.io/developerinlondon/assay:latest` (~8 MB compressed). Install locally with
 `cargo install assay-lua` or download from GitHub Releases.
 
 ## Quick Start

--- a/SKILL.md
+++ b/SKILL.md
@@ -12,7 +12,7 @@ Assay is a single ~9 MB static binary that runs Lua scripts in Kubernetes. It re
 Python/Node/kubectl containers in K8s Jobs. One binary, two modes: run a `.lua` script directly, or
 run a `.yaml` check config with retry/backoff/structured output.
 
-The image is `ghcr.io/developerinlondon/assay:latest` (~8 MB compressed). Install locally with
+The image is `ghcr.io/developerinlondon/assay:latest` (~9 MB compressed). Install locally with
 `cargo install assay-lua` or download from GitHub Releases.
 
 ## Quick Start

--- a/llms.txt
+++ b/llms.txt
@@ -76,7 +76,7 @@
 
 ## Optional
 - [Crates.io](https://crates.io/crates/assay-lua): Use Assay as a Rust crate in your own projects
-- [Docker](https://github.com/developerinlondon/assay/pkgs/container/assay): ghcr.io/developerinlondon/assay:latest (~6MB compressed)
+- [Docker](https://github.com/developerinlondon/assay/pkgs/container/assay): ghcr.io/developerinlondon/assay:latest (~8MB compressed)
 - [MCP Comparison](https://assay.rs/mcp-comparison.html): How Assay replaces 42 popular MCP servers
 - [Agent Guides](https://assay.rs/agent-guides.html): Integration guides for Claude Code, Cursor, Windsurf, Cline, OpenCode
 - [Changelog](https://github.com/developerinlondon/assay/releases): Release history

--- a/llms.txt
+++ b/llms.txt
@@ -76,7 +76,7 @@
 
 ## Optional
 - [Crates.io](https://crates.io/crates/assay-lua): Use Assay as a Rust crate in your own projects
-- [Docker](https://github.com/developerinlondon/assay/pkgs/container/assay): ghcr.io/developerinlondon/assay:latest (~8MB compressed)
+- [Docker](https://github.com/developerinlondon/assay/pkgs/container/assay): ghcr.io/developerinlondon/assay:latest (~9MB compressed)
 - [MCP Comparison](https://assay.rs/mcp-comparison.html): How Assay replaces 42 popular MCP servers
 - [Agent Guides](https://assay.rs/agent-guides.html): Integration guides for Claude Code, Cursor, Windsurf, Cline, OpenCode
 - [Changelog](https://github.com/developerinlondon/assay/releases): Release history

--- a/site/changelog.html
+++ b/site/changelog.html
@@ -6,6 +6,13 @@
   <title>Assay — Changelog</title>
   <meta name="description" content="Assay release history and changelog. All notable changes, new features, bug fixes, and breaking changes.">
   <link rel="stylesheet" href="style.css">
+  <style>
+    .changelog h2 { border-bottom: 1px solid var(--border); padding-bottom: 0.3rem; margin-top: 2.5rem; }
+    .changelog h3 { font-size: 1.1rem; margin-top: 1rem; margin-bottom: 0.5rem; }
+    .changelog ul { margin-top: 0.3rem; }
+    .changelog code { font-size: 0.9em; }
+    .changelog > h2:first-child { margin-top: 0; }
+  </style>
 </head>
 <body>
   <header>
@@ -31,174 +38,35 @@
       as pre-built binaries, Docker image, and crates.io package.
     </p>
 
-    <!-- v0.7.0 -->
-    <section style="margin-bottom: 2.5rem;">
-      <h2 id="v0.7.0" style="border-bottom: 1px solid var(--border); padding-bottom: 0.3rem;">
-        v0.7.0 <span style="font-weight: 400; font-size: 0.9rem; color: var(--text-secondary);">— 2026-04-06</span>
-      </h2>
-      <h3>Added</h3>
-      <ul>
-        <li><strong>Temporal gRPC client</strong> (optional <code>temporal</code> feature) — Native gRPC bridge for Temporal workflow engine via <code>temporalio-client</code> v0.2.0. The <code>temporal</code> global provides <code>connect()</code> for persistent clients and <code>start()</code> for one-shot workflow execution.</li>
-        <li>Client methods: <code>start_workflow</code>, <code>signal_workflow</code>, <code>query_workflow</code>, <code>describe_workflow</code>, <code>get_result</code>, <code>cancel_workflow</code>, <code>terminate_workflow</code>.</li>
-        <li>All methods are async with JSON payload encoding.</li>
-        <li>Build with <code>cargo build --features temporal</code> (requires <code>protoc</code>).</li>
-        <li>8 new tests for gRPC registration, error handling, and stdlib compatibility.</li>
-      </ul>
-      <h3>Dependencies (temporal feature only)</h3>
-      <ul>
-        <li><code>temporalio-client</code> 0.2.0, <code>temporalio-sdk</code> 0.2.0, <code>temporalio-common</code> 0.2.0, <code>url</code> 2.x</li>
-      </ul>
-    </section>
-
-    <!-- v0.6.1 -->
-    <section style="margin-bottom: 2.5rem;">
-      <h2 id="v0.6.1" style="border-bottom: 1px solid var(--border); padding-bottom: 0.3rem;">
-        v0.6.1 <span style="font-weight: 400; font-size: 0.9rem; color: var(--text-secondary);">— 2026-04-06</span>
-      </h2>
-      <h3>Fixed</h3>
-      <ul>
-        <li><strong>http.serve async handlers</strong> — Route handlers are now async (<code>call_async</code>), allowing them to call <code>http.get</code>, <code>sleep</code>, and other async builtins from inside route handlers.</li>
-      </ul>
-      <h3>Added</h3>
-      <ul>
-        <li><code>npx skills add developerinlondon/assay</code> for SKILL.md installation.</li>
-        <li>Dark/light theme toggle on assay.rs with localStorage persistence.</li>
-        <li>Infrastructure Testing highlighted as core capability on homepage.</li>
-      </ul>
-      <h3>Changed</h3>
-      <ul>
-        <li><strong>Site overhaul</strong> — compact hero, service grid above fold, size &amp; speed comparison charts, consistent nav.</li>
-        <li><strong>Comparison page</strong> — renamed from "MCP Comparison", shows only domains Assay covers.</li>
-      </ul>
-    </section>
-
-    <!-- v0.6.0 -->
-    <section style="margin-bottom: 2.5rem;">
-      <h2 id="v0.6.0" style="border-bottom: 1px solid var(--border); padding-bottom: 0.3rem;">
-        v0.6.0 <span style="font-weight: 400; font-size: 0.9rem; color: var(--text-secondary);">— 2026-04-05</span>
-      </h2>
-      <h3>Added</h3>
-      <ul>
-        <li><strong>6 new stdlib modules</strong> (23 &rarr; 29 total):
-          <code>assay.openclaw</code>, <code>assay.github</code>, <code>assay.gmail</code>, <code>assay.gcal</code>, <code>assay.oauth2</code>, <code>assay.email_triage</code></li>
-        <li><strong>Tool mode</strong>: <code>assay run --mode tool</code> for OpenClaw AI agent integration with structured JSON output.</li>
-        <li><strong>Resume mechanism</strong>: <code>assay resume --token &lt;token&gt; --approve yes|no</code> for paused workflows.</li>
-        <li><strong>OpenClaw extension</strong>: <code>@developerinlondon/assay-openclaw-extension</code> npm package.</li>
-      </ul>
-    </section>
-
-    <!-- v0.5.6 -->
-    <section style="margin-bottom: 2.5rem;">
-      <h2 id="v0.5.6" style="border-bottom: 1px solid var(--border); padding-bottom: 0.3rem;">
-        v0.5.6 <span style="font-weight: 400; font-size: 0.9rem; color: var(--text-secondary);">— 2026-04-03</span>
-      </h2>
-      <h3>Added</h3>
-      <ul>
-        <li><strong>SSE streaming</strong> for <code>http.serve</code> via <code>{ sse = function(send) ... end }</code> return shape.</li>
-        <li><strong>assert.ne(a, b, msg?)</strong> — inequality assertion.</li>
-      </ul>
-      <h3>Fixed</h3>
-      <ul>
-        <li>Content-Type precedence in <code>http.serve</code> responses.</li>
-        <li>SSE newline validation prevents field injection.</li>
-      </ul>
-    </section>
-
-    <!-- v0.5.5 -->
-    <section style="margin-bottom: 2.5rem;">
-      <h2 id="v0.5.5" style="border-bottom: 1px solid var(--border); padding-bottom: 0.3rem;">
-        v0.5.5 <span style="font-weight: 400; font-size: 0.9rem; color: var(--text-secondary);">— 2026-03-13</span>
-      </h2>
-      <h3>Added</h3>
-      <ul>
-        <li><strong>follow_redirects</strong> option for YAML HTTP checks and Lua <code>http.client()</code> builder.</li>
-      </ul>
-    </section>
-
-    <!-- v0.5.4 -->
-    <section style="margin-bottom: 2.5rem;">
-      <h2 id="v0.5.4" style="border-bottom: 1px solid var(--border); padding-bottom: 0.3rem;">
-        v0.5.4 <span style="font-weight: 400; font-size: 0.9rem; color: var(--text-secondary);">— 2026-03-12</span>
-      </h2>
-      <h3>Fixed</h3>
-      <ul>
-        <li><strong>unleash.ensure_token</strong>: Send <code>tokenName</code> instead of <code>username</code> in create token API payload.</li>
-      </ul>
-    </section>
-
-    <!-- v0.5.3 -->
-    <section style="margin-bottom: 2.5rem;">
-      <h2 id="v0.5.3" style="border-bottom: 1px solid var(--border); padding-bottom: 0.3rem;">
-        v0.5.3 <span style="font-weight: 400; font-size: 0.9rem; color: var(--text-secondary);">— 2026-03-12</span>
-      </h2>
-      <h3>Added</h3>
-      <ul>
-        <li><strong>disk builtins</strong>: <code>disk.usage(path)</code> and <code>disk.mounts()</code>.</li>
-        <li><strong>os builtins</strong>: <code>os.info()</code> — name, version, arch, hostname, uptime.</li>
-        <li><strong>Expanded fs and env builtins</strong>: <code>fs.exists</code>, <code>fs.mkdir</code>, <code>fs.glob</code>, <code>env.set</code>, <code>env.list</code>, etc.</li>
-      </ul>
-    </section>
-
-    <!-- v0.5.0 - v0.5.2 -->
-    <section style="margin-bottom: 2.5rem;">
-      <h2 id="v0.5.0" style="border-bottom: 1px solid var(--border); padding-bottom: 0.3rem;">
-        v0.5.0 &ndash; v0.5.2 <span style="font-weight: 400; font-size: 0.9rem; color: var(--text-secondary);">— 2026-02 to 2026-03</span>
-      </h2>
-      <ul>
-        <li><strong>CLI subcommands</strong>: <code>assay exec</code>, <code>assay context</code>, <code>assay modules</code></li>
-        <li><strong>Module discovery</strong>: BM25 search with FTS5 backend.</li>
-        <li><strong>shell builtins</strong>: <code>shell.run</code>, <code>shell.output</code>, <code>shell.pipe</code></li>
-        <li><strong>process builtins</strong>: <code>process.spawn</code>, <code>process.kill</code>, <code>process.list</code></li>
-      </ul>
-    </section>
-
-    <!-- v0.4.x -->
-    <section style="margin-bottom: 2.5rem;">
-      <h2 id="v0.4.0" style="border-bottom: 1px solid var(--border); padding-bottom: 0.3rem;">
-        v0.4.0 &ndash; v0.4.4 <span style="font-weight: 400; font-size: 0.9rem; color: var(--text-secondary);">— 2026-02</span>
-      </h2>
-      <ul>
-        <li><strong>unleash</strong>, <strong>zitadel</strong>, <strong>postgres</strong> stdlib modules.</li>
-        <li><strong>crypto.hmac</strong> with all 8 hash algorithms.</li>
-        <li><strong>S3 stdlib module</strong> with AWS Sig V4 auth.</li>
-        <li>Modular builtins refactoring (split monolithic builtins.rs).</li>
-      </ul>
-    </section>
-
-    <!-- v0.3.0 -->
-    <section style="margin-bottom: 2.5rem;">
-      <h2 id="v0.3.0" style="border-bottom: 1px solid var(--border); padding-bottom: 0.3rem;">
-        v0.3.0 <span style="font-weight: 400; font-size: 0.9rem; color: var(--text-secondary);">— 2026-02-11</span>
-      </h2>
-      <p>First feature-complete release. 19 stdlib modules, HTTP server, database, WebSocket, JWT, templates, async, regex, YAML/TOML, crypto. Lua 5.5. 491 tests.</p>
-    </section>
-
-    <!-- v0.0.1 -->
-    <section style="margin-bottom: 2.5rem;">
-      <h2 id="v0.0.1" style="border-bottom: 1px solid var(--border); padding-bottom: 0.3rem;">
-        v0.0.1 <span style="font-weight: 400; font-size: 0.9rem; color: var(--text-secondary);">— 2026-02-09</span>
-      </h2>
-      <p>Initial release. YAML-based check orchestration for ArgoCD PostSync verification.</p>
-    </section>
-
+    <div class="changelog">
+__CHANGELOG_CONTENT__
+    </div>
   </main>
 
   <footer>
-    <p>Assay &copy; 2026 &mdash; MIT License &mdash; <a href="https://github.com/developerinlondon/assay">Source</a></p>
+    <p>Assay is MIT licensed &mdash;
+      <a href="https://github.com/developerinlondon/assay">GitHub</a> &middot;
+      <a href="https://crates.io/crates/assay-lua">crates.io</a> &middot;
+      <a href="https://github.com/developerinlondon/assay/pkgs/container/assay">Docker</a>
+    </p>
+    <p class="text-muted">&copy; 2026 Assay Contributors &middot; <span style="font-family: monospace; font-size: 0.75rem;">__GIT_SHA__</span></p>
   </footer>
 
   <script>
     function toggleTheme() {
       const html = document.documentElement;
       const current = html.getAttribute('data-theme');
-      const next = current === 'dark' ? 'light' : 'dark';
+      const next = current === 'dark' ? 'light' : (current === 'light' ? 'dark' :
+        (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'light' : 'dark'));
       html.setAttribute('data-theme', next);
       localStorage.setItem('theme', next);
+      document.querySelector('.theme-toggle').textContent = next === 'dark' ? '\u2600' : '\u263D';
     }
-    (function() {
-      const saved = localStorage.getItem('theme');
-      if (saved) document.documentElement.setAttribute('data-theme', saved);
-    })();
+    const saved = localStorage.getItem('theme');
+    if (saved) {
+      document.documentElement.setAttribute('data-theme', saved);
+      document.querySelector('.theme-toggle').textContent = saved === 'dark' ? '\u2600' : '\u263D';
+    }
   </script>
 </body>
 </html>

--- a/site/comparison.html
+++ b/site/comparison.html
@@ -35,7 +35,7 @@
         <div style="font-size: 0.75rem;">
           <div style="display: flex; align-items: center; gap: 0.4rem; margin-bottom: 2px;">
             <div style="background: var(--accent); padding: 0.3rem; border-radius: 3px; width: 4.7%; min-width: 4px;">&nbsp;</div>
-            <span style="color: var(--accent); font-weight: 700;">Assay 6 MB</span>
+            <span style="color: var(--accent); font-weight: 700;">Assay 8 MB</span>
           </div>
           <div style="display: flex; align-items: center; gap: 0.4rem; margin-bottom: 2px;">
             <div style="background: var(--border); padding: 0.3rem; border-radius: 3px; width: 13.3%;">&nbsp;</div>

--- a/site/comparison.html
+++ b/site/comparison.html
@@ -35,7 +35,7 @@
         <div style="font-size: 0.75rem;">
           <div style="display: flex; align-items: center; gap: 0.4rem; margin-bottom: 2px;">
             <div style="background: var(--accent); padding: 0.3rem; border-radius: 3px; width: 4.7%; min-width: 4px;">&nbsp;</div>
-            <span style="color: var(--accent); font-weight: 700;">Assay 8 MB</span>
+            <span style="color: var(--accent); font-weight: 700;">Assay 9 MB</span>
           </div>
           <div style="display: flex; align-items: center; gap: 0.4rem; margin-bottom: 2px;">
             <div style="background: var(--border); padding: 0.3rem; border-radius: 3px; width: 13.3%;">&nbsp;</div>

--- a/site/index.html
+++ b/site/index.html
@@ -238,7 +238,7 @@ checks:
         <tr><th>Runtime</th><th>Compressed</th><th>vs Assay</th></tr>
       </thead>
       <tbody>
-        <tr style="font-weight: 600; color: var(--accent);"><td>Assay</td><td>8 MB</td><td>1x</td></tr>
+        <tr style="font-weight: 600; color: var(--accent);"><td>Assay</td><td>9 MB</td><td>1x</td></tr>
         <tr><td>alpine/python</td><td>17 MB</td><td>3x</td></tr>
         <tr><td>bitnami/kubectl</td><td>35 MB</td><td>6x</td></tr>
         <tr><td>Node.js alpine</td><td>57 MB</td><td>12x</td></tr>

--- a/site/index.html
+++ b/site/index.html
@@ -238,7 +238,7 @@ checks:
         <tr><th>Runtime</th><th>Compressed</th><th>vs Assay</th></tr>
       </thead>
       <tbody>
-        <tr style="font-weight: 600; color: var(--accent);"><td>Assay</td><td>6 MB</td><td>1x</td></tr>
+        <tr style="font-weight: 600; color: var(--accent);"><td>Assay</td><td>8 MB</td><td>1x</td></tr>
         <tr><td>alpine/python</td><td>17 MB</td><td>3x</td></tr>
         <tr><td>bitnami/kubectl</td><td>35 MB</td><td>6x</td></tr>
         <tr><td>Node.js alpine</td><td>57 MB</td><td>12x</td></tr>

--- a/site/llms-full.txt
+++ b/site/llms-full.txt
@@ -1342,7 +1342,7 @@ local smart_buckets = email_triage.categorize_llm(emails, oc)
 ## Optional
 
 - [Crates.io](https://crates.io/crates/assay-lua): Use Assay as a Rust crate in your own projects
-- [Docker](https://github.com/developerinlondon/assay/pkgs/container/assay): ghcr.io/developerinlondon/assay:latest (~8MB compressed)
+- [Docker](https://github.com/developerinlondon/assay/pkgs/container/assay): ghcr.io/developerinlondon/assay:latest (~9MB compressed)
 - [MCP Comparison](https://assay.rs/mcp-comparison.html): How Assay replaces 42 popular MCP servers
 - [Agent Guides](https://assay.rs/agent-guides.html): Integration guides for Claude Code, Cursor, Windsurf, Cline, OpenCode
 - [Changelog](https://github.com/developerinlondon/assay/releases): Release history

--- a/site/llms-full.txt
+++ b/site/llms-full.txt
@@ -1342,7 +1342,7 @@ local smart_buckets = email_triage.categorize_llm(emails, oc)
 ## Optional
 
 - [Crates.io](https://crates.io/crates/assay-lua): Use Assay as a Rust crate in your own projects
-- [Docker](https://github.com/developerinlondon/assay/pkgs/container/assay): ghcr.io/developerinlondon/assay:latest (~6MB compressed)
+- [Docker](https://github.com/developerinlondon/assay/pkgs/container/assay): ghcr.io/developerinlondon/assay:latest (~8MB compressed)
 - [MCP Comparison](https://assay.rs/mcp-comparison.html): How Assay replaces 42 popular MCP servers
 - [Agent Guides](https://assay.rs/agent-guides.html): Integration guides for Claude Code, Cursor, Windsurf, Cline, OpenCode
 - [Changelog](https://github.com/developerinlondon/assay/releases): Release history

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -77,7 +77,7 @@
 
 ## Optional
 - [Crates.io](https://crates.io/crates/assay-lua): Use Assay as a Rust crate in your own projects
-- [Docker](https://github.com/developerinlondon/assay/pkgs/container/assay): ghcr.io/developerinlondon/assay:latest (~6MB compressed)
+- [Docker](https://github.com/developerinlondon/assay/pkgs/container/assay): ghcr.io/developerinlondon/assay:latest (~8MB compressed)
 - [MCP Comparison](https://assay.rs/mcp-comparison.html): How Assay replaces 42 popular MCP servers
 - [Agent Guides](https://assay.rs/agent-guides.html): Integration guides for Claude Code, Cursor, Windsurf, Cline, OpenCode
 - [Changelog](https://github.com/developerinlondon/assay/releases): Release history

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -77,7 +77,7 @@
 
 ## Optional
 - [Crates.io](https://crates.io/crates/assay-lua): Use Assay as a Rust crate in your own projects
-- [Docker](https://github.com/developerinlondon/assay/pkgs/container/assay): ghcr.io/developerinlondon/assay:latest (~8MB compressed)
+- [Docker](https://github.com/developerinlondon/assay/pkgs/container/assay): ghcr.io/developerinlondon/assay:latest (~9MB compressed)
 - [MCP Comparison](https://assay.rs/mcp-comparison.html): How Assay replaces 42 popular MCP servers
 - [Agent Guides](https://assay.rs/agent-guides.html): Integration guides for Claude Code, Cursor, Windsurf, Cline, OpenCode
 - [Changelog](https://github.com/developerinlondon/assay/releases): Release history

--- a/skills/assay/SKILL.md
+++ b/skills/assay/SKILL.md
@@ -12,7 +12,7 @@ Assay is a single ~9 MB static binary that runs Lua scripts in Kubernetes. It re
 Python/Node/kubectl containers in K8s Jobs. One binary, two modes: run a `.lua` script directly, or
 run a `.yaml` check config with retry/backoff/structured output.
 
-The image is `ghcr.io/developerinlondon/assay:latest` (~6 MB compressed). Install locally with
+The image is `ghcr.io/developerinlondon/assay:latest` (~8 MB compressed). Install locally with
 `cargo install assay-lua` or download from GitHub Releases.
 
 ## Quick Start

--- a/skills/assay/SKILL.md
+++ b/skills/assay/SKILL.md
@@ -12,7 +12,7 @@ Assay is a single ~9 MB static binary that runs Lua scripts in Kubernetes. It re
 Python/Node/kubectl containers in K8s Jobs. One binary, two modes: run a `.lua` script directly, or
 run a `.yaml` check config with retry/backoff/structured output.
 
-The image is `ghcr.io/developerinlondon/assay:latest` (~8 MB compressed). Install locally with
+The image is `ghcr.io/developerinlondon/assay:latest` (~9 MB compressed). Install locally with
 `cargo install assay-lua` or download from GitHub Releases.
 
 ## Quick Start


### PR DESCRIPTION
## Summary

- Add `temporal` to default features in Cargo.toml
- Add `protoc` to CI, release, and Docker build environments
- Bump version to 0.7.1

## Test plan

- [x] `cargo clippy` — zero warnings
- [x] `cargo test` — all tests pass (temporal tests run by default)
- [ ] CI passes on both platforms