### PR TITLE
fix(site): make active nav tab visibly distinct

### DIFF
--- a/site/style.css
+++ b/site/style.css
@@ -117,7 +117,9 @@ nav a:hover {
   color: var(--accent);
 }
 
-/* Active page in nav — driven by a body class set per page */
+/* Active page in nav — driven by a body class set per page.
+   Highlights the link with the accent color, bolder weight,
+   and a clear underline so the current page is unmistakable. */
 body.page-home      nav a[href="index.html"],
 body.page-comparison nav a[href="comparison.html"],
 body.page-agents    nav a[href="agent-guides.html"],
@@ -125,6 +127,8 @@ body.page-modules   nav a[href="modules.html"],
 body.page-changelog nav a[href="changelog.html"] {
   color: var(--accent);
   font-weight: 700;
+  border-bottom: 2px solid var(--accent);
+  padding-bottom: 2px;
 }
 
 /* Theme toggle */


### PR DESCRIPTION
## Summary

The active-page nav rule added in #25 was technically working (correct body class set per page, correct CSS rule deployed) but visually too subtle — orange-on-grey at 14px just doesn't catch the eye on a quick glance.

Adds a 2px accent-coloured bottom border under the active link so the current page is immediately obvious.

## Test plan

- [x] All 5 page body classes still set correctly (verified on live site)
- [x] CSS rule already in deployed style.css (verified with curl)
- [ ] Visit each page on assay.rs and confirm the active tab now has a clear underline