### PR TITLE
fix(http): URL-decode req.params query string values (0.8.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Assay are documented here.
 
+## [0.8.1] - 2026-04-07
+
+### Fixed
+
+- **`req.params` now URL-decodes query string values** in `http.serve`. Previously
+  `?challenge=abc%3D` produced `req.params.challenge == "abc%3D"`, so consumers
+  that re-encoded the value (such as `assay.hydra:get_login_request`) ended up
+  double-encoding it to `abc%253D` and getting a 404 from the upstream service.
+  Values are now decoded with `form_urlencoded::parse`, so `+` becomes a space
+  and percent-escapes are decoded correctly. The raw query string remains
+  available as `req.query` for handlers that need the verbatim form.
+
 ## [0.8.0] - 2026-04-07
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "assay-lua"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-lua"
-version = "0.8.0"
+version = "0.8.1"
 categories = ["command-line-utilities", "development-tools::testing"]
 edition = "2024"
 homepage = "https://assay.rs"
@@ -23,7 +23,7 @@ default = ["db", "server", "cli", "temporal"]
 db = ["dep:sqlx"]
 server = ["dep:http-body-util", "dep:hyper", "dep:hyper-util"]
 cli = ["dep:clap", "dep:tracing-subscriber"]
-temporal = ["dep:temporalio-client", "dep:temporalio-sdk", "dep:temporalio-common", "dep:url"]
+temporal = ["dep:temporalio-client", "dep:temporalio-sdk", "dep:temporalio-common"]
 
 [dependencies]
 # Lua scripting engine
@@ -94,7 +94,9 @@ minijinja = "2.15.1"
 temporalio-client = { version = "0.2.0", optional = true }
 temporalio-sdk = { version = "0.2.0", optional = true }
 temporalio-common = { version = "0.2.0", optional = true }
-url = { version = "2", optional = true }
+
+# URL parsing/encoding (used by http server query string decoding and Temporal)
+url = "2"
 
 # HTTP server (optional — only needed for http.serve() Lua builtin)
 axum = "0.8.8"

--- a/src/lua/builtins/http.rs
+++ b/src/lua/builtins/http.rs
@@ -483,13 +483,14 @@ async fn build_lua_request_and_call(
     req_table.set("query", query.to_string())?;
     req_table.set("body", body.to_string())?;
 
-    // Parse query string into a params table (e.g. "a=1&b=2" -> {a="1", b="2"})
+    // Parse query string into a params table with URL-decoded keys and values
+    // (e.g. "a=1&b=hello%20world" -> {a="1", b="hello world"}).
+    // Uses form_urlencoded which handles percent-encoding and `+` -> ` ` correctly,
+    // so consumers like assay.hydra get the raw value back rather than a doubly-encoded string.
     let params_table = lua.create_table()?;
     if !query.is_empty() {
-        for pair in query.split('&') {
-            if let Some((key, value)) = pair.split_once('=') {
-                params_table.set(key.to_string(), value.to_string())?;
-            }
+        for (key, value) in url::form_urlencoded::parse(query.as_bytes()) {
+            params_table.set(key.into_owned(), value.into_owned())?;
         }
     }
     req_table.set("params", params_table)?;

--- a/tests/http_serve.rs
+++ b/tests/http_serve.rs
@@ -354,6 +354,51 @@ async fn test_http_serve_query_params() {
 }
 
 #[tokio::test]
+async fn test_http_serve_url_encoded_query_params() {
+    // Regression test: req.params must contain URL-decoded values, not raw
+    // percent-encoded strings. Otherwise consumers that re-encode (e.g.
+    // assay.hydra) end up double-encoding values like "g=" -> "g%3D" -> "g%253D".
+    run_lua_local(
+        r#"
+        local server = async.spawn(function()
+            http.serve(0, {
+                GET = {
+                    ["/echo"] = function(req)
+                        return {
+                            status = 200,
+                            json = {
+                                challenge = req.params.challenge,
+                                space    = req.params.space,
+                                plus     = req.params.plus,
+                                eq       = req.params.eq,
+                                unicode  = req.params.unicode,
+                            }
+                        }
+                    end,
+                }
+            })
+        end)
+        sleep(0.1)
+        local port = _SERVER_PORT
+        -- challenge ends with `=` (base64 padding) URL-encoded as %3D
+        -- space encoded as %20 and as `+`
+        -- raw `=` mid-value, and a unicode char
+        local resp = http.get("http://127.0.0.1:" .. port
+            .. "/echo?challenge=abc%3D&space=hello%20world&plus=hello+world&eq=a%3Db&unicode=caf%C3%A9")
+        assert.eq(resp.status, 200)
+        local data = json.parse(resp.body)
+        assert.eq(data.challenge, "abc=")
+        assert.eq(data.space, "hello world")
+        assert.eq(data.plus, "hello world")
+        assert.eq(data.eq, "a=b")
+        assert.eq(data.unicode, "café")
+    "#,
+    )
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
 async fn test_http_serve_multi_value_header() {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
     use tokio::net::TcpStream;


### PR DESCRIPTION
## Summary

Fixes a bug in `http.serve` where `req.params` returned raw percent-encoded query string values instead of decoded ones.

Hit in production: a Hydra OIDC login flow passed a base64 challenge ending in \`=\` (encoded as \`%3D\` in the URL). The handler read \`req.params.login_challenge\` (which gave back \`...g%3D\` instead of \`...g=\`), then \`assay.hydra:get_login_request\` URL-encoded that value again, sending \`...g%253D\` to Hydra's admin API. Hydra returned 404 Not Found and the whole login flow broke.

## Changes

- **`src/lua/builtins/http.rs`** — replace ad-hoc \`split('&')\` / \`split_once('=')\` parsing with \`url::form_urlencoded::parse\`. Decodes percent-escapes and \`+\`-as-space, matches every other HTTP framework.
- **\`Cargo.toml\`** — promote \`url\` from an optional (temporal-only) dep to a regular dep since the http server now needs it. No new transitive deps; binary size unchanged.
- **\`tests/http_serve.rs\`** — adds \`test_http_serve_url_encoded_query_params\` covering \`%3D\`, \`%20\`, \`+\`, embedded \`=\`, and unicode (\`café\`).
- **\`CHANGELOG.md\`** — 0.8.1 entry under Fixed.
- **\`Cargo.toml\`** — version bump 0.8.0 → 0.8.1.

## Test plan

- [x] \`cargo test\` (full suite passes)
- [x] \`cargo clippy --all-targets -- -D warnings\` (clean)
- [x] New regression test exercises percent-decoding, plus-as-space, embedded \`=\`, and unicode
- [x] CI green