### PR TITLE
feat: parse query string into req.params in http.serve (v0.7.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to Assay are documented here.
 
+## [0.7.2] - 2026-04-07
+
+### Added
+
+- **`req.params` in `http.serve`**: Query string parameters are now automatically parsed
+  into a `params` table on incoming requests. For example, `?login_challenge=abc&foo=bar`
+  becomes `req.params.login_challenge == "abc"` and `req.params.foo == "bar"`. The raw
+  query string remains available as `req.query`.
+
 ## [0.7.1] - 2026-04-06
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-lua"
-version = "0.7.1"
+version = "0.7.2"
 categories = ["command-line-utilities", "development-tools::testing"]
 edition = "2024"
 homepage = "https://assay.rs"

--- a/src/lua/builtins/http.rs
+++ b/src/lua/builtins/http.rs
@@ -483,6 +483,17 @@ async fn build_lua_request_and_call(
     req_table.set("query", query.to_string())?;
     req_table.set("body", body.to_string())?;
 
+    // Parse query string into a params table (e.g. "a=1&b=2" -> {a="1", b="2"})
+    let params_table = lua.create_table()?;
+    if !query.is_empty() {
+        for pair in query.split('&') {
+            if let Some((key, value)) = pair.split_once('=') {
+                params_table.set(key.to_string(), value.to_string())?;
+            }
+        }
+    }
+    req_table.set("params", params_table)?;
+
     let headers_table = lua.create_table()?;
     for (k, v) in headers {
         headers_table.set(k.as_str(), v.as_str())?;

--- a/tests/http_serve.rs
+++ b/tests/http_serve.rs
@@ -318,3 +318,69 @@ async fn test_http_serve_async_handler() {
     .await
     .unwrap();
 }
+
+#[tokio::test]
+async fn test_http_serve_query_params() {
+    run_lua_local(
+        r#"
+        local server = async.spawn(function()
+            http.serve(0, {
+                GET = {
+                    ["/search"] = function(req)
+                        return {
+                            status = 200,
+                            json = {
+                                raw_query = req.query,
+                                name = req.params.name,
+                                page = req.params.page,
+                            }
+                        }
+                    end,
+                }
+            })
+        end)
+        sleep(0.1)
+        local port = _SERVER_PORT
+        local resp = http.get("http://127.0.0.1:" .. port .. "/search?name=hello&page=2")
+        assert.eq(resp.status, 200)
+        local data = json.parse(resp.body)
+        assert.eq(data.raw_query, "name=hello&page=2")
+        assert.eq(data.name, "hello")
+        assert.eq(data.page, "2")
+    "#,
+    )
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn test_http_serve_empty_query_params() {
+    run_lua_local(
+        r#"
+        local server = async.spawn(function()
+            http.serve(0, {
+                GET = {
+                    ["/noquery"] = function(req)
+                        return {
+                            status = 200,
+                            json = {
+                                raw_query = req.query,
+                                has_params = next(req.params) ~= nil,
+                            }
+                        }
+                    end,
+                }
+            })
+        end)
+        sleep(0.1)
+        local port = _SERVER_PORT
+        local resp = http.get("http://127.0.0.1:" .. port .. "/noquery")
+        assert.eq(resp.status, 200)
+        local data = json.parse(resp.body)
+        assert.eq(data.raw_query, "")
+        assert.eq(data.has_params, false)
+    "#,
+    )
+    .await
+    .unwrap();
+}


### PR DESCRIPTION
## Summary

- `req.params` — parsed query parameters as a Lua table (e.g., `req.params.name`)
- `req.query` — raw query string (unchanged, backward compatible)
- 2 new tests for param parsing and empty query handling
- Bump to v0.7.2

## Motivation

The Hydra login handler needs `login_challenge` from the query string. Currently
`req.query` is a raw string requiring manual parsing in every app. This adds
automatic parsing so apps can use `req.params.login_challenge` directly.

## Test plan

- [x] `cargo clippy` — zero warnings
- [x] `cargo test --test http_serve` — 13/13 pass (2 new)
- [ ] CI passes on both platforms