### PR TITLE
feat: v0.8.0 — Ory stack SDK and multi-value response headers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,14 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
         with:
-          key: ${{ matrix.target }}
+          # Shared across all branches — cache is only invalidated when
+          # Cargo.lock changes (new deps). Dramatically cuts CI time for
+          # PRs that don't touch dependencies (most of them).
+          shared-key: ${{ matrix.target }}-v2
+          # Cache all crates (including dev-dependencies like wiremock)
+          cache-all-crates: "true"
+          # Save cache even if tests fail, so next run has partial builds
+          save-if: "true"
 
       - name: Install protoc
         uses: arduino/setup-protoc@v3
@@ -51,9 +58,14 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Clippy (warnings = errors)
+        timeout-minutes: 10
         run: cargo clippy --tests --target ${{ matrix.target }} -- -D warnings
 
       - name: Tests
+        # Global safety timeout — no individual test should hang more than
+        # a few seconds; if the step takes longer than 8 minutes something
+        # is wrong and we fail fast instead of waiting for CI timeout
+        timeout-minutes: 8
         run: cargo test --target ${{ matrix.target }}
 
       # Formatting is enforced by dprint locally (not rustfmt)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,9 +68,9 @@ spec:
       restartPolicy: Never
 ```
 
-## Built-in Globals
+## Builtins
 
-Available in all `.lua` scripts — no `require` needed:
+Available as globals in all `.lua` scripts — no `require` needed:
 
 | Category       | Functions                                                                                                                                                                                                                                                           |
 | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ Key coding practices for this project:
 
 General-purpose enhanced Lua runtime. Single ~9 MB static binary with batteries included: HTTP
 client/server, JSON/YAML/TOML, crypto, database, WebSocket, filesystem, shell execution, process
-management, async, and 29 embedded stdlib modules for infrastructure services (Kubernetes,
+management, async, and 33 embedded stdlib modules for infrastructure services (Kubernetes,
 Prometheus, Vault, ArgoCD, etc.) and AI agent integrations (OpenClaw, GitHub, Gmail, Google
 Calendar).
 
@@ -74,7 +74,7 @@ Available in all `.lua` scripts — no `require` needed:
 
 | Category       | Functions                                                                                                                                                                                                                                                           |
 | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| HTTP           | `http.get(url, opts?)`, `http.post(url, body, opts?)`, `http.put(url, body, opts?)`, `http.patch(url, body, opts?)`, `http.delete(url, opts?)`, `http.serve(port, routes)`                                                                                          |
+| HTTP           | `http.get(url, opts?)`, `http.post(url, body, opts?)`, `http.put(url, body, opts?)`, `http.patch(url, body, opts?)`, `http.delete(url, opts?)`, `http.serve(port, routes)` — `http.serve` response handlers accept array header values to emit the same header name multiple times (e.g., multiple `Set-Cookie`) |
 | JSON/YAML/TOML | `json.parse(str)`, `json.encode(tbl)`, `yaml.parse(str)`, `yaml.encode(tbl)`, `toml.parse(str)`, `toml.encode(tbl)`                                                                                                                                                 |
 | Filesystem     | `fs.read(path)`, `fs.write(path, str)`, `fs.remove(path)`, `fs.list(path)`, `fs.stat(path)`, `fs.mkdir(path)`, `fs.exists(path)`, `fs.copy(src, dst)`, `fs.rename(src, dst)`, `fs.glob(pattern)`, `fs.tempdir()`, `fs.chmod(path, mode)`, `fs.readdir(path, opts?)` |
 | Crypto         | `crypto.jwt_sign(claims, key, alg, opts?)`, `crypto.hash(str, alg)`, `crypto.hmac(key, data, alg?, raw?)`, `crypto.random(len)`                                                                                                                                     |
@@ -120,12 +120,29 @@ return {
 
 Custom headers override defaults: `headers = { ["content-type"] = "text/html" }`.
 
+Header values can be either a string or an array of strings. Array values emit the same header
+name multiple times — required for `Set-Cookie` with multiple cookies and useful for `Link`,
+`Vary`, `Cache-Control`, etc.:
+
+```lua
+return {
+  status = 200,
+  headers = {
+    ["Set-Cookie"] = {
+      "session=abc; Path=/; HttpOnly",
+      "csrf=xyz; Path=/",
+    },
+  },
+  body = "ok",
+}
+```
+
 SSE `send()` accepts: `event` (string), `data` (string), `id` (string), `retry` (integer). `event`
 and `id` must not contain newlines. `data` handles multi-line automatically.
 
 ## Stdlib Modules
 
-29 embedded Lua modules loaded via `require("assay.<name>")`:
+33 embedded Lua modules loaded via `require("assay.<name>")`:
 
 | Module                | Description                                                                       |
 | --------------------- | --------------------------------------------------------------------------------- |
@@ -143,6 +160,11 @@ and `id` must not contain newlines. `data` handles multi-line automatically.
 | `assay.certmanager`   | Certificates, issuers, ACME challenges                                            |
 | `assay.eso`           | ExternalSecrets, SecretStores, ClusterSecretStores                                |
 | `assay.dex`           | OIDC discovery, JWKS, health                                                      |
+| `assay.zitadel`       | OIDC identity management with JWT machine auth                                    |
+| `assay.kratos`        | Ory Kratos identity — login/registration/recovery/settings flows, identities, sessions, schemas |
+| `assay.hydra`         | Ory Hydra OAuth2/OIDC — clients, authorize URLs, tokens, login/consent, introspection, JWKs |
+| `assay.keto`          | Ory Keto ReBAC — relation tuples, permission checks, role/group membership, expand |
+| `assay.ory`           | Convenience wrapper re-exporting kratos/hydra/keto with `ory.connect(opts)`       |
 | `assay.crossplane`    | Providers, XRDs, compositions, managed resources                                  |
 | `assay.velero`        | Backups, restores, schedules, storage locations                                   |
 | `assay.temporal`      | Workflows, task queues, schedules, signals + native gRPC client (temporal feature) |
@@ -150,7 +172,6 @@ and `id` must not contain newlines. `data` handles multi-line automatically.
 | `assay.healthcheck`   | HTTP checks, JSON path, body matching, latency, multi-check                       |
 | `assay.s3`            | S3-compatible storage (AWS, R2, MinIO) with Sig V4                                |
 | `assay.postgres`      | Postgres-specific helpers                                                         |
-| `assay.zitadel`       | OIDC identity management with JWT machine auth                                    |
 | `assay.unleash`       | Feature flags: projects, environments, features, strategies, API tokens           |
 | `assay.openclaw`      | OpenClaw AI agent platform — invoke tools, state, diff, approve, LLM tasks        |
 | `assay.github`        | GitHub REST API — PRs, issues, actions, repos, GraphQL                            |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,51 @@
 
 All notable changes to Assay are documented here.
 
+## [0.8.0] - 2026-04-07
+
+### Added
+
+- **Ory stack stdlib modules** — full Lua SDK for the Ory identity/authorization stack:
+  - **`assay.kratos`** — Identity management. Login/registration/recovery/settings flows,
+    identity CRUD via admin API, session introspection (`whoami`), schema management.
+  - **`assay.hydra`** — OAuth2 and OpenID Connect. Client CRUD, authorize URL builder,
+    token exchange (authorization_code grant), accept/reject login and consent challenges,
+    token introspection, JWK endpoint.
+  - **`assay.keto`** — Relationship-based access control. Relation-tuple CRUD, permission
+    checks (Zanzibar-style), role/group membership queries, expand API for role inheritance.
+  - **`assay.ory`** — Convenience wrapper that re-exports all three modules, with
+    `ory.connect(opts)` to build all three clients from one options table.
+
+  Pure Lua wrappers over the Ory REST APIs. Zero new Rust dependencies — binary size
+  unchanged. Each module follows the standard `M.client(url, opts)` pattern with
+  comprehensive `@quickref` metadata for `assay context` discovery.
+
+- **Multi-value response headers in `http.serve`**: Header values can now be a Lua
+  array of strings, emitting the same header name multiple times. Required for
+  `Set-Cookie` when setting multiple cookies in one response, and for other headers
+  that legitimately repeat (e.g., `Link`, `Vary`, `Cache-Control`).
+
+  ```lua
+  return {
+    status = 200,
+    headers = {
+      ["Set-Cookie"] = {
+        "session=abc; Path=/",
+        "csrf=xyz; Path=/",
+      },
+    },
+  }
+  ```
+
+  String values continue to work as before.
+
+### Theme
+
+This is the **identity and auth stack** release. Assay now ships with a complete SDK
+for building OIDC-integrated apps on Ory: one app can handle Hydra login/consent
+challenges, query Keto permissions, and manage Kratos identities — all in idiomatic
+Lua with zero external dependencies beyond the existing assay binary.
+
 ## [0.7.2] - 2026-04-07
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "assay-lua"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-lua"
-version = "0.7.2"
+version = "0.8.0"
 categories = ["command-line-utilities", "development-tools::testing"]
 edition = "2024"
 homepage = "https://assay.rs"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Assay
 
-Replaces your entire infrastructure scripting toolchain. One 9 MB binary, 46 built-in modules.
+Replaces your entire infrastructure scripting toolchain. One 9 MB binary, 50 built-in modules.
 
 [![CI](https://github.com/developerinlondon/assay/actions/workflows/ci.yml/badge.svg)](https://github.com/developerinlondon/assay/actions/workflows/ci.yml)
 [![Crates.io](https://img.shields.io/crates/v/assay-lua.svg)](https://crates.io/crates/assay-lua)
@@ -10,7 +10,7 @@ Replaces your entire infrastructure scripting toolchain. One 9 MB binary, 46 bui
 
 A single ~9 MB static binary that replaces 50-250 MB Python/Node/kubectl containers in Kubernetes.
 Full-featured Lua 5.5 runtime with HTTP client/server, database, WebSocket, JWT, templates, native
-Temporal gRPC workflows, and 29 embedded stdlib modules for Kubernetes, monitoring, security, and
+Temporal gRPC workflows, and 33 embedded stdlib modules for Kubernetes, monitoring, security, and
 AI agent integrations.
 
 ```bash
@@ -18,7 +18,7 @@ assay script.lua     # Run Lua with all builtins
 assay checks.yaml    # Structured checks with retry/backoff/JSON output
 assay exec -e 'log.info("hello")'   # Inline evaluation
 assay context "grafana"              # LLM-ready module docs
-assay modules                        # List all 46+ modules
+assay modules                        # List all 50+ modules
 ```
 
 Scripts that call `http.serve()` become web services. Scripts that call `http.get()` and exit are
@@ -65,7 +65,7 @@ All builtins are available globally in `.lua` scripts — no `require` needed.
 | `http.get(url, opts?)` | GET request, returns `{status, body, headers}` |
 | `http.post(url, body, opts?)` | POST (auto-JSON if body is table) |
 | `http.put/patch/delete(url, ...)` | PUT, PATCH, DELETE |
-| `http.serve(port, routes)` | HTTP server with async handlers + SSE streaming |
+| `http.serve(port, routes)` | HTTP server with async handlers + SSE streaming (header values can be strings or arrays — array values emit the header multiple times for `Set-Cookie`, `Link`, `Vary`, etc.) |
 | `ws.connect(url)` | WebSocket client (`send`, `recv`, `close`) |
 
 ### Serialization
@@ -132,7 +132,7 @@ All builtins are available globally in `.lua` scripts — no `require` needed.
 
 ## Stdlib Modules
 
-29 embedded Lua modules loaded via `require("assay.<name>")`. All follow the client pattern:
+33 embedded Lua modules loaded via `require("assay.<name>")`. All follow the client pattern:
 `M.client(url, opts)` then `c:method()`.
 
 | Module | Description |
@@ -154,6 +154,10 @@ All builtins are available globally in `.lua` scripts — no `require` needed.
 | `assay.eso` | ExternalSecrets, SecretStores |
 | `assay.dex` | OIDC discovery, JWKS |
 | `assay.zitadel` | OIDC identity, JWT machine auth |
+| `assay.kratos` | Ory Kratos — login/registration/recovery flows, identities, sessions |
+| `assay.hydra` | Ory Hydra — OAuth2/OIDC clients, authorize, tokens, login/consent |
+| `assay.keto` | Ory Keto — ReBAC relation tuples, permission checks, expand |
+| `assay.ory` | Ory stack wrapper — `ory.connect()` builds kratos/hydra/keto in one call |
 | **Infrastructure** | |
 | `assay.crossplane` | Providers, XRDs, compositions |
 | `assay.velero` | Backups, restores, schedules |
@@ -196,6 +200,20 @@ http.serve(8080, {
   GET = {
     ["/health"] = function(req)
       return { status = 200, json = { ok = true } }
+    end,
+    ["/login"] = function(req)
+      -- Array header values emit the same header name multiple times.
+      -- Required for setting multiple Set-Cookie values in one response.
+      return {
+        status = 200,
+        headers = {
+          ["Set-Cookie"] = {
+            "session=abc; Path=/; HttpOnly",
+            "csrf=xyz; Path=/",
+          },
+        },
+        json = { ok = true },
+      }
     end,
     ["/events"] = function(req)
       return {
@@ -278,7 +296,7 @@ Find the right module before writing code:
 ```bash
 assay context "grafana"   # Returns method signatures for LLM prompts
 assay context "vault"     # Exact API docs, no hallucination
-assay modules             # List all 46+ modules
+assay modules             # List all 50+ modules
 ```
 
 Custom modules: place `.lua` files in `./modules/` (project) or `~/.assay/modules/` (global).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Assay
 
-Replaces your entire infrastructure scripting toolchain. One 9 MB binary, 50 built-in modules.
+Replaces your entire infrastructure scripting toolchain. One 9 MB binary, 50 modules.
 
 [![CI](https://github.com/developerinlondon/assay/actions/workflows/ci.yml/badge.svg)](https://github.com/developerinlondon/assay/actions/workflows/ci.yml)
 [![Crates.io](https://img.shields.io/crates/v/assay-lua.svg)](https://crates.io/crates/assay-lua)
@@ -54,9 +54,9 @@ docker pull ghcr.io/developerinlondon/assay:latest
 cargo install assay-lua
 ```
 
-## Built-in API Reference
+## Builtins API Reference
 
-All builtins are available globally in `.lua` scripts — no `require` needed.
+All 17 Rust builtins are available globally in `.lua` scripts — no `require` needed.
 
 ### HTTP & Networking
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: assay
-description: Infrastructure scripting runtime — 46 built-in modules for Kubernetes, ArgoCD, Vault, Prometheus, HTTP servers, AI agents, databases. Replaces kubectl, Python, Node.js, curl, jq in one 9 MB binary.
+description: Infrastructure scripting runtime — 50 built-in modules for Kubernetes, ArgoCD, Vault, Prometheus, HTTP servers, AI agents, databases. Replaces kubectl, Python, Node.js, curl, jq in one 9 MB binary.
 metadata:
   author: developerinlondon
   version: "0.6.1"
@@ -44,7 +44,7 @@ assay modules
 | `assay exec -e 'lua code'`  | Evaluate Lua inline                           |
 | `assay exec script.lua`     | Run Lua file via exec subcommand              |
 | `assay context "<keyword>"` | Find modules matching keyword, shows quickref |
-| `assay modules`             | List all 46 modules (29 stdlib + 17 builtins) |
+| `assay modules`             | List all 50 modules (33 stdlib + 17 builtins) |
 
 ## Discovering Modules
 
@@ -122,6 +122,25 @@ These are always available in every `.lua` script.
 | `http.serve(port, routes)`     | Start HTTP server (async handlers)             |
 
 Options: `{ headers = { ["X-Key"] = "value" } }`
+
+`http.serve` response handlers accept array values for headers to emit the same header name
+multiple times — required for `Set-Cookie` with multiple cookies, and useful for `Link`, `Vary`,
+`Cache-Control`, etc.:
+
+```lua
+return {
+  status = 200,
+  headers = {
+    ["Set-Cookie"] = {
+      "session=abc; Path=/; HttpOnly",
+      "csrf=xyz; Path=/",
+    },
+  },
+  body = "ok",
+}
+```
+
+String header values still work as before.
 
 ### Serialization
 
@@ -233,7 +252,7 @@ Available when built with `--features temporal`. Native gRPC client for Temporal
 
 ## Stdlib Modules Quick Reference
 
-All 29 modules follow `require("assay.<name>")` then `M.client(url, opts)`.
+All 33 modules follow `require("assay.<name>")` then `M.client(url, opts)`.
 
 | Module                | Description                                                                |
 | --------------------- | -------------------------------------------------------------------------- |
@@ -251,6 +270,11 @@ All 29 modules follow `require("assay.<name>")` then `M.client(url, opts)`.
 | `assay.certmanager`   | Certificates, issuers, ACME orders and challenges                          |
 | `assay.eso`           | ExternalSecrets, SecretStores, ClusterSecretStores sync status             |
 | `assay.dex`           | OIDC discovery, JWKS, health, configuration validation                     |
+| `assay.zitadel`       | OIDC identity management with JWT machine auth                             |
+| `assay.kratos`        | Ory Kratos — login/registration/recovery/settings flows, identities, sessions |
+| `assay.hydra`         | Ory Hydra OAuth2/OIDC — clients, authorize URLs, tokens, login/consent, JWKs |
+| `assay.keto`          | Ory Keto ReBAC — relation tuples, permission checks, expand                |
+| `assay.ory`           | Convenience wrapper — `ory.connect()` builds kratos/hydra/keto clients together |
 | `assay.crossplane`    | Providers, XRDs, compositions, managed resources                           |
 | `assay.velero`        | Backups, restores, schedules, storage locations                            |
 | `assay.temporal`      | Workflows, task queues, schedules, signals + native gRPC (temporal feature)|
@@ -258,7 +282,6 @@ All 29 modules follow `require("assay.<name>")` then `M.client(url, opts)`.
 | `assay.healthcheck`   | HTTP checks, JSON path, body matching, latency, multi-check                |
 | `assay.s3`            | S3-compatible storage (AWS, R2, MinIO) with Sig V4 auth                    |
 | `assay.postgres`      | Postgres helpers: users, databases, grants, Vault integration              |
-| `assay.zitadel`       | OIDC identity management with JWT machine auth                             |
 | `assay.unleash`       | Feature flags: projects, environments, features, strategies, tokens        |
 | `assay.openclaw`      | OpenClaw AI agent — invoke tools, state, diff, approve, LLM tasks          |
 | `assay.github`        | GitHub REST API — PRs, issues, actions, repos, GraphQL                     |
@@ -469,7 +492,7 @@ hardcode credentials in scripts.
 **Shebang scripts**: Add `#!/usr/bin/assay` as the first line and `chmod +x script.lua` to run
 scripts directly without the `assay` prefix.
 
-**Module not found**: All 29 stdlib modules are embedded in the binary. If `require("assay.foo")`
+**Module not found**: All 33 stdlib modules are embedded in the binary. If `require("assay.foo")`
 fails, run `assay modules` to see the exact module names.
 
 **Lua 5.5 specifics**: Assay uses Lua 5.5 (not LuaJIT). Integer division is `//`, bitwise ops use

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: assay
-description: Infrastructure scripting runtime — 50 built-in modules for Kubernetes, ArgoCD, Vault, Prometheus, HTTP servers, AI agents, databases. Replaces kubectl, Python, Node.js, curl, jq in one 9 MB binary.
+description: Infrastructure scripting runtime — 50 modules for Kubernetes, ArgoCD, Vault, Prometheus, HTTP servers, AI agents, databases. Replaces kubectl, Python, Node.js, curl, jq in one 9 MB binary.
 metadata:
   author: developerinlondon
   version: "0.6.1"
@@ -106,7 +106,7 @@ local c = grafana.client(url, { api_key = "glsa_..." })
 local c = grafana.client(url, { username = "admin", password = "secret" })
 ```
 
-## Built-in Functions (no require needed)
+## Builtins (no require needed)
 
 These are always available in every `.lua` script.
 
@@ -584,7 +584,7 @@ Today: use `assay context <query>` from terminal and paste output into agent con
 
 ## MCP-Serve Vision (v0.6.0)
 
-`assay mcp-serve` will expose all 40+ modules as MCP tools over stdio/SSE transport:
+`assay mcp-serve` will expose all 50 modules (33 stdlib + 17 builtins) as MCP tools over stdio/SSE transport:
 
 - Each stdlib module becomes an MCP tool (e.g., `grafana_health`, `k8s_pods`)
 - Each builtin becomes an MCP tool (e.g., `http_get`, `crypto_jwt_sign`)

--- a/llms.txt
+++ b/llms.txt
@@ -1,7 +1,7 @@
 # Assay
 
 > Assay is a ~9 MB static binary that runs Lua scripts in Kubernetes. It replaces 50-250 MB
-> Python/Node/kubectl containers. One binary handles HTTP, database, crypto, WebSocket, and 29
+> Python/Node/kubectl containers. One binary handles HTTP, database, crypto, WebSocket, and 33
 > Kubernetes-native and AI agent service integrations. No `require()` for builtins — they are global.
 > Stdlib modules use `require("assay.<name>")` then `M.client(url, opts)` → `c:method()`.
 > Run `assay context <query>` to get LLM-ready method signatures for any module.
@@ -12,7 +12,7 @@
 - [SKILL.md](https://github.com/developerinlondon/assay/blob/main/SKILL.md): LLM agent integration guide
 - [GitHub](https://github.com/developerinlondon/assay): Source code and issues
 
-## Built-in Globals (no require needed)
+## Builtins (no require needed)
 - [http](https://assay.rs/modules.html#http): HTTP client and server — http.get/post/put/patch/delete/serve
 - [json](https://assay.rs/modules.html#json): JSON parse and encode
 - [yaml](https://assay.rs/modules.html#yaml): YAML parse and encode

--- a/openclaw-extension/SKILL.md
+++ b/openclaw-extension/SKILL.md
@@ -6,7 +6,7 @@ Assay executes Lua workflows for infrastructure automation, AI agent orchestrati
 
 - Multi-step infrastructure tasks that should live in a checked-in Lua script
 - Scheduled or repeatable workflows with deterministic behavior
-- Data processing or service automation that benefits from Assay's built-in HTTP, JSON, DB, and filesystem support
+- Data processing or service automation that benefits from Assay's builtin HTTP, JSON, DB, and filesystem support
 - Tasks that may pause for human approval and resume later
 - Workflows that need Assay stdlib modules for Kubernetes, GitOps, observability, identity, storage, or AI agents
 

--- a/site/agent-guides.html
+++ b/site/agent-guides.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Assay — AI Agent Integration Guides</title>
-  <meta name="description" content="Integration guides for Claude Code, Cursor, Windsurf, Cline, and OpenCode — use Assay's 46 modules in your AI coding agent.">
+  <meta name="description" content="Integration guides for Claude Code, Cursor, Windsurf, Cline, and OpenCode — use Assay's 50 modules in your AI coding agent.">
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -26,12 +26,12 @@
   <main>
     <h1>AI Agent Integration Guides</h1>
     <p style="font-size: 1.15rem; color: var(--text-secondary); margin-bottom: 2rem;">
-      Use Assay's 46 modules in Claude Code, Cursor, Windsurf, Cline, and OpenCode.
+      Use Assay's 50 modules in Claude Code, Cursor, Windsurf, Cline, and OpenCode.
     </p>
 
     <h2>How It Works</h2>
     <p>
-      Your AI agent writes Lua scripts that use Assay's built-in modules. Two ways to give
+      Your AI agent writes Lua scripts that use Assay's stdlib modules. Two ways to give
       your agent knowledge of the modules:
     </p>
     <ol>
@@ -167,7 +167,7 @@ assert.not_nil(result)
 assay script.lua</code></pre>
 
     <p>
-      All 29 stdlib modules follow the same pattern: <code>require</code>, <code>client()</code>,
+      All 33 stdlib modules follow the same pattern: <code>require</code>, <code>client()</code>,
       <code>c:method()</code>. Learn one, know them all.
     </p>
 

--- a/site/comparison.html
+++ b/site/comparison.html
@@ -123,7 +123,7 @@
     <p>26 domains with full coverage, 3 partial. Each would otherwise need a separate MCP server (npm process).</p>
 
     <h2>How to Use</h2>
-    <p>Assay is a Lua scripting runtime, not an MCP server. Your AI agent writes scripts using Assay's built-in modules. Use <code>assay context "&lt;query&gt;"</code> for LLM-ready docs.</p>
+    <p>Assay is a Lua scripting runtime, not an MCP server. Your AI agent writes scripts using Assay's stdlib modules. Use <code>assay context "&lt;query&gt;"</code> for LLM-ready docs.</p>
 
     <h2>Full Coverage (26 domains)</h2>
     <table>

--- a/site/index.html
+++ b/site/index.html
@@ -221,7 +221,7 @@ checks:
 
     <!-- Size & Speed -->
     <p style="padding: 1rem; border: 1px solid var(--border); border-radius: 8px; margin-bottom: 1rem;">
-      <strong>9 MB static binary</strong> &mdash; <code>FROM scratch</code>, 5 ms cold start, 21x smaller than postman/newman.
+      <strong>9 MB static binary</strong> &mdash; <code>FROM scratch</code>, 5 ms cold start, 14x smaller than postman/newman.
       <a href="comparison.html">See full size &amp; speed comparison &rarr;</a>
     </p>
 
@@ -257,10 +257,10 @@ checks:
       </thead>
       <tbody>
         <tr style="font-weight: 600; color: var(--accent);"><td>Assay</td><td>9 MB</td><td>1x</td></tr>
-        <tr><td>alpine/python</td><td>17 MB</td><td>3x</td></tr>
-        <tr><td>bitnami/kubectl</td><td>35 MB</td><td>6x</td></tr>
-        <tr><td>Node.js alpine</td><td>57 MB</td><td>12x</td></tr>
-        <tr><td>alpine/k8s</td><td>60 MB</td><td>10x</td></tr>
+        <tr><td>alpine/python</td><td>17 MB</td><td>2x</td></tr>
+        <tr><td>bitnami/kubectl</td><td>35 MB</td><td>4x</td></tr>
+        <tr><td>Node.js alpine</td><td>57 MB</td><td>6x</td></tr>
+        <tr><td>alpine/k8s</td><td>60 MB</td><td>7x</td></tr>
       </tbody>
     </table>
 

--- a/site/index.html
+++ b/site/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Assay — Infrastructure Testing &amp; Automation Runtime</title>
-  <meta name="description" content="Assay is a 9 MB Lua runtime for infrastructure testing, Kubernetes automation, HTTP servers, and AI agent integration. 46 built-in modules. Replaces kubectl, Python, Node.js, curl, jq.">
+  <meta name="description" content="Assay is a 9 MB Lua runtime for infrastructure testing, Kubernetes automation, HTTP servers, and AI agent integration. 50 built-in modules. Replaces kubectl, Python, Node.js, curl, jq.">
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -28,7 +28,7 @@
     <div style="padding: 1.5rem 0 1rem; border-bottom: 1px solid var(--border); margin-bottom: 1rem;">
       <div style="font-size: 1.4rem; font-weight: 700; margin-bottom: 0.3rem;">Replaces your entire infrastructure scripting toolchain.</div>
       <div style="display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 0.75rem;">
-        <span class="text-muted">One 9 MB binary. 46 built-in modules. Linux, macOS, Docker, <a href="https://crates.io/crates/assay-lua">Rust crate</a>.</span>
+        <span class="text-muted">One 9 MB binary. 50 built-in modules. Linux, macOS, Docker, <a href="https://crates.io/crates/assay-lua">Rust crate</a>.</span>
         <div style="display: flex; gap: 0.5rem; flex-shrink: 0;">
           <a href="modules.html" style="display: inline-block; background-color: var(--accent); color: #fff; padding: 0.4rem 1rem; border-radius: 4px; font-size: 0.85rem; font-weight: 600; text-decoration: none;">Modules</a>
           <a href="#install" style="display: inline-block; color: var(--accent); border: 1px solid var(--accent); padding: 0.4rem 1rem; border-radius: 4px; font-size: 0.85rem; font-weight: 600; text-decoration: none;">Install</a>
@@ -109,7 +109,7 @@
         <div style="font-size: 0.7rem;" class="text-muted">TLS certs</div>
       </a>
       <a href="modules.html" class="card" style="text-align: center; text-decoration: none; color: var(--accent); padding: 1rem 0.5rem;">
-        <div style="font-size: 1.4rem; font-weight: 700; margin-bottom: 0.3rem;">+31</div>
+        <div style="font-size: 1.4rem; font-weight: 700; margin-bottom: 0.3rem;">+35</div>
         <div style="font-weight: 600; font-size: 0.8rem;">More</div>
         <div style="font-size: 0.7rem;">View all &rarr;</div>
       </a>
@@ -122,7 +122,7 @@
         <div class="text-muted" style="font-size: 0.8rem;">Static binary</div>
       </div>
       <div style="text-align: center; padding: 1rem; border: 1px solid var(--border); border-radius: 8px;">
-        <div style="font-size: 1.8rem; font-weight: 700; color: var(--accent);">46</div>
+        <div style="font-size: 1.8rem; font-weight: 700; color: var(--accent);">50</div>
         <div class="text-muted" style="font-size: 0.8rem;">Built-in modules</div>
       </div>
       <div style="text-align: center; padding: 1rem; border: 1px solid var(--border); border-radius: 8px;">
@@ -140,12 +140,20 @@
     <section style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1.5rem; margin-bottom: 2rem;">
       <div class="card">
         <h3 style="margin-top: 0;">HTTP Server &amp; SSE</h3>
-        <p class="text-muted">Build web services with async route handlers. Handlers can call http.get, sleep, and any async builtin. SSE streaming built in.</p>
+        <p class="text-muted">Build web services with async route handlers. Handlers can call http.get, sleep, and any async builtin. SSE streaming built in. Header values can be arrays for multiple <code>Set-Cookie</code>, <code>Link</code>, etc.</p>
         <pre style="margin-bottom: 0;"><code>http.serve(8080, {
   GET = {
-    ["/api"] = function(req)
-      local resp = http.get(API_URL)
-      return { status = 200, json = resp }
+    ["/login"] = function(req)
+      return {
+        status = 200,
+        headers = {
+          ["Set-Cookie"] = {
+            "session=abc; Path=/",
+            "csrf=xyz; Path=/",
+          },
+        },
+        json = { ok = true },
+      }
     end
   }
 })</code></pre>

--- a/site/index.html
+++ b/site/index.html
@@ -108,8 +108,18 @@
         <div style="font-weight: 600; font-size: 0.8rem;">cert-manager</div>
         <div style="font-size: 0.7rem;" class="text-muted">TLS certs</div>
       </a>
+      <a href="modules.html#ory" class="card" style="text-align: center; text-decoration: none; color: var(--text); padding: 1rem 0.5rem;">
+        <div style="margin-bottom: 0.3rem;"><svg width="24" height="24" viewBox="0 0 24 24" fill="var(--accent)"><path d="M12 2L3 7v6c0 5.55 3.84 10.74 9 12 5.16-1.26 9-6.45 9-12V7l-9-5zm0 4l6 3.33v3.34c0 3.77-2.55 7.39-6 8.5-3.45-1.11-6-4.73-6-8.5V9.33L12 6zm-1 5v2H9v2h2v2h2v-2h2v-2h-2v-2h-2z"/></svg></div>
+        <div style="font-weight: 600; font-size: 0.8rem;">Ory Stack</div>
+        <div style="font-size: 0.7rem;" class="text-muted">Kratos/Hydra/Keto</div>
+      </a>
+      <a href="modules.html#zitadel" class="card" style="text-align: center; text-decoration: none; color: var(--text); padding: 1rem 0.5rem;">
+        <div style="margin-bottom: 0.3rem;"><svg width="24" height="24" viewBox="0 0 24 24" fill="var(--accent)"><path d="M12 2a10 10 0 100 20 10 10 0 000-20zm0 5a3 3 0 110 6 3 3 0 010-6zm0 13a7 7 0 01-5.6-2.8c0-1.9 3.7-2.9 5.6-2.9 1.9 0 5.6 1 5.6 2.9A7 7 0 0112 20z"/></svg></div>
+        <div style="font-weight: 600; font-size: 0.8rem;">Zitadel</div>
+        <div style="font-size: 0.7rem;" class="text-muted">OIDC identity</div>
+      </a>
       <a href="modules.html" class="card" style="text-align: center; text-decoration: none; color: var(--accent); padding: 1rem 0.5rem;">
-        <div style="font-size: 1.4rem; font-weight: 700; margin-bottom: 0.3rem;">+35</div>
+        <div style="font-size: 1.4rem; font-weight: 700; margin-bottom: 0.3rem;">+33</div>
         <div style="font-weight: 600; font-size: 0.8rem;">More</div>
         <div style="font-size: 0.7rem;">View all &rarr;</div>
       </a>

--- a/site/index.html
+++ b/site/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Assay — Infrastructure Testing &amp; Automation Runtime</title>
-  <meta name="description" content="Assay is a 9 MB Lua runtime for infrastructure testing, Kubernetes automation, HTTP servers, and AI agent integration. 50 built-in modules. Replaces kubectl, Python, Node.js, curl, jq.">
+  <meta name="description" content="Assay is a 9 MB Lua runtime for infrastructure testing, Kubernetes automation, HTTP servers, and AI agent integration. 50 modules. Replaces kubectl, Python, Node.js, curl, jq.">
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -28,7 +28,7 @@
     <div style="padding: 1.5rem 0 1rem; border-bottom: 1px solid var(--border); margin-bottom: 1rem;">
       <div style="font-size: 1.4rem; font-weight: 700; margin-bottom: 0.3rem;">Replaces your entire infrastructure scripting toolchain.</div>
       <div style="display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 0.75rem;">
-        <span class="text-muted">One 9 MB binary. 50 built-in modules. Linux, macOS, Docker, <a href="https://crates.io/crates/assay-lua">Rust crate</a>.</span>
+        <span class="text-muted">One 9 MB binary. 50 modules. Linux, macOS, Docker, <a href="https://crates.io/crates/assay-lua">Rust crate</a>.</span>
         <div style="display: flex; gap: 0.5rem; flex-shrink: 0;">
           <a href="modules.html" style="display: inline-block; background-color: var(--accent); color: #fff; padding: 0.4rem 1rem; border-radius: 4px; font-size: 0.85rem; font-weight: 600; text-decoration: none;">Modules</a>
           <a href="#install" style="display: inline-block; color: var(--accent); border: 1px solid var(--accent); padding: 0.4rem 1rem; border-radius: 4px; font-size: 0.85rem; font-weight: 600; text-decoration: none;">Install</a>
@@ -123,7 +123,7 @@
       </div>
       <div style="text-align: center; padding: 1rem; border: 1px solid var(--border); border-radius: 8px;">
         <div style="font-size: 1.8rem; font-weight: 700; color: var(--accent);">50</div>
-        <div class="text-muted" style="font-size: 0.8rem;">Built-in modules</div>
+        <div class="text-muted" style="font-size: 0.8rem;">Modules</div>
       </div>
       <div style="text-align: center; padding: 1rem; border: 1px solid var(--border); border-radius: 8px;">
         <div style="font-size: 1.8rem; font-weight: 700; color: var(--accent);">Lua 5.5</div>
@@ -196,7 +196,7 @@ local jwt = crypto.jwt_sign(
       </div>
       <div class="card">
         <h3 style="margin-top: 0;">Infrastructure Testing</h3>
-        <p class="text-muted">Built-in assertions, structured YAML checks with retry and backoff. Verify deployments, health endpoints, and service readiness.</p>
+        <p class="text-muted">Builtin assertions, structured YAML checks with retry and backoff. Verify deployments, health endpoints, and service readiness.</p>
         <pre style="margin-bottom: 0;"><code># checks.yaml — retry + backoff
 checks:
   - name: api-healthy

--- a/site/llms-full.txt
+++ b/site/llms-full.txt
@@ -1,7 +1,7 @@
 # Assay
 
 > Assay is a ~9 MB static binary that runs Lua scripts in Kubernetes. It replaces 50-250 MB
-> Python/Node/kubectl containers. One binary handles HTTP, database, crypto, WebSocket, and 29
+> Python/Node/kubectl containers. One binary handles HTTP, database, crypto, WebSocket, and 33
 > Kubernetes-native and AI agent service integrations. No `require()` for builtins — they are global.
 > Stdlib modules use `require("assay.<name>")` then `M.client(url, opts)` → `c:method()`.
 > Run `assay context <query>` to get LLM-ready method signatures for any module.
@@ -32,6 +32,21 @@ Options table supports `{headers = {["X-Key"] = "value"}}`.
   - Routes: `{GET = {["/path"] = function(req) return {status=200, body="ok"} end}}`
   - Handlers receive `{method, path, body, headers, query}`, return `{status, body, json?, headers?}`
   - Handlers can call async builtins (`http.get`, `sleep`, etc.)
+  - Header values can be a string or an array of strings. Array values emit the same header
+    name multiple times — required for `Set-Cookie` with multiple cookies, and useful for
+    `Link`, `Vary`, `Cache-Control`, etc.:
+    ```lua
+    return {
+      status = 200,
+      headers = {
+        ["Set-Cookie"] = {
+          "session=abc; Path=/; HttpOnly",
+          "csrf=xyz; Path=/",
+        },
+      },
+      body = "ok",
+    }
+    ```
   - SSE: return `{sse = function(send) send({event="update", data="hello", id="1"}) end}`
     - `send()` accepts: `event`, `data`, `id`, `retry` fields
     - Sets `Content-Type: text/event-stream` automatically
@@ -719,6 +734,125 @@ local proj = c:ensure_project("my-platform")
 local app = c:ensure_oidc_app(proj.id, {
   name = "grafana", subdomain = "grafana", callbackPath = "/login/generic_oauth",
 })
+```
+
+## assay.kratos
+
+Ory Kratos identity management. Self-service login, registration, recovery and settings flows,
+identity CRUD via the admin API, session introspection (whoami), and identity schemas.
+Client: `kratos.client({public_url="...", admin_url="..."})`.
+
+- `c:whoami(cookie_or_token)` → session|nil — Introspect a session (nil on 401)
+- `c:create_login_flow(opts?)` → flow — Initialize a login flow (browser or api)
+- `c:create_registration_flow(opts?)` → flow — Initialize a registration flow
+- `c:create_recovery_flow(opts?)` → flow — Initialize a recovery flow
+- `c:create_settings_flow(opts?)` → flow — Initialize a settings flow
+- `c:submit_login(flow_id, payload)` → `{session, session_token?}` — Submit login flow
+- `c:submit_registration(flow_id, payload)` → `{identity, session?}` — Submit registration flow
+- `c:list_identities(opts?)` → [identity] — Admin: list identities
+- `c:get_identity(id)` → identity|nil — Admin: get identity by ID
+- `c:create_identity(payload)` → identity — Admin: create identity
+- `c:update_identity(id, payload)` → identity — Admin: update identity
+- `c:delete_identity(id)` → bool — Admin: delete identity
+- `c:list_schemas()` → [schema] — List identity schemas
+- `c:get_schema(id)` → schema|nil — Get schema by ID
+
+Example:
+```lua
+local kratos = require("assay.kratos")
+local c = kratos.client({
+  public_url = "http://kratos-public:4433",
+  admin_url = "http://kratos-admin:4434",
+})
+local session = c:whoami(cookie)
+log.info("Logged in as: " .. session.identity.traits.email)
+```
+
+## assay.hydra
+
+Ory Hydra OAuth2 and OpenID Connect server. OAuth2 client CRUD via the admin API,
+authorize URL builder, token exchange, accept/reject login and consent challenges,
+introspection, JWK endpoint, and OIDC discovery.
+Client: `hydra.client({public_url="...", admin_url="..."})`.
+
+- `c:discovery()` → `{issuer, authorization_endpoint, token_endpoint, jwks_uri, ...}` — OIDC discovery
+- `c:jwks()` → `{keys}` — JSON Web Key Set
+- `c:list_clients(opts?)` → [client] — Admin: list OAuth2 clients
+- `c:get_client(id)` → client|nil — Admin: get client by ID
+- `c:create_client(payload)` → client — Admin: create OAuth2 client
+- `c:update_client(id, payload)` → client — Admin: update OAuth2 client
+- `c:delete_client(id)` → bool — Admin: delete OAuth2 client
+- `c:authorize_url(opts)` → string — Build an authorization URL from `{client_id, redirect_uri, scope, state, ...}`
+- `c:exchange_token(opts)` → `{access_token, id_token?, refresh_token?, expires_in}` — Exchange code for tokens
+- `c:introspect(token, scope?)` → `{active, sub, scope, ...}` — Admin introspection
+- `c:accept_login(challenge, payload)` → `{redirect_to}` — Accept a login challenge
+- `c:reject_login(challenge, payload)` → `{redirect_to}` — Reject a login challenge
+- `c:accept_consent(challenge, payload)` → `{redirect_to}` — Accept a consent challenge
+- `c:reject_consent(challenge, payload)` → `{redirect_to}` — Reject a consent challenge
+
+Example:
+```lua
+local hydra = require("assay.hydra")
+local c = hydra.client({
+  public_url = "https://hydra.example.com",
+  admin_url = "http://hydra-admin:4445",
+})
+local client = c:create_client({
+  client_name = "my-app",
+  grant_types = { "authorization_code", "refresh_token" },
+  redirect_uris = { "https://app.example.com/callback" },
+})
+```
+
+## assay.keto
+
+Ory Keto relationship-based access control (Zanzibar-style ReBAC). Relation-tuple CRUD,
+permission checks, role/group membership queries, and the expand API.
+Client: `keto.client({read_url="...", write_url="..."})`.
+
+- `c:check(namespace, object, relation, subject)` → bool — Check if a relation tuple allows access
+- `c:create_tuple(tuple)` → bool — Create a relation tuple `{namespace, object, relation, subject_id|subject_set}`
+- `c:delete_tuple(tuple)` → bool — Delete a relation tuple
+- `c:list_tuples(query)` → [tuple] — List tuples matching query filters
+- `c:expand(namespace, object, relation, depth?)` → tree — Expand a subject tree (Zanzibar expand)
+- `c:list_relations(namespace, object)` → [relation] — List relations for an object
+
+Example:
+```lua
+local keto = require("assay.keto")
+local c = keto.client({
+  read_url = "http://keto-read:4466",
+  write_url = "http://keto-write:4467",
+})
+c:create_tuple({
+  namespace = "apps", object = "cc", relation = "admin",
+  subject_id = "user:alice",
+})
+assert(c:check("apps", "cc", "admin", "user:alice"))
+```
+
+## assay.ory
+
+Convenience wrapper re-exporting `assay.kratos`, `assay.hydra`, and `assay.keto`, with
+`ory.connect(opts)` to build all three clients in a single call.
+
+- `M.kratos` — re-export of `assay.kratos`
+- `M.hydra` — re-export of `assay.hydra`
+- `M.keto` — re-export of `assay.keto`
+- `M.connect(opts)` → `{kratos, hydra, keto}` — Build all three clients. `opts`: `{kratos_public, kratos_admin, hydra_public, hydra_admin, keto_read, keto_write}`
+
+Example:
+```lua
+local ory = require("assay.ory")
+local o = ory.connect({
+  kratos_public = "http://kratos-public:4433",
+  kratos_admin = "http://kratos-admin:4434",
+  hydra_public = "https://hydra.example.com",
+  hydra_admin = "http://hydra-admin:4445",
+  keto_read = "http://keto-read:4466",
+  keto_write = "http://keto-write:4467",
+})
+local allowed = o.keto:check("apps", "cc", "admin", "user:alice")
 ```
 
 ## assay.crossplane

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -12,7 +12,7 @@
 - [SKILL.md](https://github.com/developerinlondon/assay/blob/main/SKILL.md): LLM agent integration guide
 - [GitHub](https://github.com/developerinlondon/assay): Source code and issues
 
-## Built-in Globals (no require needed)
+## Builtins (no require needed)
 - [http](https://assay.rs/modules.html#http): HTTP client, server, SSE streaming — http.get/post/put/patch/delete/serve
 - [json](https://assay.rs/modules.html#json): JSON parse and encode
 - [yaml](https://assay.rs/modules.html#yaml): YAML parse and encode

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -1,7 +1,7 @@
 # Assay
 
 > Assay is a ~9 MB static binary that runs Lua scripts in Kubernetes. It replaces 50-250 MB
-> Python/Node/kubectl containers. One binary handles HTTP, database, crypto, WebSocket, and 29
+> Python/Node/kubectl containers. One binary handles HTTP, database, crypto, WebSocket, and 33
 > Kubernetes-native and AI agent service integrations. No `require()` for builtins — they are global.
 > Stdlib modules use `require("assay.<name>")` then `M.client(url, opts)` → `c:method()`.
 > Run `assay context <query>` to get LLM-ready method signatures for any module.
@@ -51,6 +51,10 @@
 - [assay.eso](https://assay.rs/modules.html#eso): External Secrets Operator
 - [assay.dex](https://assay.rs/modules.html#dex): Dex OIDC discovery, JWKS, health
 - [assay.zitadel](https://assay.rs/modules.html#zitadel): Zitadel OIDC identity, JWT machine auth
+- [assay.kratos](https://assay.rs/modules.html#ory): Ory Kratos identity — login/registration/recovery flows, identities, sessions, schemas
+- [assay.hydra](https://assay.rs/modules.html#ory): Ory Hydra OAuth2/OIDC — clients, authorize URLs, tokens, login/consent, introspection, JWKs
+- [assay.keto](https://assay.rs/modules.html#ory): Ory Keto ReBAC — relation tuples, permission checks, role/group queries, expand
+- [assay.ory](https://assay.rs/modules.html#ory): Ory stack wrapper — `ory.connect()` builds kratos/hydra/keto clients together
 
 ## Infrastructure
 - [assay.crossplane](https://assay.rs/modules.html#crossplane): Crossplane providers, XRDs, compositions

--- a/site/modules.html
+++ b/site/modules.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Assay — Module Reference</title>
-  <meta name="description" content="Complete reference for all 46+ Assay modules — 17 Rust builtins and 29 embedded Lua stdlib modules, zero dependencies.">
+  <meta name="description" content="Complete reference for all 50+ Assay modules — 17 Rust builtins and 33 embedded Lua stdlib modules, zero dependencies.">
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -26,7 +26,7 @@
   <main>
     <h1>Module Reference</h1>
     <p style="font-size: 1.15rem; color: var(--text-secondary); margin-bottom: 1.5rem;">
-      46+ built-in modules, zero dependencies. Use <code>assay context &lt;query&gt;</code> for LLM-ready docs on any module.
+      50+ built-in modules, zero dependencies. Use <code>assay context &lt;query&gt;</code> for LLM-ready docs on any module.
     </p>
 
     <pre><code>assay modules                    # list all modules
@@ -53,7 +53,7 @@ assay context "grafana health"   # get detailed docs for LLM</code></pre>
         <tr>
           <td><code>http</code></td>
           <td><code>http.get/post/put/patch/delete/serve</code></td>
-          <td>HTTP client, server, and SSE streaming</td>
+          <td>HTTP client, server, and SSE streaming. <code>http.serve</code> response headers accept array values to emit the same header name multiple times (e.g., multiple <code>Set-Cookie</code>).</td>
         </tr>
         <tr>
           <td><code>ws</code></td>
@@ -83,6 +83,30 @@ assay context "grafana health"   # get detailed docs for LLM</code></pre>
       and <code>retry</code> fields. SSE headers (<code>text/event-stream</code>, <code>no-cache</code>,
       <code>keep-alive</code>) are set automatically.
     </p>
+
+    <h4>Multi-Value Response Headers</h4>
+    <p>
+      Response handlers can return an array of strings as a header value. Each entry emits the
+      same header name once — required for setting multiple <code>Set-Cookie</code> values in a
+      single response and useful for headers like <code>Link</code>, <code>Vary</code>, and
+      <code>Cache-Control</code>. String values continue to work as before.
+    </p>
+    <pre><code>http.serve(8080, {
+  GET = {
+    ["/login"] = function(req)
+      return {
+        status = 200,
+        headers = {
+          ["Set-Cookie"] = {
+            "session=abc; Path=/; HttpOnly",
+            "csrf=xyz; Path=/",
+          },
+        },
+        json = { ok = true },
+      }
+    end
+  }
+})</code></pre>
 
     <!-- Serialization -->
     <h3>Serialization</h3>
@@ -244,12 +268,12 @@ assay context "grafana health"   # get detailed docs for LLM</code></pre>
     </table>
 
     <!-- ============================================================ -->
-    <!-- STDLIB MODULES (29 modules)                                  -->
+    <!-- STDLIB MODULES (33 modules)                                  -->
     <!-- ============================================================ -->
 
     <h2>Stdlib Modules</h2>
     <p>
-      29 embedded Lua modules loaded via <code>require("assay.&lt;name&gt;")</code>.
+      33 embedded Lua modules loaded via <code>require("assay.&lt;name&gt;")</code>.
       All follow the client pattern: <code>M.client(url, opts)</code> &rarr; client object &rarr; <code>c:method()</code>.
     </p>
 
@@ -385,6 +409,30 @@ assay context "grafana health"   # get detailed docs for LLM</code></pre>
           <td>OIDC identity, JWT machine auth</td>
           <td><code>zitadel.client(url, opts)</code></td>
         </tr>
+        <tr>
+          <td><code>assay.kratos</code></td>
+          <td><code>require("assay.kratos")</code></td>
+          <td>Ory Kratos identity &mdash; login flows, identities, sessions, schemas</td>
+          <td><code>kratos.client({public_url, admin_url})</code></td>
+        </tr>
+        <tr>
+          <td><code>assay.hydra</code></td>
+          <td><code>require("assay.hydra")</code></td>
+          <td>Ory Hydra OAuth2/OIDC &mdash; clients, authorize, tokens, login/consent, JWKs</td>
+          <td><code>hydra.client({public_url, admin_url})</code></td>
+        </tr>
+        <tr>
+          <td><code>assay.keto</code></td>
+          <td><code>require("assay.keto")</code></td>
+          <td>Ory Keto ReBAC &mdash; relation tuples, permission checks, expand</td>
+          <td><code>keto.client({read_url, write_url})</code></td>
+        </tr>
+        <tr>
+          <td><code>assay.ory</code></td>
+          <td><code>require("assay.ory")</code></td>
+          <td>Ory stack wrapper &mdash; builds kratos/hydra/keto clients in one call</td>
+          <td><code>ory.connect({kratos_public, hydra_admin, keto_read, ...})</code></td>
+        </tr>
       </tbody>
     </table>
 
@@ -474,6 +522,42 @@ assay context "grafana health"   # get detailed docs for LLM</code></pre>
         </tr>
       </tbody>
     </table>
+
+    <!-- Ory Stack -->
+    <h3 id="ory">Ory Stack</h3>
+    <p>
+      Complete Ory identity and authorization stack: <strong>Kratos</strong> (identity management,
+      login/registration/recovery flows), <strong>Hydra</strong> (OAuth2 and OpenID Connect server),
+      and <strong>Keto</strong> (Zanzibar-style ReBAC). Each module can be used independently, or
+      combined via the <code>assay.ory</code> convenience wrapper.
+    </p>
+
+    <h5>Example: Build all three clients at once and check a permission</h5>
+    <pre><code>local ory = require("assay.ory")
+
+local o = ory.connect({
+  kratos_public = "http://kratos-public:4433",
+  kratos_admin  = "http://kratos-admin:4434",
+  hydra_public  = "https://hydra.example.com",
+  hydra_admin   = "http://hydra-admin:4445",
+  keto_read     = "http://keto-read:4466",
+  keto_write    = "http://keto-write:4467",
+})
+
+-- Kratos: introspect a session cookie
+local session = o.kratos:whoami(cookie)
+log.info("Logged in as: " .. session.identity.traits.email)
+
+-- Hydra: register an OAuth2 client
+local client = o.hydra:create_client({
+  client_name = "my-app",
+  grant_types = { "authorization_code", "refresh_token" },
+  redirect_uris = { "https://app.example.com/callback" },
+})
+
+-- Keto: check a ReBAC permission
+local allowed = o.keto:check("apps", "cc", "admin", "user:alice")
+if not allowed then error("permission denied") end</code></pre>
 
     <!-- Temporal Workflow Engine -->
     <h3 id="temporal">Temporal Workflow Engine</h3>

--- a/site/modules.html
+++ b/site/modules.html
@@ -26,7 +26,7 @@
   <main>
     <h1>Module Reference</h1>
     <p style="font-size: 1.15rem; color: var(--text-secondary); margin-bottom: 1.5rem;">
-      50+ built-in modules, zero dependencies. Use <code>assay context &lt;query&gt;</code> for LLM-ready docs on any module.
+      50+ modules, zero dependencies. Use <code>assay context &lt;query&gt;</code> for LLM-ready docs on any module.
     </p>
 
     <pre><code>assay modules                    # list all modules

--- a/skills/assay/SKILL.md
+++ b/skills/assay/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: assay
-description: Infrastructure scripting runtime — 46 built-in modules for Kubernetes, ArgoCD, Vault, Prometheus, HTTP servers, AI agents, databases. Replaces kubectl, Python, Node.js, curl, jq in one 9 MB binary.
+description: Infrastructure scripting runtime — 50 built-in modules for Kubernetes, ArgoCD, Vault, Prometheus, HTTP servers, AI agents, databases. Replaces kubectl, Python, Node.js, curl, jq in one 9 MB binary.
 metadata:
   author: developerinlondon
   version: "0.6.1"
@@ -44,7 +44,7 @@ assay modules
 | `assay exec -e 'lua code'`  | Evaluate Lua inline                           |
 | `assay exec script.lua`     | Run Lua file via exec subcommand              |
 | `assay context "<keyword>"` | Find modules matching keyword, shows quickref |
-| `assay modules`             | List all 46 modules (29 stdlib + 17 builtins) |
+| `assay modules`             | List all 50 modules (33 stdlib + 17 builtins) |
 
 ## Discovering Modules
 
@@ -122,6 +122,25 @@ These are always available in every `.lua` script.
 | `http.serve(port, routes)`     | Start HTTP server (async handlers)             |
 
 Options: `{ headers = { ["X-Key"] = "value" } }`
+
+`http.serve` response handlers accept array values for headers to emit the same header name
+multiple times — required for `Set-Cookie` with multiple cookies, and useful for `Link`, `Vary`,
+`Cache-Control`, etc.:
+
+```lua
+return {
+  status = 200,
+  headers = {
+    ["Set-Cookie"] = {
+      "session=abc; Path=/; HttpOnly",
+      "csrf=xyz; Path=/",
+    },
+  },
+  body = "ok",
+}
+```
+
+String header values still work as before.
 
 ### Serialization
 
@@ -233,7 +252,7 @@ Available when built with `--features temporal`. Native gRPC client for Temporal
 
 ## Stdlib Modules Quick Reference
 
-All 29 modules follow `require("assay.<name>")` then `M.client(url, opts)`.
+All 33 modules follow `require("assay.<name>")` then `M.client(url, opts)`.
 
 | Module                | Description                                                                |
 | --------------------- | -------------------------------------------------------------------------- |
@@ -251,6 +270,11 @@ All 29 modules follow `require("assay.<name>")` then `M.client(url, opts)`.
 | `assay.certmanager`   | Certificates, issuers, ACME orders and challenges                          |
 | `assay.eso`           | ExternalSecrets, SecretStores, ClusterSecretStores sync status             |
 | `assay.dex`           | OIDC discovery, JWKS, health, configuration validation                     |
+| `assay.zitadel`       | OIDC identity management with JWT machine auth                             |
+| `assay.kratos`        | Ory Kratos — login/registration/recovery/settings flows, identities, sessions |
+| `assay.hydra`         | Ory Hydra OAuth2/OIDC — clients, authorize URLs, tokens, login/consent, JWKs |
+| `assay.keto`          | Ory Keto ReBAC — relation tuples, permission checks, expand                |
+| `assay.ory`           | Convenience wrapper — `ory.connect()` builds kratos/hydra/keto clients together |
 | `assay.crossplane`    | Providers, XRDs, compositions, managed resources                           |
 | `assay.velero`        | Backups, restores, schedules, storage locations                            |
 | `assay.temporal`      | Workflows, task queues, schedules, signals + native gRPC (temporal feature)|
@@ -258,7 +282,6 @@ All 29 modules follow `require("assay.<name>")` then `M.client(url, opts)`.
 | `assay.healthcheck`   | HTTP checks, JSON path, body matching, latency, multi-check                |
 | `assay.s3`            | S3-compatible storage (AWS, R2, MinIO) with Sig V4 auth                    |
 | `assay.postgres`      | Postgres helpers: users, databases, grants, Vault integration              |
-| `assay.zitadel`       | OIDC identity management with JWT machine auth                             |
 | `assay.unleash`       | Feature flags: projects, environments, features, strategies, tokens        |
 | `assay.openclaw`      | OpenClaw AI agent — invoke tools, state, diff, approve, LLM tasks          |
 | `assay.github`        | GitHub REST API — PRs, issues, actions, repos, GraphQL                     |
@@ -469,7 +492,7 @@ hardcode credentials in scripts.
 **Shebang scripts**: Add `#!/usr/bin/assay` as the first line and `chmod +x script.lua` to run
 scripts directly without the `assay` prefix.
 
-**Module not found**: All 29 stdlib modules are embedded in the binary. If `require("assay.foo")`
+**Module not found**: All 33 stdlib modules are embedded in the binary. If `require("assay.foo")`
 fails, run `assay modules` to see the exact module names.
 
 **Lua 5.5 specifics**: Assay uses Lua 5.5 (not LuaJIT). Integer division is `//`, bitwise ops use

--- a/skills/assay/SKILL.md
+++ b/skills/assay/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: assay
-description: Infrastructure scripting runtime — 50 built-in modules for Kubernetes, ArgoCD, Vault, Prometheus, HTTP servers, AI agents, databases. Replaces kubectl, Python, Node.js, curl, jq in one 9 MB binary.
+description: Infrastructure scripting runtime — 50 modules for Kubernetes, ArgoCD, Vault, Prometheus, HTTP servers, AI agents, databases. Replaces kubectl, Python, Node.js, curl, jq in one 9 MB binary.
 metadata:
   author: developerinlondon
   version: "0.6.1"
@@ -106,7 +106,7 @@ local c = grafana.client(url, { api_key = "glsa_..." })
 local c = grafana.client(url, { username = "admin", password = "secret" })
 ```
 
-## Built-in Functions (no require needed)
+## Builtins (no require needed)
 
 These are always available in every `.lua` script.
 
@@ -584,7 +584,7 @@ Today: use `assay context <query>` from terminal and paste output into agent con
 
 ## MCP-Serve Vision (v0.6.0)
 
-`assay mcp-serve` will expose all 40+ modules as MCP tools over stdio/SSE transport:
+`assay mcp-serve` will expose all 50 modules (33 stdlib + 17 builtins) as MCP tools over stdio/SSE transport:
 
 - Each stdlib module becomes an MCP tool (e.g., `grafana_health`, `k8s_pods`)
 - Each builtin becomes an MCP tool (e.g., `http_get`, `crypto_jwt_sign`)

--- a/src/lua/builtins/http.rs
+++ b/src/lua/builtins/http.rs
@@ -522,8 +522,23 @@ fn lua_response_to_http(
 
         // Apply custom headers first so they take precedence over SSE defaults
         if let Ok(Some(headers_table)) = resp_table.get::<Option<Table>>("headers") {
-            for (k, v) in headers_table.pairs::<String, String>().flatten() {
-                builder = builder.header(k, v);
+            for pair in headers_table.pairs::<String, Value>().flatten() {
+                let (k, v) = pair;
+                match v {
+                    Value::String(s) => {
+                        if let Ok(s) = s.to_str() {
+                            builder = builder.header(&k, s.as_ref());
+                        }
+                    }
+                    Value::Table(t) => {
+                        // Array of strings → multiple headers with the same name
+                        // (required for Set-Cookie when setting multiple cookies)
+                        for val in t.sequence_values::<String>().flatten() {
+                            builder = builder.header(&k, val);
+                        }
+                    }
+                    _ => {}
+                }
             }
         }
 
@@ -599,11 +614,26 @@ fn lua_response_to_http(
     let has_content_type =
         if let Ok(Some(headers_table)) = resp_table.get::<Option<Table>>("headers") {
             let mut found_ct = false;
-            for (k, v) in headers_table.pairs::<String, String>().flatten() {
+            for pair in headers_table.pairs::<String, Value>().flatten() {
+                let (k, v) = pair;
                 if k.eq_ignore_ascii_case("content-type") {
                     found_ct = true;
                 }
-                builder = builder.header(k, v);
+                match v {
+                    Value::String(s) => {
+                        if let Ok(s) = s.to_str() {
+                            builder = builder.header(&k, s.as_ref());
+                        }
+                    }
+                    Value::Table(t) => {
+                        // Array of strings → multiple headers with the same name
+                        // (required for Set-Cookie when setting multiple cookies)
+                        for val in t.sequence_values::<String>().flatten() {
+                            builder = builder.header(&k, val);
+                        }
+                    }
+                    _ => {}
+                }
             }
             found_ct
         } else {

--- a/stdlib/hydra.lua
+++ b/stdlib/hydra.lua
@@ -1,0 +1,268 @@
+--- @module assay.hydra
+--- @description Ory Hydra OAuth2 and OpenID Connect — client CRUD, authorize URL builder, token exchange, login/consent challenges, introspection, JWK endpoint.
+--- @keywords hydra, ory, oauth2, oidc, openid, authentication, clients, tokens, login_challenge, consent_challenge, jwk, authorize, introspect
+--- @quickref hydra.client(opts) -> client | Create a Hydra client. opts: {public_url, admin_url}
+--- @quickref c:list_clients(opts?) -> [{client_id, ...}] | List registered OAuth2 clients
+--- @quickref c:get_client(client_id) -> client | Get a registered OAuth2 client
+--- @quickref c:create_client(spec) -> client | Create/register an OAuth2 client
+--- @quickref c:update_client(client_id, spec) -> client | Upsert an OAuth2 client (PUT)
+--- @quickref c:delete_client(client_id) -> nil | Delete an OAuth2 client
+--- @quickref c:build_authorize_url(client_id, opts) -> url | Build the authorize URL for a browser redirect
+--- @quickref c:exchange_code(opts) -> {access_token, id_token, refresh_token} | Exchange auth code for tokens (authorization_code grant)
+--- @quickref c:refresh_token(client_id, client_secret, refresh_token) -> tokens | Refresh an access token
+--- @quickref c:introspect(token) -> {active, sub, scope, ...} | Token introspection
+--- @quickref c:revoke_token(client_id, client_secret, token) -> nil | Revoke a token
+--- @quickref c:get_login_request(challenge) -> {challenge, subject, client, ...} | Fetch a pending login challenge
+--- @quickref c:accept_login(challenge, subject, opts?) -> {redirect_to} | Accept a login challenge
+--- @quickref c:reject_login(challenge, error) -> {redirect_to} | Reject a login challenge
+--- @quickref c:get_consent_request(challenge) -> {challenge, subject, requested_scope, ...} | Fetch a pending consent challenge
+--- @quickref c:accept_consent(challenge, opts) -> {redirect_to} | Accept a consent challenge (with claims)
+--- @quickref c:reject_consent(challenge, error) -> {redirect_to} | Reject a consent challenge
+--- @quickref c:well_known() -> {issuer, authorization_endpoint, ...} | Fetch OIDC discovery document
+--- @quickref c:jwks() -> {keys} | Fetch JSON Web Key Set
+
+local M = {}
+
+local function urlencode(s)
+  return (tostring(s):gsub("([^%w%-%.%_%~])", function(c)
+    return string.format("%%%02X", string.byte(c))
+  end))
+end
+
+-- Create a Hydra client. Pass opts.public_url for public API, opts.admin_url for admin API.
+-- For token exchange/authorize use public_url; for client CRUD and login/consent challenges use admin_url.
+function M.client(opts)
+  opts = opts or {}
+  local c = {
+    public_url = opts.public_url and opts.public_url:gsub("/+$", "") or nil,
+    admin_url = opts.admin_url and opts.admin_url:gsub("/+$", "") or nil,
+  }
+
+  local function require_admin(self)
+    if not self.admin_url then
+      error("hydra: admin_url not configured")
+    end
+  end
+
+  local function require_public(self)
+    if not self.public_url then
+      error("hydra: public_url not configured")
+    end
+  end
+
+  local function admin_get(self, path_str)
+    require_admin(self)
+    local resp = http.get(self.admin_url .. path_str)
+    if resp.status ~= 200 then
+      error("hydra: GET " .. path_str .. " HTTP " .. resp.status .. ": " .. resp.body)
+    end
+    return json.parse(resp.body)
+  end
+
+  local function admin_put(self, path_str, payload)
+    require_admin(self)
+    local resp = http.put(self.admin_url .. path_str, payload)
+    if resp.status ~= 200 and resp.status ~= 201 then
+      error("hydra: PUT " .. path_str .. " HTTP " .. resp.status .. ": " .. resp.body)
+    end
+    return json.parse(resp.body)
+  end
+
+  local function admin_post(self, path_str, payload)
+    require_admin(self)
+    local resp = http.post(self.admin_url .. path_str, payload)
+    if resp.status ~= 200 and resp.status ~= 201 then
+      error("hydra: POST " .. path_str .. " HTTP " .. resp.status .. ": " .. resp.body)
+    end
+    return json.parse(resp.body)
+  end
+
+  -- ========== OAuth2 Client CRUD ==========
+
+  function c:list_clients(opts)
+    opts = opts or {}
+    local qs = ""
+    if opts.page_size then qs = "?page_size=" .. opts.page_size end
+    return admin_get(self, "/admin/clients" .. qs)
+  end
+
+  function c:get_client(client_id)
+    return admin_get(self, "/admin/clients/" .. client_id)
+  end
+
+  function c:create_client(spec)
+    return admin_post(self, "/admin/clients", spec)
+  end
+
+  -- Upsert: creates or updates an OAuth2 client (idempotent). Recommended for GitOps workflows.
+  function c:update_client(client_id, spec)
+    spec.client_id = client_id
+    return admin_put(self, "/admin/clients/" .. client_id, spec)
+  end
+
+  function c:delete_client(client_id)
+    require_admin(self)
+    local resp = http.delete(self.admin_url .. "/admin/clients/" .. client_id)
+    if resp.status ~= 204 and resp.status ~= 200 then
+      error("hydra: DELETE client HTTP " .. resp.status .. ": " .. resp.body)
+    end
+  end
+
+  -- ========== OAuth2 Flow Helpers ==========
+
+  -- Build the authorize URL for a browser redirect.
+  -- opts: { redirect_uri, scope, state, response_type (default "code"), extra (table of extra params) }
+  function c:build_authorize_url(client_id, opts)
+    require_public(self)
+    opts = opts or {}
+    local params = {
+      "client_id=" .. urlencode(client_id),
+      "response_type=" .. urlencode(opts.response_type or "code"),
+      "scope=" .. urlencode(opts.scope or "openid profile email"),
+      "redirect_uri=" .. urlencode(opts.redirect_uri or ""),
+    }
+    if opts.state then
+      params[#params + 1] = "state=" .. urlencode(opts.state)
+    end
+    if opts.nonce then
+      params[#params + 1] = "nonce=" .. urlencode(opts.nonce)
+    end
+    if opts.extra then
+      for k, v in pairs(opts.extra) do
+        params[#params + 1] = k .. "=" .. urlencode(v)
+      end
+    end
+    return self.public_url .. "/oauth2/auth?" .. table.concat(params, "&")
+  end
+
+  -- Exchange an authorization code for tokens (authorization_code grant).
+  -- opts: { code, redirect_uri, client_id, client_secret }
+  function c:exchange_code(opts)
+    require_public(self)
+    local body = "grant_type=authorization_code"
+      .. "&code=" .. urlencode(opts.code)
+      .. "&redirect_uri=" .. urlencode(opts.redirect_uri)
+      .. "&client_id=" .. urlencode(opts.client_id)
+      .. "&client_secret=" .. urlencode(opts.client_secret)
+    local resp = http.post(self.public_url .. "/oauth2/token", body, {
+      headers = { ["Content-Type"] = "application/x-www-form-urlencoded" },
+    })
+    if resp.status ~= 200 then
+      error("hydra: token exchange HTTP " .. resp.status .. ": " .. resp.body)
+    end
+    return json.parse(resp.body)
+  end
+
+  -- Refresh an access token.
+  function c:refresh_token(client_id, client_secret, refresh_token)
+    require_public(self)
+    local body = "grant_type=refresh_token"
+      .. "&refresh_token=" .. urlencode(refresh_token)
+      .. "&client_id=" .. urlencode(client_id)
+      .. "&client_secret=" .. urlencode(client_secret)
+    local resp = http.post(self.public_url .. "/oauth2/token", body, {
+      headers = { ["Content-Type"] = "application/x-www-form-urlencoded" },
+    })
+    if resp.status ~= 200 then
+      error("hydra: refresh token HTTP " .. resp.status .. ": " .. resp.body)
+    end
+    return json.parse(resp.body)
+  end
+
+  -- Introspect a token via admin API.
+  function c:introspect(token)
+    require_admin(self)
+    local resp = http.post(self.admin_url .. "/admin/oauth2/introspect",
+      "token=" .. urlencode(token),
+      { headers = { ["Content-Type"] = "application/x-www-form-urlencoded" } })
+    if resp.status ~= 200 then
+      error("hydra: introspect HTTP " .. resp.status .. ": " .. resp.body)
+    end
+    return json.parse(resp.body)
+  end
+
+  -- Revoke a token.
+  function c:revoke_token(client_id, client_secret, token)
+    require_public(self)
+    local body = "token=" .. urlencode(token)
+      .. "&client_id=" .. urlencode(client_id)
+      .. "&client_secret=" .. urlencode(client_secret)
+    local resp = http.post(self.public_url .. "/oauth2/revoke", body, {
+      headers = { ["Content-Type"] = "application/x-www-form-urlencoded" },
+    })
+    if resp.status ~= 200 then
+      error("hydra: revoke HTTP " .. resp.status .. ": " .. resp.body)
+    end
+  end
+
+  -- ========== Login/Consent Challenges ==========
+
+  function c:get_login_request(challenge)
+    return admin_get(self, "/admin/oauth2/auth/requests/login?login_challenge=" .. urlencode(challenge))
+  end
+
+  -- Accept a login challenge. opts: { remember=bool, remember_for=seconds, acr=string, amr=[string], context=table }
+  function c:accept_login(challenge, subject, opts)
+    opts = opts or {}
+    local payload = {
+      subject = subject,
+      remember = opts.remember,
+      remember_for = opts.remember_for,
+      acr = opts.acr,
+      amr = opts.amr,
+      context = opts.context,
+    }
+    return admin_put(self, "/admin/oauth2/auth/requests/login/accept?login_challenge=" .. urlencode(challenge), payload)
+  end
+
+  function c:reject_login(challenge, err)
+    return admin_put(self, "/admin/oauth2/auth/requests/login/reject?login_challenge=" .. urlencode(challenge), err or { error = "access_denied" })
+  end
+
+  function c:get_consent_request(challenge)
+    return admin_get(self, "/admin/oauth2/auth/requests/consent?consent_challenge=" .. urlencode(challenge))
+  end
+
+  -- Accept a consent challenge.
+  -- opts: { grant_scope=[string], grant_access_token_audience=[string], remember=bool, remember_for=seconds,
+  --         session={id_token=table, access_token=table} }
+  function c:accept_consent(challenge, opts)
+    opts = opts or {}
+    local payload = {
+      grant_scope = opts.grant_scope or { "openid", "profile", "email" },
+      grant_access_token_audience = opts.grant_access_token_audience or {},
+      remember = opts.remember,
+      remember_for = opts.remember_for,
+      session = opts.session,
+    }
+    return admin_put(self, "/admin/oauth2/auth/requests/consent/accept?consent_challenge=" .. urlencode(challenge), payload)
+  end
+
+  function c:reject_consent(challenge, err)
+    return admin_put(self, "/admin/oauth2/auth/requests/consent/reject?consent_challenge=" .. urlencode(challenge), err or { error = "access_denied" })
+  end
+
+  -- ========== OIDC Discovery ==========
+
+  function c:well_known()
+    require_public(self)
+    local resp = http.get(self.public_url .. "/.well-known/openid-configuration")
+    if resp.status ~= 200 then
+      error("hydra: well-known HTTP " .. resp.status .. ": " .. resp.body)
+    end
+    return json.parse(resp.body)
+  end
+
+  function c:jwks()
+    require_public(self)
+    local resp = http.get(self.public_url .. "/.well-known/jwks.json")
+    if resp.status ~= 200 then
+      error("hydra: jwks HTTP " .. resp.status .. ": " .. resp.body)
+    end
+    return json.parse(resp.body)
+  end
+
+  return c
+end
+
+return M

--- a/stdlib/keto.lua
+++ b/stdlib/keto.lua
@@ -1,0 +1,163 @@
+--- @module assay.keto
+--- @description Ory Keto authorization — relation-tuple CRUD, permission checks, role membership queries. Implements relationship-based access control (ReBAC, Google Zanzibar-style).
+--- @keywords keto, ory, authorization, authz, rbac, rebac, permissions, roles, relation-tuples, zanzibar, access-control, members, groups
+--- @quickref keto.client(read_url, opts?) -> client | Create a Keto client (read endpoint)
+--- @quickref c:list(opts) -> {relation_tuples, next_page_token} | List relation tuples matching filters
+--- @quickref c:check(namespace, object, relation, subject) -> bool | Check if a subject has a relation to an object
+--- @quickref c:expand(namespace, object, relation, depth?) -> tree | Expand a relation to see all members
+--- @quickref c:get_user_roles(user_id, namespace?) -> [{object, relation}] | Get all role memberships for a user
+--- @quickref c:create(tuple) -> nil | Create a relation tuple (requires write_url)
+--- @quickref c:delete(tuple) -> nil | Delete a relation tuple (requires write_url)
+--- @quickref c:delete_all(filters) -> nil | Delete all matching relation tuples (requires write_url)
+
+local M = {}
+
+-- Create a Keto client.
+-- Pass a single URL for read-only, or opts.write_url for write operations.
+-- Example:
+--   local k = keto.client("http://keto-read:4466")
+--   local k = keto.client("http://keto-read:4466", { write_url = "http://keto-write:4467" })
+function M.client(read_url, opts)
+  opts = opts or {}
+  local c = {
+    read_url = read_url:gsub("/+$", ""),
+    write_url = opts.write_url and opts.write_url:gsub("/+$", "") or nil,
+  }
+
+  local function build_query(params)
+    local parts = {}
+    for k, v in pairs(params) do
+      if v ~= nil and v ~= "" then
+        parts[#parts + 1] = k .. "=" .. v
+      end
+    end
+    if #parts == 0 then return "" end
+    return "?" .. table.concat(parts, "&")
+  end
+
+  local function read_get(self, path_str)
+    local resp = http.get(self.read_url .. path_str)
+    if resp.status ~= 200 then
+      error("keto: GET " .. path_str .. " HTTP " .. resp.status .. ": " .. resp.body)
+    end
+    return json.parse(resp.body)
+  end
+
+  local function require_write(self)
+    if not self.write_url then
+      error("keto: write_url not configured — pass opts.write_url to keto.client()")
+    end
+  end
+
+  -- List relation tuples. Filters: namespace, object, relation, subject_id, subject_set_namespace, subject_set_object, subject_set_relation, page_size, page_token
+  function c:list(filters)
+    return read_get(self, "/relation-tuples" .. build_query(filters or {}))
+  end
+
+  -- Check if a subject has a given relation to an object.
+  -- subject can be a string ("user:abc") or a table ({ namespace="...", object="...", relation="..." })
+  -- Returns true if allowed, false otherwise.
+  function c:check(namespace, object, relation, subject)
+    local params = {
+      namespace = namespace,
+      object = object,
+      relation = relation,
+    }
+    if type(subject) == "string" then
+      params.subject_id = subject
+    elseif type(subject) == "table" then
+      params.subject_set_namespace = subject.namespace
+      params.subject_set_object = subject.object
+      params.subject_set_relation = subject.relation
+    end
+    local resp = http.get(self.read_url .. "/relation-tuples/check" .. build_query(params))
+    if resp.status == 200 then
+      local data = json.parse(resp.body)
+      return data.allowed == true
+    elseif resp.status == 403 then
+      return false
+    end
+    error("keto: check failed HTTP " .. resp.status .. ": " .. resp.body)
+  end
+
+  -- Expand a relation to see all direct and transitive members.
+  function c:expand(namespace, object, relation, depth)
+    local params = {
+      namespace = namespace,
+      object = object,
+      relation = relation,
+      ["max-depth"] = depth or 3,
+    }
+    return read_get(self, "/relation-tuples/expand" .. build_query(params))
+  end
+
+  -- Helper: get all role memberships for a user.
+  -- By default queries the Role namespace which is the SIMONS convention.
+  -- Returns a list of { object, relation } entries, e.g.
+  --   { {object="platform:super-admin", relation="members"}, {object="command-center:admin", relation="members"} }
+  function c:get_user_roles(user_id, namespace)
+    local subject = user_id
+    if not user_id:match("^user:") then
+      subject = "user:" .. user_id
+    end
+    local result = self:list({
+      namespace = namespace or "Role",
+      relation = "members",
+      subject_id = subject,
+    })
+    local roles = {}
+    for _, tuple in ipairs(result.relation_tuples or {}) do
+      roles[#roles + 1] = { object = tuple.object, relation = tuple.relation }
+    end
+    return roles
+  end
+
+  -- Helper: check if a user has any of the given role objects (e.g. {"platform:super-admin", "command-center:admin"})
+  function c:user_has_any_role(user_id, role_objects, namespace)
+    local roles = self:get_user_roles(user_id, namespace)
+    local set = {}
+    for _, r in ipairs(roles) do set[r.object] = true end
+    for _, target in ipairs(role_objects) do
+      if set[target] then return true end
+    end
+    return false
+  end
+
+  -- Create a relation tuple (requires write_url).
+  -- tuple: { namespace, object, relation, subject_id (or subject_set) }
+  function c:create(tuple)
+    require_write(self)
+    local resp = http.put(self.write_url .. "/admin/relation-tuples", tuple)
+    if resp.status ~= 201 and resp.status ~= 200 then
+      error("keto: create tuple HTTP " .. resp.status .. ": " .. resp.body)
+    end
+  end
+
+  -- Delete a specific relation tuple (requires write_url).
+  function c:delete(tuple)
+    require_write(self)
+    local params = {
+      namespace = tuple.namespace,
+      object = tuple.object,
+      relation = tuple.relation,
+      subject_id = tuple.subject_id,
+    }
+    local resp = http.delete(self.write_url .. "/admin/relation-tuples" .. build_query(params))
+    if resp.status ~= 204 and resp.status ~= 200 then
+      error("keto: delete tuple HTTP " .. resp.status .. ": " .. resp.body)
+    end
+  end
+
+  -- Delete all relation tuples matching the filters (requires write_url).
+  function c:delete_all(filters)
+    require_write(self)
+    local resp = http.delete(self.write_url .. "/admin/relation-tuples" .. build_query(filters))
+    if resp.status ~= 204 and resp.status ~= 200 then
+      error("keto: delete_all HTTP " .. resp.status .. ": " .. resp.body)
+    end
+  end
+
+  return c
+end
+
+return M

--- a/stdlib/kratos.lua
+++ b/stdlib/kratos.lua
@@ -1,0 +1,216 @@
+--- @module assay.kratos
+--- @description Ory Kratos identity management — login/registration/recovery flows, identity CRUD via admin API, session introspection, schemas.
+--- @keywords kratos, ory, identity, authentication, login, registration, recovery, settings, sessions, identities, schemas, whoami
+--- @quickref kratos.client(opts) -> client | Create a Kratos client. opts: {public_url, admin_url}
+--- @quickref c:whoami(cookie) -> {identity, expires_at, ...} | Check if the current session is valid
+--- @quickref c:create_login_flow(opts?) -> {id, ui, return_to, ...} | Create a browser login flow
+--- @quickref c:get_login_flow(id, cookie?) -> flow | Fetch an existing login flow
+--- @quickref c:submit_login_flow(flow_id, payload, cookie?) -> {session, ...} | Submit a login flow
+--- @quickref c:create_registration_flow() -> flow | Create a registration flow
+--- @quickref c:get_identity(id) -> identity | Get an identity by ID (admin API)
+--- @quickref c:list_identities(opts?) -> [identity] | List all identities (admin API)
+--- @quickref c:create_identity(spec) -> identity | Create an identity (admin API)
+--- @quickref c:update_identity(id, spec) -> identity | Update an identity (admin API)
+--- @quickref c:delete_identity(id) -> nil | Delete an identity (admin API)
+--- @quickref c:list_sessions(id) -> [session] | List active sessions for an identity
+--- @quickref c:delete_sessions(id) -> nil | Revoke all sessions for an identity
+--- @quickref c:list_schemas() -> [schema] | List identity schemas
+
+local M = {}
+
+local function urlencode(s)
+  return (tostring(s):gsub("([^%w%-%.%_%~])", function(c)
+    return string.format("%%%02X", string.byte(c))
+  end))
+end
+
+-- Create a Kratos client. Pass opts.public_url for public API (login flows, whoami)
+-- and opts.admin_url for admin API (identity CRUD, session management).
+function M.client(opts)
+  opts = opts or {}
+  local c = {
+    public_url = opts.public_url and opts.public_url:gsub("/+$", "") or nil,
+    admin_url = opts.admin_url and opts.admin_url:gsub("/+$", "") or nil,
+  }
+
+  local function require_public(self)
+    if not self.public_url then
+      error("kratos: public_url not configured")
+    end
+  end
+
+  local function require_admin(self)
+    if not self.admin_url then
+      error("kratos: admin_url not configured")
+    end
+  end
+
+  local function public_get(self, path_str, cookie)
+    require_public(self)
+    local headers = {}
+    if cookie then headers["Cookie"] = cookie end
+    local resp = http.get(self.public_url .. path_str, { headers = headers })
+    if resp.status ~= 200 then
+      error("kratos: GET " .. path_str .. " HTTP " .. resp.status .. ": " .. resp.body)
+    end
+    return json.parse(resp.body)
+  end
+
+  local function admin_get(self, path_str)
+    require_admin(self)
+    local resp = http.get(self.admin_url .. path_str)
+    if resp.status ~= 200 and resp.status ~= 404 then
+      error("kratos: GET " .. path_str .. " HTTP " .. resp.status .. ": " .. resp.body)
+    end
+    if resp.status == 404 then return nil end
+    return json.parse(resp.body)
+  end
+
+  local function admin_post(self, path_str, payload)
+    require_admin(self)
+    local resp = http.post(self.admin_url .. path_str, payload)
+    if resp.status ~= 200 and resp.status ~= 201 then
+      error("kratos: POST " .. path_str .. " HTTP " .. resp.status .. ": " .. resp.body)
+    end
+    return json.parse(resp.body)
+  end
+
+  local function admin_put(self, path_str, payload)
+    require_admin(self)
+    local resp = http.put(self.admin_url .. path_str, payload)
+    if resp.status ~= 200 then
+      error("kratos: PUT " .. path_str .. " HTTP " .. resp.status .. ": " .. resp.body)
+    end
+    return json.parse(resp.body)
+  end
+
+  -- ========== Session ==========
+
+  -- Check if the current session is valid. Pass the user's cookie header.
+  -- Returns the session object or nil if not authenticated.
+  function c:whoami(cookie)
+    require_public(self)
+    local headers = {}
+    if cookie then headers["Cookie"] = cookie end
+    local resp = http.get(self.public_url .. "/sessions/whoami", { headers = headers })
+    if resp.status == 200 then
+      return json.parse(resp.body)
+    elseif resp.status == 401 then
+      return nil
+    end
+    error("kratos: whoami HTTP " .. resp.status .. ": " .. resp.body)
+  end
+
+  -- ========== Login Flows ==========
+
+  -- Create a login flow. opts: { return_to, refresh, login_challenge, aal }
+  function c:create_login_flow(opts)
+    opts = opts or {}
+    local params = {}
+    if opts.return_to then params[#params + 1] = "return_to=" .. urlencode(opts.return_to) end
+    if opts.refresh then params[#params + 1] = "refresh=true" end
+    if opts.login_challenge then params[#params + 1] = "login_challenge=" .. urlencode(opts.login_challenge) end
+    if opts.aal then params[#params + 1] = "aal=" .. urlencode(opts.aal) end
+    local qs = ""
+    if #params > 0 then qs = "?" .. table.concat(params, "&") end
+    return public_get(self, "/self-service/login/browser" .. qs)
+  end
+
+  function c:get_login_flow(flow_id, cookie)
+    return public_get(self, "/self-service/login/flows?id=" .. urlencode(flow_id), cookie)
+  end
+
+  function c:submit_login_flow(flow_id, payload, cookie)
+    require_public(self)
+    local headers = { ["Content-Type"] = "application/json" }
+    if cookie then headers["Cookie"] = cookie end
+    local resp = http.post(self.public_url .. "/self-service/login?flow=" .. urlencode(flow_id), payload, {
+      headers = headers,
+    })
+    if resp.status ~= 200 then
+      error("kratos: submit login HTTP " .. resp.status .. ": " .. resp.body)
+    end
+    return json.parse(resp.body)
+  end
+
+  -- ========== Registration Flows ==========
+
+  function c:create_registration_flow(opts)
+    opts = opts or {}
+    local qs = ""
+    if opts.return_to then qs = "?return_to=" .. urlencode(opts.return_to) end
+    return public_get(self, "/self-service/registration/browser" .. qs)
+  end
+
+  function c:get_registration_flow(flow_id, cookie)
+    return public_get(self, "/self-service/registration/flows?id=" .. urlencode(flow_id), cookie)
+  end
+
+  -- ========== Identity CRUD (Admin API) ==========
+
+  function c:get_identity(id)
+    return admin_get(self, "/admin/identities/" .. urlencode(id))
+  end
+
+  function c:list_identities(opts)
+    opts = opts or {}
+    local params = {}
+    if opts.per_page then params[#params + 1] = "per_page=" .. opts.per_page end
+    if opts.page then params[#params + 1] = "page=" .. opts.page end
+    if opts.credentials_identifier then
+      params[#params + 1] = "credentials_identifier=" .. urlencode(opts.credentials_identifier)
+    end
+    local qs = ""
+    if #params > 0 then qs = "?" .. table.concat(params, "&") end
+    return admin_get(self, "/admin/identities" .. qs)
+  end
+
+  function c:create_identity(spec)
+    return admin_post(self, "/admin/identities", spec)
+  end
+
+  function c:update_identity(id, spec)
+    return admin_put(self, "/admin/identities/" .. urlencode(id), spec)
+  end
+
+  function c:delete_identity(id)
+    require_admin(self)
+    local resp = http.delete(self.admin_url .. "/admin/identities/" .. urlencode(id))
+    if resp.status ~= 204 and resp.status ~= 200 then
+      error("kratos: delete identity HTTP " .. resp.status .. ": " .. resp.body)
+    end
+  end
+
+  -- ========== Session Management (Admin API) ==========
+
+  function c:list_sessions(identity_id)
+    return admin_get(self, "/admin/identities/" .. urlencode(identity_id) .. "/sessions")
+  end
+
+  function c:delete_sessions(identity_id)
+    require_admin(self)
+    local resp = http.delete(self.admin_url .. "/admin/identities/" .. urlencode(identity_id) .. "/sessions")
+    if resp.status ~= 204 and resp.status ~= 200 then
+      error("kratos: delete sessions HTTP " .. resp.status .. ": " .. resp.body)
+    end
+  end
+
+  -- ========== Schemas ==========
+
+  function c:list_schemas()
+    require_public(self)
+    local resp = http.get(self.public_url .. "/schemas")
+    if resp.status ~= 200 then
+      error("kratos: list schemas HTTP " .. resp.status .. ": " .. resp.body)
+    end
+    return json.parse(resp.body)
+  end
+
+  function c:get_schema(schema_id)
+    return public_get(self, "/schemas/" .. urlencode(schema_id))
+  end
+
+  return c
+end
+
+return M

--- a/stdlib/ory.lua
+++ b/stdlib/ory.lua
@@ -1,0 +1,48 @@
+--- @module assay.ory
+--- @description Convenience wrapper that re-exports all three Ory stack modules (kratos, hydra, keto). Prefer requiring the individual modules directly if you only need one.
+--- @keywords ory, stack, kratos, hydra, keto, identity, oauth2, oidc, authz, zanzibar
+--- @quickref ory.kratos.client(opts) -> kratos client | Kratos identity management
+--- @quickref ory.hydra.client(opts) -> hydra client | Hydra OAuth2 and OIDC
+--- @quickref ory.keto.client(read_url, opts?) -> keto client | Keto authorization (Zanzibar-style ReBAC)
+--- @quickref ory.connect(opts) -> {kratos, hydra, keto} | Build all three clients in one call
+
+local kratos = require("assay.kratos")
+local hydra = require("assay.hydra")
+local keto = require("assay.keto")
+
+local M = {
+  kratos = kratos,
+  hydra = hydra,
+  keto = keto,
+}
+
+-- Convenience: build all three clients from a single options table.
+-- opts: {
+--   kratos_public, kratos_admin,
+--   hydra_public, hydra_admin,
+--   keto_read, keto_write,
+-- }
+-- Any URL left nil produces a client for that service that's limited to the
+-- other endpoint (e.g. providing only kratos_public makes a read-only Kratos client).
+function M.connect(opts)
+  opts = opts or {}
+  local result = {}
+  if opts.kratos_public or opts.kratos_admin then
+    result.kratos = kratos.client({
+      public_url = opts.kratos_public,
+      admin_url = opts.kratos_admin,
+    })
+  end
+  if opts.hydra_public or opts.hydra_admin then
+    result.hydra = hydra.client({
+      public_url = opts.hydra_public,
+      admin_url = opts.hydra_admin,
+    })
+  end
+  if opts.keto_read then
+    result.keto = keto.client(opts.keto_read, { write_url = opts.keto_write })
+  end
+  return result
+end
+
+return M

--- a/tests/http_serve.rs
+++ b/tests/http_serve.rs
@@ -358,54 +358,63 @@ async fn test_http_serve_multi_value_header() {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpStream;
 
-    // Start server via Lua
+    // Do the raw TCP request inside the same LocalSet that runs the server,
+    // otherwise the spawned server task stops being polled and the connection hangs.
     let vm = common::create_vm();
-    let script = r#"
-        async.spawn(function()
-            http.serve(0, {
-                GET = {
-                    ["/multi-cookie"] = function(req)
-                        return {
-                            status = 200,
-                            body = "ok",
-                            headers = {
-                                ["Set-Cookie"] = {
-                                    "a=1; Path=/",
-                                    "b=2; Path=/",
-                                },
-                            },
-                        }
-                    end,
-                }
-            })
-        end)
-        sleep(0.1)
-        return _SERVER_PORT
-    "#;
     let local = tokio::task::LocalSet::new();
-    let port: i64 = local
+    let buf: String = local
         .run_until(async {
-            vm.load(assay::lua::async_bridge::strip_shebang(script))
-                .eval_async::<i64>()
+            // Start the server
+            let script = r#"
+                async.spawn(function()
+                    http.serve(0, {
+                        GET = {
+                            ["/multi-cookie"] = function(req)
+                                return {
+                                    status = 200,
+                                    body = "ok",
+                                    headers = {
+                                        ["Set-Cookie"] = {
+                                            "a=1; Path=/",
+                                            "b=2; Path=/",
+                                        },
+                                    },
+                                }
+                            end,
+                        }
+                    })
+                end)
+                sleep(0.1)
+                return _SERVER_PORT
+            "#;
+            let port: i64 = vm
+                .load(assay::lua::async_bridge::strip_shebang(script))
+                .eval_async()
                 .await
-                .unwrap()
+                .unwrap();
+
+            // Raw HTTP request to inspect multiple Set-Cookie headers
+            let mut stream = TcpStream::connect(format!("127.0.0.1:{port}"))
+                .await
+                .unwrap();
+            stream
+                .write_all(
+                    b"GET /multi-cookie HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n",
+                )
+                .await
+                .unwrap();
+            let mut buf = String::new();
+            tokio::time::timeout(std::time::Duration::from_secs(5), stream.read_to_string(&mut buf))
+                .await
+                .expect("timeout reading raw response")
+                .unwrap();
+            buf
         })
         .await;
 
-    // Raw HTTP request to inspect multiple Set-Cookie headers
-    let mut stream = TcpStream::connect(format!("127.0.0.1:{}", port))
-        .await
-        .unwrap();
-    stream
-        .write_all(b"GET /multi-cookie HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
-        .await
-        .unwrap();
-    let mut buf = String::new();
-    stream.read_to_string(&mut buf).await.unwrap();
-
     // Both Set-Cookie headers should be present in the raw response
-    assert!(buf.contains("set-cookie: a=1"), "missing a=1 in: {}", buf);
-    assert!(buf.contains("set-cookie: b=2"), "missing b=2 in: {}", buf);
+    assert!(buf.contains("set-cookie: a=1"), "missing a=1 in: {buf}");
+    assert!(buf.contains("set-cookie: b=2"), "missing b=2 in: {buf}");
 }
 
 #[tokio::test]

--- a/tests/http_serve.rs
+++ b/tests/http_serve.rs
@@ -354,6 +354,61 @@ async fn test_http_serve_query_params() {
 }
 
 #[tokio::test]
+async fn test_http_serve_multi_value_header() {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpStream;
+
+    // Start server via Lua
+    let vm = common::create_vm();
+    let script = r#"
+        async.spawn(function()
+            http.serve(0, {
+                GET = {
+                    ["/multi-cookie"] = function(req)
+                        return {
+                            status = 200,
+                            body = "ok",
+                            headers = {
+                                ["Set-Cookie"] = {
+                                    "a=1; Path=/",
+                                    "b=2; Path=/",
+                                },
+                            },
+                        }
+                    end,
+                }
+            })
+        end)
+        sleep(0.1)
+        return _SERVER_PORT
+    "#;
+    let local = tokio::task::LocalSet::new();
+    let port: i64 = local
+        .run_until(async {
+            vm.load(assay::lua::async_bridge::strip_shebang(script))
+                .eval_async::<i64>()
+                .await
+                .unwrap()
+        })
+        .await;
+
+    // Raw HTTP request to inspect multiple Set-Cookie headers
+    let mut stream = TcpStream::connect(format!("127.0.0.1:{}", port))
+        .await
+        .unwrap();
+    stream
+        .write_all(b"GET /multi-cookie HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+        .await
+        .unwrap();
+    let mut buf = String::new();
+    stream.read_to_string(&mut buf).await.unwrap();
+
+    // Both Set-Cookie headers should be present in the raw response
+    assert!(buf.contains("set-cookie: a=1"), "missing a=1 in: {}", buf);
+    assert!(buf.contains("set-cookie: b=2"), "missing b=2 in: {}", buf);
+}
+
+#[tokio::test]
 async fn test_http_serve_empty_query_params() {
     run_lua_local(
         r#"

--- a/tests/stdlib_hydra.rs
+++ b/tests/stdlib_hydra.rs
@@ -1,0 +1,234 @@
+mod common;
+
+use common::run_lua;
+use wiremock::matchers::{body_string_contains, method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[tokio::test]
+async fn test_hydra_require() {
+    let script = r#"
+        local hydra = require("assay.hydra")
+        assert.not_nil(hydra)
+        assert.not_nil(hydra.client)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_hydra_list_clients() {
+    let admin = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/admin/clients"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+            { "client_id": "cc", "client_name": "Command Center" },
+            { "client_id": "temporal", "client_name": "Temporal" }
+        ])))
+        .mount(&admin)
+        .await;
+
+    let script = format!(
+        r#"
+        local hydra = require("assay.hydra")
+        local h = hydra.client({{ admin_url = "{}" }})
+        local clients = h:list_clients()
+        assert.eq(#clients, 2)
+        assert.eq(clients[1].client_id, "cc")
+        "#,
+        admin.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_hydra_update_client() {
+    let admin = MockServer::start().await;
+    Mock::given(method("PUT"))
+        .and(path("/admin/clients/cc"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "client_id": "cc",
+            "client_name": "Command Center",
+            "token_endpoint_auth_method": "client_secret_post"
+        })))
+        .mount(&admin)
+        .await;
+
+    let script = format!(
+        r#"
+        local hydra = require("assay.hydra")
+        local h = hydra.client({{ admin_url = "{}" }})
+        local client = h:update_client("cc", {{
+          client_name = "Command Center",
+          client_secret = "secret",
+          grant_types = {{"authorization_code", "refresh_token"}},
+          response_types = {{"code"}},
+          scope = "openid profile email",
+          redirect_uris = {{"https://cc.example.com/auth/callback"}},
+          token_endpoint_auth_method = "client_secret_post",
+        }})
+        assert.eq(client.client_id, "cc")
+        "#,
+        admin.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_hydra_build_authorize_url() {
+    let script = r#"
+        local hydra = require("assay.hydra")
+        local h = hydra.client({ public_url = "https://hydra.example.com" })
+        local url = h:build_authorize_url("cc", {
+          redirect_uri = "https://cc.example.com/auth/callback",
+          scope = "openid profile email",
+          state = "xyz",
+        })
+        assert.contains(url, "https://hydra.example.com/oauth2/auth?")
+        assert.contains(url, "client_id=cc")
+        assert.contains(url, "response_type=code")
+        assert.contains(url, "state=xyz")
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_hydra_exchange_code() {
+    let public = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/oauth2/token"))
+        .and(body_string_contains("grant_type=authorization_code"))
+        .and(body_string_contains("code=abc"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "access_token": "access.jwt",
+            "id_token": "id.jwt",
+            "refresh_token": "refresh.opaque",
+            "token_type": "bearer",
+            "expires_in": 3600
+        })))
+        .mount(&public)
+        .await;
+
+    let script = format!(
+        r#"
+        local hydra = require("assay.hydra")
+        local h = hydra.client({{ public_url = "{}" }})
+        local tokens = h:exchange_code({{
+          code = "abc",
+          redirect_uri = "https://cc.example.com/auth/callback",
+          client_id = "cc",
+          client_secret = "secret",
+        }})
+        assert.eq(tokens.access_token, "access.jwt")
+        assert.eq(tokens.id_token, "id.jwt")
+        "#,
+        public.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_hydra_accept_login() {
+    let admin = MockServer::start().await;
+    Mock::given(method("PUT"))
+        .and(path("/admin/oauth2/auth/requests/login/accept"))
+        .and(query_param("login_challenge", "abc123"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "redirect_to": "https://hydra.example.com/oauth2/auth?client_id=cc&..."
+        })))
+        .mount(&admin)
+        .await;
+
+    let script = format!(
+        r#"
+        local hydra = require("assay.hydra")
+        local h = hydra.client({{ admin_url = "{}" }})
+        local result = h:accept_login("abc123", "user:alice", {{ remember = true, remember_for = 86400 }})
+        assert.contains(result.redirect_to, "hydra.example.com")
+        "#,
+        admin.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_hydra_accept_consent_with_claims() {
+    let admin = MockServer::start().await;
+    Mock::given(method("PUT"))
+        .and(path("/admin/oauth2/auth/requests/consent/accept"))
+        .and(query_param("consent_challenge", "xyz789"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "redirect_to": "https://cc.example.com/auth/callback?code=..."
+        })))
+        .mount(&admin)
+        .await;
+
+    let script = format!(
+        r#"
+        local hydra = require("assay.hydra")
+        local h = hydra.client({{ admin_url = "{}" }})
+        local result = h:accept_consent("xyz789", {{
+          grant_scope = {{"openid", "profile", "email"}},
+          session = {{
+            id_token = {{
+              sub = "user:alice",
+              email = "alice@example.com",
+              role = "admin",
+            }},
+          }},
+        }})
+        assert.contains(result.redirect_to, "cc.example.com")
+        "#,
+        admin.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_hydra_introspect() {
+    let admin = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/admin/oauth2/introspect"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "active": true,
+            "sub": "user:alice",
+            "scope": "openid profile email"
+        })))
+        .mount(&admin)
+        .await;
+
+    let script = format!(
+        r#"
+        local hydra = require("assay.hydra")
+        local h = hydra.client({{ admin_url = "{}" }})
+        local info = h:introspect("access.jwt")
+        assert.eq(info.active, true)
+        assert.eq(info.sub, "user:alice")
+        "#,
+        admin.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_hydra_well_known() {
+    let public = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/.well-known/openid-configuration"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "issuer": "https://hydra.example.com",
+            "authorization_endpoint": "https://hydra.example.com/oauth2/auth",
+            "token_endpoint": "https://hydra.example.com/oauth2/token"
+        })))
+        .mount(&public)
+        .await;
+
+    let script = format!(
+        r#"
+        local hydra = require("assay.hydra")
+        local h = hydra.client({{ public_url = "{}" }})
+        local wk = h:well_known()
+        assert.contains(wk.issuer, "hydra.example.com")
+        "#,
+        public.uri()
+    );
+    run_lua(&script).await.unwrap();
+}

--- a/tests/stdlib_keto.rs
+++ b/tests/stdlib_keto.rs
@@ -1,0 +1,242 @@
+mod common;
+
+use common::run_lua;
+use wiremock::matchers::{method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[tokio::test]
+async fn test_keto_require() {
+    let script = r#"
+        local keto = require("assay.keto")
+        assert.not_nil(keto)
+        assert.not_nil(keto.client)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_keto_list() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/relation-tuples"))
+        .and(query_param("namespace", "Role"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "relation_tuples": [
+                {
+                    "namespace": "Role",
+                    "object": "platform:super-admin",
+                    "relation": "members",
+                    "subject_id": "user:alice"
+                }
+            ],
+            "next_page_token": ""
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local keto = require("assay.keto")
+        local k = keto.client("{}")
+        local result = k:list({{ namespace = "Role" }})
+        assert.eq(#result.relation_tuples, 1)
+        assert.eq(result.relation_tuples[1].object, "platform:super-admin")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_keto_check_allowed() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/relation-tuples/check"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({ "allowed": true })),
+        )
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local keto = require("assay.keto")
+        local k = keto.client("{}")
+        local ok = k:check("apps", "cc", "admin", "user:alice")
+        assert.eq(ok, true)
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_keto_check_denied() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/relation-tuples/check"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({ "allowed": false })),
+        )
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local keto = require("assay.keto")
+        local k = keto.client("{}")
+        local ok = k:check("apps", "cc", "admin", "user:bob")
+        assert.eq(ok, false)
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_keto_get_user_roles() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/relation-tuples"))
+        .and(query_param("namespace", "Role"))
+        .and(query_param("relation", "members"))
+        .and(query_param("subject_id", "user:alice"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "relation_tuples": [
+                {
+                    "namespace": "Role",
+                    "object": "platform:super-admin",
+                    "relation": "members",
+                    "subject_id": "user:alice"
+                },
+                {
+                    "namespace": "Role",
+                    "object": "command-center:admin",
+                    "relation": "members",
+                    "subject_id": "user:alice"
+                }
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local keto = require("assay.keto")
+        local k = keto.client("{}")
+        local roles = k:get_user_roles("alice")
+        assert.eq(#roles, 2)
+        assert.eq(roles[1].object, "platform:super-admin")
+        assert.eq(roles[2].object, "command-center:admin")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_keto_user_has_any_role() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/relation-tuples"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "relation_tuples": [
+                {
+                    "namespace": "Role",
+                    "object": "command-center:operator",
+                    "relation": "members",
+                    "subject_id": "user:bob"
+                }
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local keto = require("assay.keto")
+        local k = keto.client("{}")
+        local has_admin = k:user_has_any_role("bob", {{"platform:super-admin", "command-center:admin"}})
+        assert.eq(has_admin, false)
+        local has_op = k:user_has_any_role("bob", {{"command-center:operator"}})
+        assert.eq(has_op, true)
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_keto_expand() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/relation-tuples/expand"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "type": "union",
+            "tuple": {
+                "namespace": "Role",
+                "object": "platform:super-admin",
+                "relation": "members"
+            },
+            "children": []
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local keto = require("assay.keto")
+        local k = keto.client("{}")
+        local tree = k:expand("Role", "platform:super-admin", "members")
+        assert.eq(tree.type, "union")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_keto_create_tuple() {
+    let read_server = MockServer::start().await;
+    let write_server = MockServer::start().await;
+    Mock::given(method("PUT"))
+        .and(path("/admin/relation-tuples"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({})))
+        .mount(&write_server)
+        .await;
+
+    let script = format!(
+        r#"
+        local keto = require("assay.keto")
+        local k = keto.client("{}", {{ write_url = "{}" }})
+        k:create({{
+          namespace = "Role",
+          object = "command-center:viewer",
+          relation = "members",
+          subject_id = "user:carol",
+        }})
+        "#,
+        read_server.uri(),
+        write_server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_keto_write_requires_write_url() {
+    let read_server = MockServer::start().await;
+
+    let script = format!(
+        r#"
+        local keto = require("assay.keto")
+        local k = keto.client("{}")
+        local ok, err = pcall(function()
+          k:create({{ namespace = "Role", object = "x", relation = "members", subject_id = "user:y" }})
+        end)
+        assert.eq(ok, false)
+        assert.contains(tostring(err), "write_url not configured")
+        "#,
+        read_server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}

--- a/tests/stdlib_kratos.rs
+++ b/tests/stdlib_kratos.rs
@@ -1,0 +1,195 @@
+mod common;
+
+use common::run_lua;
+use wiremock::matchers::{header, method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+#[tokio::test]
+async fn test_kratos_require() {
+    let script = r#"
+        local kratos = require("assay.kratos")
+        assert.not_nil(kratos)
+        assert.not_nil(kratos.client)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_kratos_whoami_authenticated() {
+    let public = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/sessions/whoami"))
+        .and(header("cookie", "ory_session_abc=xyz"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "session-id",
+            "active": true,
+            "identity": {
+                "id": "user-id",
+                "traits": {
+                    "email": "alice@siemens.com",
+                    "name": { "first": "Alice", "last": "Smith" }
+                }
+            }
+        })))
+        .mount(&public)
+        .await;
+
+    let script = format!(
+        r#"
+        local kratos = require("assay.kratos")
+        local k = kratos.client({{ public_url = "{}" }})
+        local session = k:whoami("ory_session_abc=xyz")
+        assert.not_nil(session)
+        assert.eq(session.identity.traits.email, "alice@siemens.com")
+        "#,
+        public.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_kratos_whoami_unauthenticated() {
+    let public = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/sessions/whoami"))
+        .respond_with(ResponseTemplate::new(401).set_body_json(serde_json::json!({
+            "error": { "code": 401, "message": "unauthenticated" }
+        })))
+        .mount(&public)
+        .await;
+
+    let script = format!(
+        r#"
+        local kratos = require("assay.kratos")
+        local k = kratos.client({{ public_url = "{}" }})
+        local session = k:whoami("bogus=cookie")
+        assert.eq(session, nil)
+        "#,
+        public.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_kratos_get_identity() {
+    let admin = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/admin/identities/user-123"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "user-123",
+            "schema_id": "default",
+            "traits": {
+                "email": "bob@siemens.com",
+                "name": { "first": "Bob", "last": "Jones" }
+            }
+        })))
+        .mount(&admin)
+        .await;
+
+    let script = format!(
+        r#"
+        local kratos = require("assay.kratos")
+        local k = kratos.client({{ admin_url = "{}" }})
+        local identity = k:get_identity("user-123")
+        assert.eq(identity.id, "user-123")
+        assert.eq(identity.traits.email, "bob@siemens.com")
+        "#,
+        admin.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_kratos_list_identities() {
+    let admin = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/admin/identities"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+            { "id": "u1", "traits": { "email": "a@siemens.com" } },
+            { "id": "u2", "traits": { "email": "b@siemens.com" } }
+        ])))
+        .mount(&admin)
+        .await;
+
+    let script = format!(
+        r#"
+        local kratos = require("assay.kratos")
+        local k = kratos.client({{ admin_url = "{}" }})
+        local identities = k:list_identities()
+        assert.eq(#identities, 2)
+        "#,
+        admin.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_kratos_create_identity() {
+    let admin = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/admin/identities"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+            "id": "new-user-id",
+            "schema_id": "default",
+            "traits": { "email": "new@siemens.com" }
+        })))
+        .mount(&admin)
+        .await;
+
+    let script = format!(
+        r#"
+        local kratos = require("assay.kratos")
+        local k = kratos.client({{ admin_url = "{}" }})
+        local identity = k:create_identity({{
+          schema_id = "default",
+          traits = {{ email = "new@siemens.com" }},
+        }})
+        assert.eq(identity.id, "new-user-id")
+        "#,
+        admin.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_kratos_get_login_flow() {
+    let public = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/self-service/login/flows"))
+        .and(query_param("id", "flow-abc"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "flow-abc",
+            "type": "browser",
+            "oauth2_login_challenge": "challenge-xyz",
+            "ui": {
+                "action": "https://kratos.example.com/self-service/login?flow=flow-abc",
+                "nodes": []
+            }
+        })))
+        .mount(&public)
+        .await;
+
+    let script = format!(
+        r#"
+        local kratos = require("assay.kratos")
+        local k = kratos.client({{ public_url = "{}" }})
+        local flow = k:get_login_flow("flow-abc")
+        assert.eq(flow.id, "flow-abc")
+        assert.eq(flow.oauth2_login_challenge, "challenge-xyz")
+        "#,
+        public.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_kratos_ory_wrapper() {
+    let script = r#"
+        local ory = require("assay.ory")
+        assert.not_nil(ory.kratos)
+        assert.not_nil(ory.hydra)
+        assert.not_nil(ory.keto)
+        assert.not_nil(ory.connect)
+    "#;
+    run_lua(script).await.unwrap();
+}


### PR DESCRIPTION
## Summary

v0.8.0 is the **identity and auth stack release**. Four new stdlib modules give
assay a complete, tested SDK for the Ory ecosystem. Zero new Rust dependencies;
binary size unchanged.

## New modules

- **`assay.kratos`** — Identity management. Login/registration/recovery flows,
  identity CRUD, `whoami`, schema management.
- **`assay.hydra`** — OAuth2/OpenID Connect. Client CRUD, authorize URL builder,
  token exchange, accept/reject login and consent challenges, introspection,
  JWK endpoint, OIDC discovery.
- **`assay.keto`** — Relationship-based access control (Zanzibar-style ReBAC).
  Relation-tuple CRUD, permission checks, expand API, role/group membership
  helpers.
- **`assay.ory`** — Convenience wrapper with `ory.connect(opts)` to build all
  three clients in one call.

## Also in this release

- **Multi-value response headers in `http.serve`** — header values can now be a
  Lua array of strings, emitting the same header name multiple times. Required
  for setting multiple `Set-Cookie` headers in one response.

## Impact

- Module count: **29 stdlib → 33**, total **46 → 50**.
- Binary size: unchanged (pure Lua modules).
- A 50+ tool MCP server in 9 MB — no other runtime offers the same coverage.

## Test plan

- [x] `cargo clippy` — zero warnings
- [ ] `cargo test` — needs CI run