### PR TITLE
chore: relicense to Apache 2.0, extract site partials, add CLA

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,7 @@ on:
       - main
     paths:
       - "site/**"
+      - "site-partials/**"
       - "CHANGELOG.md"
       - "wrangler.toml"
 
@@ -47,14 +48,8 @@ jobs:
             d
           }' site/changelog.html
 
-      - name: Stamp version into site
-        run: |
-          TAG=$(git describe --tags --exact-match HEAD 2>/dev/null || echo "")
-          SHORT_SHA=$(git rev-parse --short HEAD)
-          VERSION="${TAG:-$SHORT_SHA}"
-          for f in site/*.html; do
-            sed -i "s|__GIT_SHA__|${VERSION}|g" "$f"
-          done
+      - name: Render site (inline partials, stamp version)
+        run: ./site-partials/build.sh
 
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,117 @@
+# Assay Contributor License Agreement
+
+Thank you for your interest in contributing to Assay (the "Project"), maintained
+by Nayeem Syed (the "Project Owner").
+
+This Contributor License Agreement ("Agreement") clarifies the intellectual
+property license granted with Contributions from any person or entity to the
+Project. It protects You, the Project Owner, and users of the Project; it does
+not change Your rights to use Your own Contributions for any other purpose.
+
+By submitting a Contribution to the Project (for example, by opening a pull
+request and acknowledging this Agreement via the CLA Assistant comment), You
+accept and agree to the following terms for Your present and future
+Contributions submitted to the Project.
+
+## 1. Definitions
+
+**"You"** (or **"Your"**) means the copyright owner or legal entity authorized
+by the copyright owner that is making this Agreement with the Project Owner.
+
+**"Contribution"** means any original work of authorship, including any
+modifications or additions to an existing work, that is intentionally submitted
+by You to the Project for inclusion in, or documentation of, the Project. For
+the purposes of this definition, "submitted" means any form of electronic,
+verbal, or written communication sent to the Project or its maintainers,
+including but not limited to communication on issue trackers, source code
+control systems, and mailing lists, but excluding communication that is
+conspicuously marked or otherwise designated in writing by You as
+"Not a Contribution."
+
+## 2. Grant of Copyright License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to the
+Project Owner and to recipients of software distributed by the Project Owner a
+**perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable**
+copyright license to **reproduce, prepare derivative works of, publicly display,
+publicly perform, sublicense, and distribute** Your Contributions and such
+derivative works **under any license terms, including but not limited to**
+the Apache License, Version 2.0, **and including under proprietary or
+commercial license terms**.
+
+This means: You retain the copyright to Your Contribution, but You grant the
+Project Owner the right to relicense the Project (including Your Contribution)
+under different terms in the future, and to include Your Contribution in
+proprietary or commercial editions of the Project or related products.
+
+## 3. Grant of Patent License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to the
+Project Owner and to recipients of software distributed by the Project Owner a
+perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+(except as stated in this section) patent license to make, have made, use,
+offer to sell, sell, import, and otherwise transfer the Project, where such
+license applies only to those patent claims licensable by You that are
+necessarily infringed by Your Contribution(s) alone or by combination of Your
+Contribution(s) with the Project to which such Contribution(s) was submitted.
+If any entity institutes patent litigation against You or any other entity
+(including a cross-claim or counterclaim in a lawsuit) alleging that Your
+Contribution, or the Project to which You have contributed, constitutes direct
+or contributory patent infringement, then any patent licenses granted to that
+entity under this Agreement for that Contribution or Project shall terminate
+as of the date such litigation is filed.
+
+## 4. You Have the Right to Grant This License
+
+You represent that:
+
+1. You are legally entitled to grant the above license. If Your employer(s)
+   have rights to intellectual property that You create that includes Your
+   Contributions, You represent that You have received permission to make
+   Contributions on behalf of that employer, that Your employer has waived
+   such rights for Your Contributions to the Project, or that Your employer
+   has executed a separate agreement with the Project Owner.
+2. Each of Your Contributions is Your original creation (see Section 5 for
+   submissions on behalf of others).
+3. Your Contribution submissions include complete details of any third-party
+   license or other restriction (including, but not limited to, related
+   patents and trademarks) of which You are personally aware and which are
+   associated with any part of Your Contributions.
+
+## 5. Submissions of Work That Is Not Your Original Creation
+
+Should You wish to submit work that is not Your original creation, You may
+submit it to the Project separately from any Contribution, identifying the
+complete details of its source and of any license or other restriction
+(including, but not limited to, related patents, trademarks, and license
+agreements) of which You are personally aware, and conspicuously marking the
+work as "Submitted on behalf of a third-party: [named here]".
+
+## 6. No Obligation
+
+You are not expected to provide support for Your Contributions, except to the
+extent You desire to provide support. You may provide support for free, for a
+fee, or not at all. Unless required by applicable law or agreed to in writing,
+You provide Your Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied, including, without
+limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT,
+MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+## 7. Notice of Changes
+
+You agree to notify the Project Owner of any facts or circumstances of which
+You become aware that would make the representations in this Agreement
+inaccurate in any respect.
+
+---
+
+## How to sign
+
+When You open a pull request, the **CLA Assistant** bot will post a comment
+asking You to sign this Agreement. You sign by clicking the link in the bot's
+comment and agreeing to these terms with Your GitHub account. You only need to
+sign once — the signature applies to all Your future Contributions to the
+Project.
+
+If You are contributing on behalf of an employer, please ensure You have Your
+employer's permission before signing.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,71 @@
+# Contributing to Assay
+
+Thanks for your interest in contributing to Assay! This document explains how
+to file issues, submit pull requests, and what we expect from contributions.
+
+## Reporting bugs and requesting features
+
+- **Bug reports**: please open an issue on GitHub with a minimal reproduction
+  (the smallest `.lua` script that triggers the problem) plus the assay
+  version (`assay --version`), platform, and full error output.
+- **Feature requests**: open an issue describing the use case first. We'd
+  rather discuss design before you spend time on a PR that may need to be
+  redone.
+
+## Pull requests
+
+Before sending a PR:
+
+1. **Open or comment on an issue first** for anything non-trivial. A two-line
+   bug fix is fine to send directly. A new stdlib module or builtin is not.
+2. **Run the full test suite locally**:
+
+   ```sh
+   cargo test
+   cargo clippy --all-targets -- -D warnings
+   cargo fmt --check
+   ```
+
+3. **Add tests for your change**. Bug fixes need a regression test that fails
+   before the fix and passes after. New features need coverage of the happy
+   path and the obvious failure modes.
+4. **Match the existing code style**. We use `cargo fmt` for Rust and follow
+   the conventions in `stdlib/` for Lua modules. Look at neighbouring files
+   before writing new ones.
+5. **Update documentation**. If you change a public API, update `CHANGELOG.md`,
+   any relevant `@quickref` metadata in stdlib files, and the matching
+   section of `README.md` / `site/modules.html` if applicable.
+6. **Keep PRs focused**. One logical change per PR. If you find unrelated
+   issues while working, open a separate PR for those.
+
+## Contributor License Agreement (CLA)
+
+Assay requires all contributors to sign a Contributor License Agreement before
+their PRs can be merged. The full text of the CLA is in [`CLA.md`](CLA.md).
+
+**Why we have a CLA**: it lets the project owner relicense the project (or
+include contributions in proprietary commercial editions) in the future
+without needing to track down every contributor for permission. You retain
+the copyright on your contribution; you grant the project owner a broad
+license to use it.
+
+**How to sign**: when you open your first PR, the CLA Assistant bot will post
+a comment with a link. Click the link, agree to the terms with your GitHub
+account, and you're done — your signature is recorded for all future PRs to
+this project.
+
+If you can't or won't sign the CLA (for example, because your employer
+prohibits it), please open an issue describing the change instead and we'll
+figure out an alternative path together.
+
+## Code of conduct
+
+Be kind. Disagree on technical merits, not on people. Project maintainers
+reserve the right to close issues, remove comments, or block users that
+consistently fail to engage in good faith.
+
+## License
+
+By contributing to Assay, you agree that your contributions will be licensed
+under the [Apache License, Version 2.0](LICENSE) and that your contribution
+is also subject to the terms of the [CLA](CLA.md).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ categories = ["command-line-utilities", "development-tools::testing"]
 edition = "2024"
 homepage = "https://assay.rs"
 keywords = ["lua", "scripting", "automation", "runtime", "kubernetes"]
-license = "MIT"
+license = "Apache-2.0"
 repository = "https://github.com/developerinlondon/assay"
 description = "General-purpose enhanced Lua runtime. Batteries-included scripting, automation, and web services."
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for describing the origin of the Work and
+      reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may accept and charge a
+      fee for, or grant additional warranty, support, indemnity, or
+      other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Nayeem Syed
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,7 @@
+Assay
+Copyright 2026 Nayeem Syed
+
+This product includes software developed by Assay contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License").
+See the LICENSE file for the full license text.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Replaces your entire infrastructure scripting toolchain. One 9 MB binary, 50 mod
 
 [![CI](https://github.com/developerinlondon/assay/actions/workflows/ci.yml/badge.svg)](https://github.com/developerinlondon/assay/actions/workflows/ci.yml)
 [![Crates.io](https://img.shields.io/crates/v/assay-lua.svg)](https://crates.io/crates/assay-lua)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 
 ## What is Assay?
 
@@ -312,7 +312,17 @@ dprint fmt                # Format (Rust, Markdown, YAML, JSON, TOML)
 
 ## License
 
-MIT
+Assay is licensed under the [Apache License, Version 2.0](LICENSE). You can use,
+modify, and redistribute it freely — including in commercial and proprietary
+products — as long as you preserve the copyright notice and the license text.
+
+## Contributing
+
+Pull requests are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for the
+workflow and [CLA.md](CLA.md) for the Contributor License Agreement that all
+contributors are required to sign (it lets the project owner relicense or
+incorporate contributions into commercial editions in the future, while you
+keep the copyright on your contribution).
 
 ## Links
 

--- a/site-partials/build.sh
+++ b/site-partials/build.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Build script for the assay.rs static site.
+#
+# Substitutes the following placeholders in every site/*.html:
+#   __HEADER__   → contents of site-partials/header.html
+#   __FOOTER__   → contents of site-partials/footer.html
+#   __GIT_SHA__  → current git tag or short SHA
+#
+# Used by .github/workflows/deploy.yml in CI, and runnable locally for
+# preview. Mutates files in place — in CI that's fine because each run
+# starts from a clean checkout. Locally, run on a clean working tree
+# and `git checkout site/` afterwards if you want the placeholders back.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SITE_DIR="${REPO_ROOT}/site"
+PARTIALS_DIR="${REPO_ROOT}/site-partials"
+
+if [[ ! -d "${SITE_DIR}" ]]; then
+  echo "error: ${SITE_DIR} not found" >&2
+  exit 1
+fi
+
+# sed -i has different syntax on macOS vs GNU; use a portable wrapper
+sed_inplace() {
+  if [[ "$(uname)" == "Darwin" ]]; then
+    sed -i "" "$@"
+  else
+    sed -i "$@"
+  fi
+}
+
+# Substitute a placeholder line with the contents of a file.
+# Uses awk so we don't have to escape every special character in the partial.
+substitute_partial() {
+  local placeholder="$1"
+  local partial_file="$2"
+  local target_file="$3"
+
+  awk -v ph="${placeholder}" -v pf="${partial_file}" '
+    $0 ~ ph {
+      while ((getline line < pf) > 0) print line
+      close(pf)
+      next
+    }
+    { print }
+  ' "${target_file}" > "${target_file}.tmp"
+  mv "${target_file}.tmp" "${target_file}"
+}
+
+echo "Substituting partials into site/*.html"
+for f in "${SITE_DIR}"/*.html; do
+  substitute_partial "__HEADER__" "${PARTIALS_DIR}/header.html" "${f}"
+  substitute_partial "__FOOTER__" "${PARTIALS_DIR}/footer.html" "${f}"
+done
+
+echo "Stamping version"
+TAG="$(git -C "${REPO_ROOT}" describe --tags --exact-match HEAD 2>/dev/null || true)"
+SHORT_SHA="$(git -C "${REPO_ROOT}" rev-parse --short HEAD 2>/dev/null || true)"
+VERSION="${TAG:-${SHORT_SHA:-local-dev}}"
+for f in "${SITE_DIR}"/*.html; do
+  sed_inplace "s|__GIT_SHA__|${VERSION}|g" "${f}"
+done
+
+echo "Done. Site rendered at ${SITE_DIR}/"

--- a/site-partials/footer.html
+++ b/site-partials/footer.html
@@ -1,0 +1,8 @@
+  <footer>
+    <p>Assay is licensed under <a href="https://github.com/developerinlondon/assay/blob/main/LICENSE">Apache 2.0</a> &mdash;
+      <a href="https://github.com/developerinlondon/assay"><svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" style="vertical-align: middle; margin-right: 2px;"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>GitHub</a> &middot;
+      <a href="https://crates.io/crates/assay-lua">crates.io</a> &middot;
+      <a href="https://github.com/developerinlondon/assay/pkgs/container/assay">Docker</a>
+    </p>
+    <p class="text-muted">&copy; 2026 Assay Contributors &middot; deployed <a href="https://github.com/developerinlondon/assay/commit/__GIT_SHA__" style="font-family: monospace; font-size: 0.75rem;">__GIT_SHA__</a></p>
+  </footer>

--- a/site-partials/header.html
+++ b/site-partials/header.html
@@ -1,0 +1,14 @@
+  <header>
+    <nav>
+      <a href="index.html" class="logo">Assay</a>
+      <ul>
+        <li><a href="index.html">Home</a></li>
+        <li><a href="comparison.html">Comparison</a></li>
+        <li><a href="agent-guides.html">Agent Guides</a></li>
+        <li><a href="modules.html">Modules</a></li>
+        <li><a href="changelog.html">Changelog</a></li>
+        <li><a href="https://github.com/developerinlondon/assay" target="_blank"><svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" style="vertical-align: middle;"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg></a></li>
+        <li><button class="theme-toggle" onclick="toggleTheme()" title="Toggle dark/light mode">&#9789;</button></li>
+      </ul>
+    </nav>
+  </header>

--- a/site/agent-guides.html
+++ b/site/agent-guides.html
@@ -7,21 +7,8 @@
   <meta name="description" content="Integration guides for Claude Code, Cursor, Windsurf, Cline, and OpenCode — use Assay's 50 modules in your AI coding agent.">
   <link rel="stylesheet" href="style.css">
 </head>
-<body>
-  <header>
-    <nav>
-      <a href="index.html" class="logo">Assay</a>
-      <ul>
-        <li><a href="index.html">Home</a></li>
-        <li><a href="comparison.html">Comparison</a></li>
-        <li><a href="agent-guides.html">Agent Guides</a></li>
-        <li><a href="modules.html">Modules</a></li>
-        <li><a href="changelog.html">Changelog</a></li>
-        <li><a href="https://github.com/developerinlondon/assay" target="_blank"><svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" style="vertical-align: middle;"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg></a></li>
-        <li><button class="theme-toggle" onclick="toggleTheme()" title="Toggle dark/light mode">&#9789;</button></li>
-      </ul>
-    </nav>
-  </header>
+<body class="page-agents">
+__HEADER__
 
   <main>
     <h1>AI Agent Integration Guides</h1>
@@ -174,14 +161,7 @@ assay script.lua</code></pre>
     <p>For LLM agents: <a href="llms.txt">llms.txt</a> &middot; <a href="llms-full.txt">llms-full.txt</a></p>
   </main>
 
-  <footer>
-    <p>Assay is MIT licensed &mdash;
-      <a href="https://github.com/developerinlondon/assay"><svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" style="vertical-align: middle; margin-right: 2px;"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>GitHub</a> &middot;
-      <a href="https://crates.io/crates/assay-lua">crates.io</a> &middot;
-      <a href="https://github.com/developerinlondon/assay/pkgs/container/assay">Docker</a>
-    </p>
-    <p class="text-muted">&copy; 2026 Assay Contributors · <span style="font-family: monospace; font-size: 0.75rem;">__GIT_SHA__</span></p>
-  </footer>
+__FOOTER__
 
   <script>
     function toggleTheme() {

--- a/site/changelog.html
+++ b/site/changelog.html
@@ -14,21 +14,8 @@
     .changelog > h2:first-child { margin-top: 0; }
   </style>
 </head>
-<body>
-  <header>
-    <nav>
-      <a href="index.html" class="logo">Assay</a>
-      <ul>
-        <li><a href="index.html">Home</a></li>
-        <li><a href="comparison.html">Comparison</a></li>
-        <li><a href="agent-guides.html">Agent Guides</a></li>
-        <li><a href="modules.html">Modules</a></li>
-        <li><a href="changelog.html">Changelog</a></li>
-        <li><a href="https://github.com/developerinlondon/assay" target="_blank"><svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" style="vertical-align: middle;"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg></a></li>
-        <li><button class="theme-toggle" onclick="toggleTheme()" title="Toggle dark/light mode">&#9789;</button></li>
-      </ul>
-    </nav>
-  </header>
+<body class="page-changelog">
+__HEADER__
 
   <main>
     <h1>Changelog</h1>
@@ -43,14 +30,7 @@ __CHANGELOG_CONTENT__
     </div>
   </main>
 
-  <footer>
-    <p>Assay is MIT licensed &mdash;
-      <a href="https://github.com/developerinlondon/assay">GitHub</a> &middot;
-      <a href="https://crates.io/crates/assay-lua">crates.io</a> &middot;
-      <a href="https://github.com/developerinlondon/assay/pkgs/container/assay">Docker</a>
-    </p>
-    <p class="text-muted">&copy; 2026 Assay Contributors &middot; <span style="font-family: monospace; font-size: 0.75rem;">__GIT_SHA__</span></p>
-  </footer>
+__FOOTER__
 
   <script>
     function toggleTheme() {

--- a/site/comparison.html
+++ b/site/comparison.html
@@ -7,21 +7,8 @@
   <meta name="description" content="Assay covers 26 domains that would otherwise need separate MCP servers. One binary, zero npm dependencies.">
   <link rel="stylesheet" href="style.css">
 </head>
-<body>
-  <header>
-    <nav>
-      <a href="index.html" class="logo">Assay</a>
-      <ul>
-        <li><a href="index.html">Home</a></li>
-        <li><a href="comparison.html">Comparison</a></li>
-        <li><a href="agent-guides.html">Agent Guides</a></li>
-        <li><a href="modules.html">Modules</a></li>
-        <li><a href="changelog.html">Changelog</a></li>
-        <li><a href="https://github.com/developerinlondon/assay" target="_blank"><svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" style="vertical-align: middle;"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg></a></li>
-        <li><button class="theme-toggle" onclick="toggleTheme()" title="Toggle dark/light mode">&#9789;</button></li>
-      </ul>
-    </nav>
-  </header>
+<body class="page-comparison">
+__HEADER__
   <main>
     <h1>Comparison</h1>
 
@@ -176,14 +163,7 @@
     </table>
 
   </main>
-  <footer>
-    <p>Assay is MIT licensed &mdash;
-      <a href="https://github.com/developerinlondon/assay"><svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" style="vertical-align: middle; margin-right: 2px;"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>GitHub</a> &middot;
-      <a href="https://crates.io/crates/assay-lua">crates.io</a> &middot;
-      <a href="https://github.com/developerinlondon/assay/pkgs/container/assay">Docker</a>
-    </p>
-    <p class="text-muted">&copy; 2026 Assay Contributors · <span style="font-family: monospace; font-size: 0.75rem;">__GIT_SHA__</span></p>
-  </footer>
+__FOOTER__
 
   <script>
     function toggleTheme() {

--- a/site/index.html
+++ b/site/index.html
@@ -7,21 +7,8 @@
   <meta name="description" content="Assay is a 9 MB Lua runtime for infrastructure testing, Kubernetes automation, HTTP servers, and AI agent integration. 50 modules. Replaces kubectl, Python, Node.js, curl, jq.">
   <link rel="stylesheet" href="style.css">
 </head>
-<body>
-  <header>
-    <nav>
-      <a href="index.html" class="logo">Assay</a>
-      <ul>
-        <li><a href="index.html">Home</a></li>
-        <li><a href="comparison.html">Comparison</a></li>
-        <li><a href="agent-guides.html">Agent Guides</a></li>
-        <li><a href="modules.html">Modules</a></li>
-        <li><a href="changelog.html">Changelog</a></li>
-        <li><a href="https://github.com/developerinlondon/assay" target="_blank"><svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" style="vertical-align: middle;"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg></a></li>
-        <li><button class="theme-toggle" onclick="toggleTheme()" title="Toggle dark/light mode">&#9789;</button></li>
-      </ul>
-    </nav>
-  </header>
+<body class="page-home">
+__HEADER__
 
   <main>
     <!-- Hero -->
@@ -292,14 +279,7 @@ cargo install assay-lua
 
   </main>
 
-  <footer>
-    <p>Assay is MIT licensed &mdash;
-      <a href="https://github.com/developerinlondon/assay"><svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" style="vertical-align: middle; margin-right: 2px;"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>GitHub</a> &middot;
-      <a href="https://crates.io/crates/assay-lua">crates.io</a> &middot;
-      <a href="https://github.com/developerinlondon/assay/pkgs/container/assay">Docker</a>
-    </p>
-    <p class="text-muted">&copy; 2026 Assay Contributors · <span style="font-family: monospace; font-size: 0.75rem;">__GIT_SHA__</span></p>
-  </footer>
+__FOOTER__
 
   <script>
     function toggleTheme() {

--- a/site/modules.html
+++ b/site/modules.html
@@ -7,21 +7,8 @@
   <meta name="description" content="Complete reference for all 50+ Assay modules — 17 Rust builtins and 33 embedded Lua stdlib modules, zero dependencies.">
   <link rel="stylesheet" href="style.css">
 </head>
-<body>
-  <header>
-    <nav>
-      <a href="index.html" class="logo">Assay</a>
-      <ul>
-        <li><a href="index.html">Home</a></li>
-        <li><a href="comparison.html">Comparison</a></li>
-        <li><a href="agent-guides.html">Agent Guides</a></li>
-        <li><a href="modules.html">Modules</a></li>
-        <li><a href="changelog.html">Changelog</a></li>
-        <li><a href="https://github.com/developerinlondon/assay" target="_blank"><svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" style="vertical-align: middle;"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg></a></li>
-        <li><button class="theme-toggle" onclick="toggleTheme()" title="Toggle dark/light mode">&#9789;</button></li>
-      </ul>
-    </nav>
-  </header>
+<body class="page-modules">
+__HEADER__
 
   <main>
     <h1>Module Reference</h1>
@@ -1026,14 +1013,7 @@ local smart_buckets = email_triage.categorize_llm(emails, oc)</code></pre>
     </p>
   </main>
 
-  <footer>
-    <p>Assay is MIT licensed &mdash;
-      <a href="https://github.com/developerinlondon/assay"><svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" style="vertical-align: middle; margin-right: 2px;"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>GitHub</a> &middot;
-      <a href="https://crates.io/crates/assay-lua">crates.io</a> &middot;
-      <a href="https://github.com/developerinlondon/assay/pkgs/container/assay">Docker</a>
-    </p>
-    <p class="text-muted">&copy; 2026 Assay Contributors · <span style="font-family: monospace; font-size: 0.75rem;">__GIT_SHA__</span></p>
-  </footer>
+__FOOTER__
 
   <script>
     function toggleTheme() {

--- a/site/style.css
+++ b/site/style.css
@@ -117,6 +117,16 @@ nav a:hover {
   color: var(--accent);
 }
 
+/* Active page in nav — driven by a body class set per page */
+body.page-home      nav a[href="index.html"],
+body.page-comparison nav a[href="comparison.html"],
+body.page-agents    nav a[href="agent-guides.html"],
+body.page-modules   nav a[href="modules.html"],
+body.page-changelog nav a[href="changelog.html"] {
+  color: var(--accent);
+  font-weight: 700;
+}
+
 /* Theme toggle */
 .theme-toggle {
   background: none;


### PR DESCRIPTION
## Summary

Three things bundled together because they all touch the project metadata + site:

1. **Relicense MIT → Apache 2.0** for the explicit patent grant + the standard convention used by serious infra runtimes (Kubernetes, Rust, TypeScript, LLVM, Android, Swift). Same permissive spirit as MIT.
2. **Add a Contributor License Agreement** (Apache ICLA-style) so the project owner retains the right to relicense or sublicense (including under proprietary/commercial terms in the future) even when accepting external contributions. CLA Assistant will prompt contributors to sign on first PR.
3. **Extract the duplicated site header/footer into shared partials** with a build-time substitution step. Adds active-tab highlighting via a body class.

## License changes

| File | Change |
|---|---|
| \`LICENSE\` | New — full Apache 2.0 text |
| \`NOTICE\` | New — copyright marker |
| \`CLA.md\` | New — contributor license agreement |
| \`CONTRIBUTING.md\` | New — workflow guide + CLA pointer |
| \`Cargo.toml\` | \`license = \"Apache-2.0\"\` (was \"MIT\") |
| \`README.md\` | License badge + section updated |

## Site refactor

| Before | After |
|---|---|
| 5 \`.html\` files each containing a copy of the nav header | All 5 reference \`__HEADER__\` placeholder, single source in \`site-partials/header.html\` |
| 5 \`.html\` files each containing a copy of the footer | All 5 reference \`__FOOTER__\` placeholder, single source in \`site-partials/footer.html\` |
| No active-tab highlighting in nav | Body class per page + one CSS rule highlights the current page |
| Footer SHA is plain text | Footer SHA is a clickable link to the GitHub commit |
| Two substitution loops inlined in \`deploy.yml\` | Single \`site-partials/build.sh\` callable from CI and locally |

\`site-partials/\` lives outside \`site/\` so it isn't deployed publicly. Cloudflare Pages still receives identical fully-rendered HTML.

## Why CLA + Apache 2.0 instead of MIT alone

- **Permissive license** (Apache 2.0) → maximum adoption, no procurement friction, matches every peer in the runtime/dev-tools category.
- **Apache over MIT** → explicit patent grant (Section 3) protects the project and users from patent trolls.
- **CLA on top** → preserves the right to relicense or include contributions in proprietary commercial editions later. Without a CLA, accepting external PRs would lock the project into Apache 2.0 forever (the same trap the Linux kernel is in with GPL v2).
- **Accept contributions** → bug fixes and features from the community without giving up control of the project's commercial trajectory.

## Test plan

- [x] \`./site-partials/build.sh\` runs cleanly on an isolated copy and produces correct rendered HTML
- [x] All \`__HEADER__\`, \`__FOOTER__\`, \`__GIT_SHA__\` placeholders substitute correctly
- [x] Active-tab CSS rule resolves to the correct nav link per body class
- [x] \`Cargo.toml\` validates as \`Apache-2.0\` SPDX identifier
- [x] No remaining \"MIT\" references in user-facing files
- [x] CI green
- [ ] Cloudflare Pages preview deploys correctly (will verify after merge to main)

## Follow-ups (not in this PR)

- Set up CLA Assistant on the GitHub repo (one-time UI step at cla-assistant.io)
- Trademark application for \"assay\" (unrelated to this PR but relevant to the overall \"protect the project\" strategy)