### PR TITLE
feat(hydra): OIDC logout methods + library hygiene cleanup (0.8.2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,39 @@ Key coding practices for this project:
 - **autonomous-workflow** — Proposal-first development, decision authority, commit hygiene
 - **code-quality** — Warnings-as-errors, no underscore prefixes, test coverage, type safety
 
+## Library hygiene: no application-domain leakage
+
+**Assay is a general-purpose library. It must have zero knowledge of any
+specific application that uses it.** When writing or modifying any code,
+test, comment, doc, changelog entry, commit message, or PR description in
+this repo, never reference:
+
+- Specific consumer applications by name (e.g. "Command Center",
+  "hydra-login", or any internal product)
+- Specific deployments, environments, or company-specific URLs
+  (e.g. `*.dev.simons.disw.siemens.com`, internal cluster names)
+- Company- or project-specific role names, namespaces, client IDs, or
+  resource names that only make sense in one consumer's context
+- The user's organisation, team, or internal project naming conventions
+
+Use generic placeholder names instead:
+
+- Client IDs: `example-app`, `demo-client`, `app-1`
+- Hostnames: `example.com`, `app.example.com`, `hydra.example.com`
+- Role objects: `app:role-a`, `namespace1:role-a`, `app:admin`
+- Project IDs: `demo-project`, `project-1`
+- Workflow names: `MyWorkflow`, `my-queue`
+
+When motivating a new feature in a CHANGELOG entry, commit message, or PR
+description, describe **the OIDC/Kubernetes/HTTP scenario it enables**, not
+**the specific consumer that asked for it**. The library should read the
+same to a stranger who has never heard of any of assay's consumers as it
+does to someone who works on one of them every day.
+
+This applies to all files in the repo: `stdlib/`, `src/`, `tests/`, `*.md`,
+`*.html`, `CHANGELOG.md`, and any commit/PR text. The only legitimate
+exception is the copyright holder's name in `LICENSE`/`NOTICE`/`CLA.md`.
+
 ## What is Assay
 
 General-purpose enhanced Lua runtime. Single ~9 MB static binary with batteries included: HTTP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,7 @@ All notable changes to Assay are documented here.
   - `c:reject_logout(challenge)` — for "stay signed in" UIs that let the
     user cancel the logout
 
-  Symmetric with the existing login/consent methods. Used by hydra-login
-  to handle Command Center and Temporal logout flows.
+  Symmetric with the existing login/consent challenge methods.
 
 ## [0.8.1] - 2026-04-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to Assay are documented here.
 
+## [0.8.2] - 2026-04-07
+
+### Added
+
+- **`assay.hydra` logout challenge methods**: completes the OIDC challenge
+  trio (login, consent, logout). When an app calls Hydra's
+  `/oauth2/sessions/logout` endpoint with `id_token_hint` and
+  `post_logout_redirect_uri`, Hydra creates a logout request and redirects
+  the browser to the configured `urls.logout` endpoint with a
+  `logout_challenge` query param. The handler now has SDK methods to
+  process these requests:
+  - `c:get_logout_request(challenge)` — fetch the pending logout request
+    (subject, sid, client, rp_initiated flag)
+  - `c:accept_logout(challenge)` — invalidate the Hydra and Kratos sessions
+    and get back the `redirect_to` URL pointing at the app's
+    `post_logout_redirect_uri`
+  - `c:reject_logout(challenge)` — for "stay signed in" UIs that let the
+    user cancel the logout
+
+  Symmetric with the existing login/consent methods. Used by hydra-login
+  to handle Command Center and Temporal logout flows.
+
 ## [0.8.1] - 2026-04-07
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "assay-lua"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-lua"
-version = "0.8.1"
+version = "0.8.2"
 categories = ["command-line-utilities", "development-tools::testing"]
 edition = "2024"
 homepage = "https://assay.rs"

--- a/site/style.css
+++ b/site/style.css
@@ -117,7 +117,9 @@ nav a:hover {
   color: var(--accent);
 }
 
-/* Active page in nav — driven by a body class set per page */
+/* Active page in nav — driven by a body class set per page.
+   Highlights the link with the accent color, bolder weight,
+   and a clear underline so the current page is unmistakable. */
 body.page-home      nav a[href="index.html"],
 body.page-comparison nav a[href="comparison.html"],
 body.page-agents    nav a[href="agent-guides.html"],
@@ -125,6 +127,8 @@ body.page-modules   nav a[href="modules.html"],
 body.page-changelog nav a[href="changelog.html"] {
   color: var(--accent);
   font-weight: 700;
+  border-bottom: 2px solid var(--accent);
+  padding-bottom: 2px;
 }
 
 /* Theme toggle */

--- a/src/lua/builtins/temporal.rs
+++ b/src/lua/builtins/temporal.rs
@@ -5,13 +5,13 @@
 /// Usage from Lua:
 ///   local client = temporal.connect({
 ///     url = "temporal-frontend:7233",
-///     namespace = "command-center",
+///     namespace = "default",
 ///   })
 ///   local handle = client:start_workflow({
-///     task_queue = "promotions",
-///     workflow_type = "promote",
-///     workflow_id = "promote-prod-v0.2.0",
-///     input = { version = "v0.2.0", target = "prod" },
+///     task_queue = "my-queue",
+///     workflow_type = "MyWorkflow",
+///     workflow_id = "workflow-1",
+///     input = { foo = "bar" },
 ///   })
 #[cfg(feature = "temporal")]
 pub fn register_temporal(lua: &mlua::Lua) -> mlua::Result<()> {

--- a/stdlib/hydra.lua
+++ b/stdlib/hydra.lua
@@ -1,6 +1,6 @@
 --- @module assay.hydra
---- @description Ory Hydra OAuth2 and OpenID Connect — client CRUD, authorize URL builder, token exchange, login/consent challenges, introspection, JWK endpoint.
---- @keywords hydra, ory, oauth2, oidc, openid, authentication, clients, tokens, login_challenge, consent_challenge, jwk, authorize, introspect
+--- @description Ory Hydra OAuth2 and OpenID Connect — client CRUD, authorize URL builder, token exchange, login/consent/logout challenges, introspection, JWK endpoint.
+--- @keywords hydra, ory, oauth2, oidc, openid, authentication, clients, tokens, login_challenge, consent_challenge, logout_challenge, jwk, authorize, introspect
 --- @quickref hydra.client(opts) -> client | Create a Hydra client. opts: {public_url, admin_url}
 --- @quickref c:list_clients(opts?) -> [{client_id, ...}] | List registered OAuth2 clients
 --- @quickref c:get_client(client_id) -> client | Get a registered OAuth2 client
@@ -18,6 +18,9 @@
 --- @quickref c:get_consent_request(challenge) -> {challenge, subject, requested_scope, ...} | Fetch a pending consent challenge
 --- @quickref c:accept_consent(challenge, opts) -> {redirect_to} | Accept a consent challenge (with claims)
 --- @quickref c:reject_consent(challenge, error) -> {redirect_to} | Reject a consent challenge
+--- @quickref c:get_logout_request(challenge) -> {request_url, rp_initiated, sid, subject, client} | Fetch a pending logout challenge
+--- @quickref c:accept_logout(challenge) -> {redirect_to} | Accept a logout challenge (invalidates session)
+--- @quickref c:reject_logout(challenge) -> nil | Reject a logout challenge (user stays signed in)
 --- @quickref c:well_known() -> {issuer, authorization_endpoint, ...} | Fetch OIDC discovery document
 --- @quickref c:jwks() -> {keys} | Fetch JSON Web Key Set
 
@@ -240,6 +243,31 @@ function M.client(opts)
 
   function c:reject_consent(challenge, err)
     return admin_put(self, "/admin/oauth2/auth/requests/consent/reject?consent_challenge=" .. urlencode(challenge), err or { error = "access_denied" })
+  end
+
+  -- ========== Logout Challenges ==========
+  -- When an OAuth2 client triggers an OIDC logout (typically by hitting
+  -- /oauth2/sessions/logout with id_token_hint and post_logout_redirect_uri),
+  -- Hydra creates a logout request and redirects the user to the configured
+  -- urls.logout endpoint. The logout handler accepts or rejects the request
+  -- via the admin API and gets back a redirect_to URL to send the browser to.
+
+  function c:get_logout_request(challenge)
+    return admin_get(self, "/admin/oauth2/auth/requests/logout?logout_challenge=" .. urlencode(challenge))
+  end
+
+  -- Accept a logout challenge. Hydra invalidates the user's Hydra session
+  -- (and any backing Kratos session) and returns a redirect_to URL pointing
+  -- at the post_logout_redirect_uri the client requested.
+  function c:accept_logout(challenge)
+    return admin_put(self, "/admin/oauth2/auth/requests/logout/accept?logout_challenge=" .. urlencode(challenge), {})
+  end
+
+  -- Reject a logout challenge (for example, if the user clicks "stay
+  -- signed in" on a logout confirmation page). Returns nothing meaningful;
+  -- the handler should redirect the browser back to the application.
+  function c:reject_logout(challenge)
+    return admin_put(self, "/admin/oauth2/auth/requests/logout/reject?logout_challenge=" .. urlencode(challenge), {})
   end
 
   -- ========== OIDC Discovery ==========

--- a/stdlib/keto.lua
+++ b/stdlib/keto.lua
@@ -92,9 +92,11 @@ function M.client(read_url, opts)
   end
 
   -- Helper: get all role memberships for a user.
-  -- By default queries the Role namespace which is the SIMONS convention.
+  -- By default queries the "Role" namespace, the standard convention for
+  -- modelling RBAC-style memberships in Keto. Pass a different namespace
+  -- if your application uses one.
   -- Returns a list of { object, relation } entries, e.g.
-  --   { {object="platform:super-admin", relation="members"}, {object="command-center:admin", relation="members"} }
+  --   { {object="app:role-a", relation="members"}, {object="app:role-b", relation="members"} }
   function c:get_user_roles(user_id, namespace)
     local subject = user_id
     if not user_id:match("^user:") then
@@ -112,7 +114,7 @@ function M.client(read_url, opts)
     return roles
   end
 
-  -- Helper: check if a user has any of the given role objects (e.g. {"platform:super-admin", "command-center:admin"})
+  -- Helper: check if a user has any of the given role objects (e.g. {"app:admin", "app:operator"})
   function c:user_has_any_role(user_id, role_objects, namespace)
     local roles = self:get_user_roles(user_id, namespace)
     local set = {}

--- a/tests/stdlib_hydra.rs
+++ b/tests/stdlib_hydra.rs
@@ -20,8 +20,8 @@ async fn test_hydra_list_clients() {
     Mock::given(method("GET"))
         .and(path("/admin/clients"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
-            { "client_id": "cc", "client_name": "Command Center" },
-            { "client_id": "temporal", "client_name": "Temporal" }
+            { "client_id": "example-app", "client_name": "Example App" },
+            { "client_id": "another-app", "client_name": "Another App" }
         ])))
         .mount(&admin)
         .await;
@@ -32,7 +32,7 @@ async fn test_hydra_list_clients() {
         local h = hydra.client({{ admin_url = "{}" }})
         local clients = h:list_clients()
         assert.eq(#clients, 2)
-        assert.eq(clients[1].client_id, "cc")
+        assert.eq(clients[1].client_id, "example-app")
         "#,
         admin.uri()
     );
@@ -43,10 +43,10 @@ async fn test_hydra_list_clients() {
 async fn test_hydra_update_client() {
     let admin = MockServer::start().await;
     Mock::given(method("PUT"))
-        .and(path("/admin/clients/cc"))
+        .and(path("/admin/clients/example-app"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "client_id": "cc",
-            "client_name": "Command Center",
+            "client_id": "example-app",
+            "client_name": "Example App",
             "token_endpoint_auth_method": "client_secret_post"
         })))
         .mount(&admin)
@@ -56,16 +56,16 @@ async fn test_hydra_update_client() {
         r#"
         local hydra = require("assay.hydra")
         local h = hydra.client({{ admin_url = "{}" }})
-        local client = h:update_client("cc", {{
-          client_name = "Command Center",
+        local client = h:update_client("example-app", {{
+          client_name = "Example App",
           client_secret = "secret",
           grant_types = {{"authorization_code", "refresh_token"}},
           response_types = {{"code"}},
           scope = "openid profile email",
-          redirect_uris = {{"https://cc.example.com/auth/callback"}},
+          redirect_uris = {{"https://app.example.com/auth/callback"}},
           token_endpoint_auth_method = "client_secret_post",
         }})
-        assert.eq(client.client_id, "cc")
+        assert.eq(client.client_id, "example-app")
         "#,
         admin.uri()
     );
@@ -77,13 +77,13 @@ async fn test_hydra_build_authorize_url() {
     let script = r#"
         local hydra = require("assay.hydra")
         local h = hydra.client({ public_url = "https://hydra.example.com" })
-        local url = h:build_authorize_url("cc", {
-          redirect_uri = "https://cc.example.com/auth/callback",
+        local url = h:build_authorize_url("example-app", {
+          redirect_uri = "https://app.example.com/auth/callback",
           scope = "openid profile email",
           state = "xyz",
         })
         assert.contains(url, "https://hydra.example.com/oauth2/auth?")
-        assert.contains(url, "client_id=cc")
+        assert.contains(url, "client_id=example-app")
         assert.contains(url, "response_type=code")
         assert.contains(url, "state=xyz")
     "#;
@@ -113,8 +113,8 @@ async fn test_hydra_exchange_code() {
         local h = hydra.client({{ public_url = "{}" }})
         local tokens = h:exchange_code({{
           code = "abc",
-          redirect_uri = "https://cc.example.com/auth/callback",
-          client_id = "cc",
+          redirect_uri = "https://app.example.com/auth/callback",
+          client_id = "example-app",
           client_secret = "secret",
         }})
         assert.eq(tokens.access_token, "access.jwt")
@@ -132,7 +132,7 @@ async fn test_hydra_accept_login() {
         .and(path("/admin/oauth2/auth/requests/login/accept"))
         .and(query_param("login_challenge", "abc123"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "redirect_to": "https://hydra.example.com/oauth2/auth?client_id=cc&..."
+            "redirect_to": "https://hydra.example.com/oauth2/auth?client_id=example-app&..."
         })))
         .mount(&admin)
         .await;
@@ -156,7 +156,7 @@ async fn test_hydra_accept_consent_with_claims() {
         .and(path("/admin/oauth2/auth/requests/consent/accept"))
         .and(query_param("consent_challenge", "xyz789"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "redirect_to": "https://cc.example.com/auth/callback?code=..."
+            "redirect_to": "https://app.example.com/auth/callback?code=..."
         })))
         .mount(&admin)
         .await;
@@ -175,7 +175,7 @@ async fn test_hydra_accept_consent_with_claims() {
             }},
           }},
         }})
-        assert.contains(result.redirect_to, "cc.example.com")
+        assert.contains(result.redirect_to, "app.example.com")
         "#,
         admin.uri()
     );
@@ -193,7 +193,7 @@ async fn test_hydra_get_logout_request() {
             "rp_initiated": true,
             "sid": "session-xyz",
             "subject": "user:alice",
-            "client": { "client_id": "command-center" }
+            "client": { "client_id": "example-app" }
         })))
         .mount(&admin)
         .await;
@@ -205,7 +205,7 @@ async fn test_hydra_get_logout_request() {
         local req = h:get_logout_request("logout-abc")
         assert.eq(req.subject, "user:alice")
         assert.eq(req.rp_initiated, true)
-        assert.eq(req.client.client_id, "command-center")
+        assert.eq(req.client.client_id, "example-app")
         "#,
         admin.uri()
     );
@@ -219,7 +219,7 @@ async fn test_hydra_accept_logout() {
         .and(path("/admin/oauth2/auth/requests/logout/accept"))
         .and(query_param("logout_challenge", "logout-abc"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "redirect_to": "https://command-center.example.com/auth/login"
+            "redirect_to": "https://app.example.com/auth/login"
         })))
         .mount(&admin)
         .await;
@@ -229,7 +229,7 @@ async fn test_hydra_accept_logout() {
         local hydra = require("assay.hydra")
         local h = hydra.client({{ admin_url = "{}" }})
         local result = h:accept_logout("logout-abc")
-        assert.contains(result.redirect_to, "command-center.example.com")
+        assert.contains(result.redirect_to, "app.example.com")
         "#,
         admin.uri()
     );

--- a/tests/stdlib_hydra.rs
+++ b/tests/stdlib_hydra.rs
@@ -183,6 +183,81 @@ async fn test_hydra_accept_consent_with_claims() {
 }
 
 #[tokio::test]
+async fn test_hydra_get_logout_request() {
+    let admin = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/admin/oauth2/auth/requests/logout"))
+        .and(query_param("logout_challenge", "logout-abc"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "request_url": "https://hydra.example.com/oauth2/sessions/logout",
+            "rp_initiated": true,
+            "sid": "session-xyz",
+            "subject": "user:alice",
+            "client": { "client_id": "command-center" }
+        })))
+        .mount(&admin)
+        .await;
+
+    let script = format!(
+        r#"
+        local hydra = require("assay.hydra")
+        local h = hydra.client({{ admin_url = "{}" }})
+        local req = h:get_logout_request("logout-abc")
+        assert.eq(req.subject, "user:alice")
+        assert.eq(req.rp_initiated, true)
+        assert.eq(req.client.client_id, "command-center")
+        "#,
+        admin.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_hydra_accept_logout() {
+    let admin = MockServer::start().await;
+    Mock::given(method("PUT"))
+        .and(path("/admin/oauth2/auth/requests/logout/accept"))
+        .and(query_param("logout_challenge", "logout-abc"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "redirect_to": "https://command-center.example.com/auth/login"
+        })))
+        .mount(&admin)
+        .await;
+
+    let script = format!(
+        r#"
+        local hydra = require("assay.hydra")
+        local h = hydra.client({{ admin_url = "{}" }})
+        local result = h:accept_logout("logout-abc")
+        assert.contains(result.redirect_to, "command-center.example.com")
+        "#,
+        admin.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_hydra_reject_logout() {
+    let admin = MockServer::start().await;
+    Mock::given(method("PUT"))
+        .and(path("/admin/oauth2/auth/requests/logout/reject"))
+        .and(query_param("logout_challenge", "logout-abc"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+        .mount(&admin)
+        .await;
+
+    let script = format!(
+        r#"
+        local hydra = require("assay.hydra")
+        local h = hydra.client({{ admin_url = "{}" }})
+        h:reject_logout("logout-abc")
+        "#,
+        admin.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
 async fn test_hydra_introspect() {
     let admin = MockServer::start().await;
     Mock::given(method("POST"))

--- a/tests/stdlib_keto.rs
+++ b/tests/stdlib_keto.rs
@@ -24,7 +24,7 @@ async fn test_keto_list() {
             "relation_tuples": [
                 {
                     "namespace": "Role",
-                    "object": "platform:super-admin",
+                    "object": "namespace1:role-a",
                     "relation": "members",
                     "subject_id": "user:alice"
                 }
@@ -40,7 +40,7 @@ async fn test_keto_list() {
         local k = keto.client("{}")
         local result = k:list({{ namespace = "Role" }})
         assert.eq(#result.relation_tuples, 1)
-        assert.eq(result.relation_tuples[1].object, "platform:super-admin")
+        assert.eq(result.relation_tuples[1].object, "namespace1:role-a")
         "#,
         server.uri()
     );
@@ -105,13 +105,13 @@ async fn test_keto_get_user_roles() {
             "relation_tuples": [
                 {
                     "namespace": "Role",
-                    "object": "platform:super-admin",
+                    "object": "namespace1:role-a",
                     "relation": "members",
                     "subject_id": "user:alice"
                 },
                 {
                     "namespace": "Role",
-                    "object": "command-center:admin",
+                    "object": "namespace2:role-a",
                     "relation": "members",
                     "subject_id": "user:alice"
                 }
@@ -126,8 +126,8 @@ async fn test_keto_get_user_roles() {
         local k = keto.client("{}")
         local roles = k:get_user_roles("alice")
         assert.eq(#roles, 2)
-        assert.eq(roles[1].object, "platform:super-admin")
-        assert.eq(roles[2].object, "command-center:admin")
+        assert.eq(roles[1].object, "namespace1:role-a")
+        assert.eq(roles[2].object, "namespace2:role-a")
         "#,
         server.uri()
     );
@@ -143,7 +143,7 @@ async fn test_keto_user_has_any_role() {
             "relation_tuples": [
                 {
                     "namespace": "Role",
-                    "object": "command-center:operator",
+                    "object": "namespace2:role-b",
                     "relation": "members",
                     "subject_id": "user:bob"
                 }
@@ -156,9 +156,9 @@ async fn test_keto_user_has_any_role() {
         r#"
         local keto = require("assay.keto")
         local k = keto.client("{}")
-        local has_admin = k:user_has_any_role("bob", {{"platform:super-admin", "command-center:admin"}})
+        local has_admin = k:user_has_any_role("bob", {{"namespace1:role-a", "namespace2:role-a"}})
         assert.eq(has_admin, false)
-        local has_op = k:user_has_any_role("bob", {{"command-center:operator"}})
+        local has_op = k:user_has_any_role("bob", {{"namespace2:role-b"}})
         assert.eq(has_op, true)
         "#,
         server.uri()
@@ -175,7 +175,7 @@ async fn test_keto_expand() {
             "type": "union",
             "tuple": {
                 "namespace": "Role",
-                "object": "platform:super-admin",
+                "object": "namespace1:role-a",
                 "relation": "members"
             },
             "children": []
@@ -187,7 +187,7 @@ async fn test_keto_expand() {
         r#"
         local keto = require("assay.keto")
         local k = keto.client("{}")
-        local tree = k:expand("Role", "platform:super-admin", "members")
+        local tree = k:expand("Role", "namespace1:role-a", "members")
         assert.eq(tree.type, "union")
         "#,
         server.uri()
@@ -211,7 +211,7 @@ async fn test_keto_create_tuple() {
         local k = keto.client("{}", {{ write_url = "{}" }})
         k:create({{
           namespace = "Role",
-          object = "command-center:viewer",
+          object = "namespace2:role-c",
           relation = "members",
           subject_id = "user:carol",
         }})

--- a/tests/stdlib_unleash.rs
+++ b/tests/stdlib_unleash.rs
@@ -51,7 +51,7 @@ async fn test_unleash_projects() {
             "version": 1,
             "projects": [
                 {"id": "default", "name": "Default", "description": "Default project", "memberCount": 1, "featureCount": 5},
-                {"id": "simons", "name": "Simons", "description": "Golden Image Factory", "memberCount": 2, "featureCount": 3}
+                {"id": "demo-project", "name": "Demo Project", "description": "Demo project description", "memberCount": 2, "featureCount": 3}
             ]
         })))
         .mount(&server)
@@ -64,8 +64,8 @@ async fn test_unleash_projects() {
         local projects = c:projects()
         assert.eq(#projects, 2)
         assert.eq(projects[1].id, "default")
-        assert.eq(projects[2].id, "simons")
-        assert.eq(projects[2].name, "Simons")
+        assert.eq(projects[2].id, "demo-project")
+        assert.eq(projects[2].name, "Demo Project")
         "#,
         server.uri()
     );
@@ -76,11 +76,11 @@ async fn test_unleash_projects() {
 async fn test_unleash_project() {
     let server = MockServer::start().await;
     Mock::given(method("GET"))
-        .and(path("/api/admin/projects/simons"))
+        .and(path("/api/admin/projects/demo-project"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "id": "simons",
-            "name": "Simons",
-            "description": "Golden Image Factory",
+            "id": "demo-project",
+            "name": "Demo Project",
+            "description": "Demo project description",
             "environments": [
                 {"environment": "development", "enabled": true},
                 {"environment": "production", "enabled": true}
@@ -94,9 +94,9 @@ async fn test_unleash_project() {
         r#"
         local unleash = require("assay.unleash")
         local c = unleash.client("{}", {{ token = "test-token" }})
-        local p = c:project("simons")
-        assert.eq(p.id, "simons")
-        assert.eq(p.name, "Simons")
+        local p = c:project("demo-project")
+        assert.eq(p.id, "demo-project")
+        assert.eq(p.name, "Demo Project")
         assert.eq(#p.environments, 2)
         "#,
         server.uri()
@@ -131,9 +131,9 @@ async fn test_unleash_create_project() {
     Mock::given(method("POST"))
         .and(path("/api/admin/projects"))
         .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
-            "id": "simons",
-            "name": "Simons",
-            "description": "Golden Image Factory"
+            "id": "demo-project",
+            "name": "Demo Project",
+            "description": "Demo project description"
         })))
         .mount(&server)
         .await;
@@ -142,9 +142,9 @@ async fn test_unleash_create_project() {
         r#"
         local unleash = require("assay.unleash")
         local c = unleash.client("{}", {{ token = "test-token" }})
-        local p = c:create_project({{ id = "simons", name = "Simons", description = "Golden Image Factory" }})
-        assert.eq(p.id, "simons")
-        assert.eq(p.name, "Simons")
+        local p = c:create_project({{ id = "demo-project", name = "Demo Project", description = "Demo project description" }})
+        assert.eq(p.id, "demo-project")
+        assert.eq(p.name, "Demo Project")
         "#,
         server.uri()
     );
@@ -155,10 +155,10 @@ async fn test_unleash_create_project() {
 async fn test_unleash_update_project() {
     let server = MockServer::start().await;
     Mock::given(method("PUT"))
-        .and(path("/api/admin/projects/simons"))
+        .and(path("/api/admin/projects/demo-project"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "id": "simons",
-            "name": "Simons Updated",
+            "id": "demo-project",
+            "name": "Demo Project Updated",
             "description": "Updated description"
         })))
         .mount(&server)
@@ -168,8 +168,8 @@ async fn test_unleash_update_project() {
         r#"
         local unleash = require("assay.unleash")
         local c = unleash.client("{}", {{ token = "test-token" }})
-        local p = c:update_project("simons", {{ name = "Simons Updated", description = "Updated description" }})
-        assert.eq(p.name, "Simons Updated")
+        local p = c:update_project("demo-project", {{ name = "Demo Project Updated", description = "Updated description" }})
+        assert.eq(p.name, "Demo Project Updated")
         "#,
         server.uri()
     );
@@ -180,7 +180,7 @@ async fn test_unleash_update_project() {
 async fn test_unleash_delete_project() {
     let server = MockServer::start().await;
     Mock::given(method("DELETE"))
-        .and(path("/api/admin/projects/simons"))
+        .and(path("/api/admin/projects/demo-project"))
         .respond_with(ResponseTemplate::new(200))
         .mount(&server)
         .await;
@@ -189,7 +189,7 @@ async fn test_unleash_delete_project() {
         r#"
         local unleash = require("assay.unleash")
         local c = unleash.client("{}", {{ token = "test-token" }})
-        c:delete_project("simons")
+        c:delete_project("demo-project")
         "#,
         server.uri()
     );
@@ -229,7 +229,7 @@ async fn test_unleash_environments() {
 async fn test_unleash_enable_environment() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))
-        .and(path("/api/admin/projects/simons/environments"))
+        .and(path("/api/admin/projects/demo-project/environments"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
         .mount(&server)
         .await;
@@ -238,7 +238,7 @@ async fn test_unleash_enable_environment() {
         r#"
         local unleash = require("assay.unleash")
         local c = unleash.client("{}", {{ token = "test-token" }})
-        c:enable_environment("simons", "production")
+        c:enable_environment("demo-project", "production")
         "#,
         server.uri()
     );
@@ -249,7 +249,7 @@ async fn test_unleash_enable_environment() {
 async fn test_unleash_disable_environment() {
     let server = MockServer::start().await;
     Mock::given(method("DELETE"))
-        .and(path("/api/admin/projects/simons/environments/staging"))
+        .and(path("/api/admin/projects/demo-project/environments/staging"))
         .respond_with(ResponseTemplate::new(200))
         .mount(&server)
         .await;
@@ -258,7 +258,7 @@ async fn test_unleash_disable_environment() {
         r#"
         local unleash = require("assay.unleash")
         local c = unleash.client("{}", {{ token = "test-token" }})
-        c:disable_environment("simons", "staging")
+        c:disable_environment("demo-project", "staging")
         "#,
         server.uri()
     );
@@ -269,12 +269,12 @@ async fn test_unleash_disable_environment() {
 async fn test_unleash_features() {
     let server = MockServer::start().await;
     Mock::given(method("GET"))
-        .and(path("/api/admin/projects/simons/features"))
+        .and(path("/api/admin/projects/demo-project/features"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
             "version": 2,
             "features": [
-                {"name": "dark-mode", "type": "release", "enabled": false, "project": "simons"},
-                {"name": "new-dashboard", "type": "experiment", "enabled": true, "project": "simons"}
+                {"name": "dark-mode", "type": "release", "enabled": false, "project": "demo-project"},
+                {"name": "new-dashboard", "type": "experiment", "enabled": true, "project": "demo-project"}
             ]
         })))
         .mount(&server)
@@ -284,7 +284,7 @@ async fn test_unleash_features() {
         r#"
         local unleash = require("assay.unleash")
         local c = unleash.client("{}", {{ token = "test-token" }})
-        local features = c:features("simons")
+        local features = c:features("demo-project")
         assert.eq(#features, 2)
         assert.eq(features[1].name, "dark-mode")
         assert.eq(features[2].name, "new-dashboard")
@@ -299,11 +299,11 @@ async fn test_unleash_features() {
 async fn test_unleash_feature() {
     let server = MockServer::start().await;
     Mock::given(method("GET"))
-        .and(path("/api/admin/projects/simons/features/dark-mode"))
+        .and(path("/api/admin/projects/demo-project/features/dark-mode"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
             "name": "dark-mode",
             "type": "release",
-            "project": "simons",
+            "project": "demo-project",
             "enabled": false,
             "environments": [
                 {"name": "development", "enabled": true},
@@ -317,7 +317,7 @@ async fn test_unleash_feature() {
         r#"
         local unleash = require("assay.unleash")
         local c = unleash.client("{}", {{ token = "test-token" }})
-        local f = c:feature("simons", "dark-mode")
+        local f = c:feature("demo-project", "dark-mode")
         assert.eq(f.name, "dark-mode")
         assert.eq(f.type, "release")
         assert.eq(#f.environments, 2)
@@ -331,7 +331,7 @@ async fn test_unleash_feature() {
 async fn test_unleash_feature_not_found() {
     let server = MockServer::start().await;
     Mock::given(method("GET"))
-        .and(path("/api/admin/projects/simons/features/nonexistent"))
+        .and(path("/api/admin/projects/demo-project/features/nonexistent"))
         .respond_with(ResponseTemplate::new(404))
         .mount(&server)
         .await;
@@ -340,7 +340,7 @@ async fn test_unleash_feature_not_found() {
         r#"
         local unleash = require("assay.unleash")
         local c = unleash.client("{}", {{ token = "test-token" }})
-        local f = c:feature("simons", "nonexistent")
+        local f = c:feature("demo-project", "nonexistent")
         assert.eq(f, nil)
         "#,
         server.uri()
@@ -352,11 +352,11 @@ async fn test_unleash_feature_not_found() {
 async fn test_unleash_create_feature() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))
-        .and(path("/api/admin/projects/simons/features"))
+        .and(path("/api/admin/projects/demo-project/features"))
         .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
             "name": "dark-mode",
             "type": "release",
-            "project": "simons",
+            "project": "demo-project",
             "description": "Enable dark mode UI"
         })))
         .mount(&server)
@@ -366,7 +366,7 @@ async fn test_unleash_create_feature() {
         r#"
         local unleash = require("assay.unleash")
         local c = unleash.client("{}", {{ token = "test-token" }})
-        local f = c:create_feature("simons", {{ name = "dark-mode", type = "release", description = "Enable dark mode UI" }})
+        local f = c:create_feature("demo-project", {{ name = "dark-mode", type = "release", description = "Enable dark mode UI" }})
         assert.eq(f.name, "dark-mode")
         assert.eq(f.type, "release")
         "#,
@@ -379,7 +379,7 @@ async fn test_unleash_create_feature() {
 async fn test_unleash_update_feature() {
     let server = MockServer::start().await;
     Mock::given(method("PUT"))
-        .and(path("/api/admin/projects/simons/features/dark-mode"))
+        .and(path("/api/admin/projects/demo-project/features/dark-mode"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
             "name": "dark-mode",
             "type": "release",
@@ -392,7 +392,7 @@ async fn test_unleash_update_feature() {
         r#"
         local unleash = require("assay.unleash")
         local c = unleash.client("{}", {{ token = "test-token" }})
-        local f = c:update_feature("simons", "dark-mode", {{ description = "Updated dark mode" }})
+        local f = c:update_feature("demo-project", "dark-mode", {{ description = "Updated dark mode" }})
         assert.eq(f.description, "Updated dark mode")
         "#,
         server.uri()
@@ -404,7 +404,7 @@ async fn test_unleash_update_feature() {
 async fn test_unleash_archive_feature() {
     let server = MockServer::start().await;
     Mock::given(method("DELETE"))
-        .and(path("/api/admin/projects/simons/features/dark-mode"))
+        .and(path("/api/admin/projects/demo-project/features/dark-mode"))
         .respond_with(ResponseTemplate::new(200))
         .mount(&server)
         .await;
@@ -413,7 +413,7 @@ async fn test_unleash_archive_feature() {
         r#"
         local unleash = require("assay.unleash")
         local c = unleash.client("{}", {{ token = "test-token" }})
-        c:archive_feature("simons", "dark-mode")
+        c:archive_feature("demo-project", "dark-mode")
         "#,
         server.uri()
     );
@@ -425,7 +425,7 @@ async fn test_unleash_toggle_on() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))
         .and(path(
-            "/api/admin/projects/simons/features/dark-mode/environments/development/on",
+            "/api/admin/projects/demo-project/features/dark-mode/environments/development/on",
         ))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
         .mount(&server)
@@ -435,7 +435,7 @@ async fn test_unleash_toggle_on() {
         r#"
         local unleash = require("assay.unleash")
         local c = unleash.client("{}", {{ token = "test-token" }})
-        c:toggle_on("simons", "dark-mode", "development")
+        c:toggle_on("demo-project", "dark-mode", "development")
         "#,
         server.uri()
     );
@@ -447,7 +447,7 @@ async fn test_unleash_toggle_off() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))
         .and(path(
-            "/api/admin/projects/simons/features/dark-mode/environments/production/off",
+            "/api/admin/projects/demo-project/features/dark-mode/environments/production/off",
         ))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
         .mount(&server)
@@ -457,7 +457,7 @@ async fn test_unleash_toggle_off() {
         r#"
         local unleash = require("assay.unleash")
         local c = unleash.client("{}", {{ token = "test-token" }})
-        c:toggle_off("simons", "dark-mode", "production")
+        c:toggle_off("demo-project", "dark-mode", "production")
         "#,
         server.uri()
     );
@@ -469,7 +469,7 @@ async fn test_unleash_strategies() {
     let server = MockServer::start().await;
     Mock::given(method("GET"))
         .and(path(
-            "/api/admin/projects/simons/features/dark-mode/environments/development/strategies",
+            "/api/admin/projects/demo-project/features/dark-mode/environments/development/strategies",
         ))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
             {"id": "strategy-1", "name": "default", "parameters": {}},
@@ -482,7 +482,7 @@ async fn test_unleash_strategies() {
         r#"
         local unleash = require("assay.unleash")
         local c = unleash.client("{}", {{ token = "test-token" }})
-        local strats = c:strategies("simons", "dark-mode", "development")
+        local strats = c:strategies("demo-project", "dark-mode", "development")
         assert.eq(#strats, 2)
         assert.eq(strats[1].name, "default")
         assert.eq(strats[2].name, "userWithId")
@@ -497,7 +497,7 @@ async fn test_unleash_add_strategy() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))
         .and(path(
-            "/api/admin/projects/simons/features/dark-mode/environments/development/strategies",
+            "/api/admin/projects/demo-project/features/dark-mode/environments/development/strategies",
         ))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
             "id": "strategy-3",
@@ -511,7 +511,7 @@ async fn test_unleash_add_strategy() {
         r#"
         local unleash = require("assay.unleash")
         local c = unleash.client("{}", {{ token = "test-token" }})
-        local s = c:add_strategy("simons", "dark-mode", "development", {{
+        local s = c:add_strategy("demo-project", "dark-mode", "development", {{
             name = "flexibleRollout",
             parameters = {{ rollout = "50", stickiness = "default" }}
         }})
@@ -530,7 +530,7 @@ async fn test_unleash_tokens() {
         .and(path("/api/admin/api-tokens"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
             "tokens": [
-                {"secret": "*:development.abc123", "tokenName": "simons-dev", "type": "client", "environment": "development", "projects": ["simons"]},
+                {"secret": "*:development.abc123", "tokenName": "demo-project-dev", "type": "client", "environment": "development", "projects": ["demo-project"]},
                 {"secret": "*:*.admin456", "tokenName": "admin", "type": "admin", "projects": ["*"]}
             ]
         })))
@@ -543,7 +543,7 @@ async fn test_unleash_tokens() {
         local c = unleash.client("{}", {{ token = "test-token" }})
         local tokens = c:tokens()
         assert.eq(#tokens, 2)
-        assert.eq(tokens[1].tokenName, "simons-dev")
+        assert.eq(tokens[1].tokenName, "demo-project-dev")
         assert.eq(tokens[1].type, "client")
         assert.eq(tokens[2].type, "admin")
         "#,
@@ -558,11 +558,11 @@ async fn test_unleash_create_token() {
     Mock::given(method("POST"))
         .and(path("/api/admin/api-tokens"))
         .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
-            "secret": "simons:development.newtoken789",
-            "tokenName": "simons-client",
+            "secret": "demo-project:development.newtoken789",
+            "tokenName": "demo-project-client",
             "type": "client",
             "environment": "development",
-            "projects": ["simons"],
+            "projects": ["demo-project"],
             "createdAt": "2026-02-20T00:00:00Z"
         })))
         .mount(&server)
@@ -573,13 +573,13 @@ async fn test_unleash_create_token() {
         local unleash = require("assay.unleash")
         local c = unleash.client("{}", {{ token = "test-token" }})
         local t = c:create_token({{
-            tokenName = "simons-client",
+            tokenName = "demo-project-client",
             type = "client",
             environment = "development",
-            projects = {{ "simons" }}
+            projects = {{ "demo-project" }}
         }})
-        assert.eq(t.secret, "simons:development.newtoken789")
-        assert.eq(t.tokenName, "simons-client")
+        assert.eq(t.secret, "demo-project:development.newtoken789")
+        assert.eq(t.tokenName, "demo-project-client")
         assert.eq(t.type, "client")
         "#,
         server.uri()
@@ -653,10 +653,10 @@ async fn test_unleash_wait_timeout() {
 async fn test_unleash_ensure_project_existing() {
     let server = MockServer::start().await;
     Mock::given(method("GET"))
-        .and(path("/api/admin/projects/simons"))
+        .and(path("/api/admin/projects/demo-project"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-            "id": "simons",
-            "name": "Simons",
+            "id": "demo-project",
+            "name": "Demo Project",
             "description": "Existing project"
         })))
         .mount(&server)
@@ -666,9 +666,9 @@ async fn test_unleash_ensure_project_existing() {
         r#"
         local unleash = require("assay.unleash")
         local c = unleash.client("{}", {{ token = "test-token" }})
-        local p = unleash.ensure_project(c, "simons")
-        assert.eq(p.id, "simons")
-        assert.eq(p.name, "Simons")
+        local p = unleash.ensure_project(c, "demo-project")
+        assert.eq(p.id, "demo-project")
+        assert.eq(p.name, "Demo Project")
         "#,
         server.uri()
     );
@@ -709,7 +709,7 @@ async fn test_unleash_ensure_project_new() {
 async fn test_unleash_ensure_environment_new() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))
-        .and(path("/api/admin/projects/simons/environments"))
+        .and(path("/api/admin/projects/demo-project/environments"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
         .mount(&server)
         .await;
@@ -718,7 +718,7 @@ async fn test_unleash_ensure_environment_new() {
         r#"
         local unleash = require("assay.unleash")
         local c = unleash.client("{}", {{ token = "test-token" }})
-        local result = unleash.ensure_environment(c, "simons", "qa")
+        local result = unleash.ensure_environment(c, "demo-project", "qa")
         assert.eq(result, true)
         "#,
         server.uri()
@@ -730,7 +730,7 @@ async fn test_unleash_ensure_environment_new() {
 async fn test_unleash_ensure_environment_already_exists() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))
-        .and(path("/api/admin/projects/simons/environments"))
+        .and(path("/api/admin/projects/demo-project/environments"))
         .respond_with(ResponseTemplate::new(409).set_body_string("Environment already enabled"))
         .mount(&server)
         .await;
@@ -739,7 +739,7 @@ async fn test_unleash_ensure_environment_already_exists() {
         r#"
         local unleash = require("assay.unleash")
         local c = unleash.client("{}", {{ token = "test-token" }})
-        local result = unleash.ensure_environment(c, "simons", "development")
+        local result = unleash.ensure_environment(c, "demo-project", "development")
         assert.eq(result, true)
         "#,
         server.uri()
@@ -754,7 +754,7 @@ async fn test_unleash_ensure_token_existing() {
         .and(path("/api/admin/api-tokens"))
         .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
             "tokens": [
-                {"secret": "hidden", "tokenName": "simons-dev", "type": "client", "environment": "development", "projects": ["simons"]}
+                {"secret": "hidden", "tokenName": "demo-project-dev", "type": "client", "environment": "development", "projects": ["demo-project"]}
             ]
         })))
         .mount(&server)
@@ -765,11 +765,11 @@ async fn test_unleash_ensure_token_existing() {
         local unleash = require("assay.unleash")
         local c = unleash.client("{}", {{ token = "test-token" }})
         local t = unleash.ensure_token(c, {{
-            tokenName = "simons-dev",
+            tokenName = "demo-project-dev",
             type = "client",
             environment = "development"
         }})
-        assert.eq(t.tokenName, "simons-dev")
+        assert.eq(t.tokenName, "demo-project-dev")
         assert.eq(t.type, "client")
         "#,
         server.uri()
@@ -790,11 +790,11 @@ async fn test_unleash_ensure_token_new() {
     Mock::given(method("POST"))
         .and(path("/api/admin/api-tokens"))
         .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
-            "secret": "simons:production.newtoken",
-            "tokenName": "simons-prod",
+            "secret": "demo-project:production.newtoken",
+            "tokenName": "demo-project-prod",
             "type": "client",
             "environment": "production",
-            "projects": ["simons"]
+            "projects": ["demo-project"]
         })))
         .mount(&server)
         .await;
@@ -804,13 +804,13 @@ async fn test_unleash_ensure_token_new() {
         local unleash = require("assay.unleash")
         local c = unleash.client("{}", {{ token = "test-token" }})
         local t = unleash.ensure_token(c, {{
-            tokenName = "simons-prod",
+            tokenName = "demo-project-prod",
             type = "client",
             environment = "production",
-            projects = {{ "simons" }}
+            projects = {{ "demo-project" }}
         }})
-        assert.eq(t.secret, "simons:production.newtoken")
-        assert.eq(t.tokenName, "simons-prod")
+        assert.eq(t.secret, "demo-project:production.newtoken")
+        assert.eq(t.tokenName, "demo-project-prod")
         "#,
         server.uri()
     );


### PR DESCRIPTION
## Summary

Two changes bundled in v0.8.2:

1. **`assay.hydra` logout challenge methods** — completes the OIDC challenge trio (login, consent, logout) so any handler sitting at Hydra's `urls.logout` can process logout requests via the SDK instead of raw HTTP calls.
2. **Site active-tab visibility fix** — the existing active-page nav rule from #25 was technically working but visually too subtle (orange-on-grey at 14px). Adds a 2px accent underline so the current page is unmistakable.
3. **Library hygiene cleanup** — strips application-domain leakage from tests, docs, code comments, and the changelog. Adds a permanent rule to `AGENTS.md` so future contributors don't reintroduce it.

## 1. Hydra logout methods

When an OAuth2 client triggers an OIDC logout via Hydra's `/oauth2/sessions/logout` endpoint with `id_token_hint` and `post_logout_redirect_uri`, Hydra creates a logout request and redirects the browser to its configured `urls.logout` endpoint with a `logout_challenge` query param. The handler at `urls.logout` now has SDK methods to process these requests symmetrically with login and consent.

### New methods

- **`c:get_logout_request(challenge)`** — fetch the pending logout request (`subject`, `sid`, `client`, `rp_initiated`)
- **`c:accept_logout(challenge)`** — invalidate the Hydra session (and any backing identity-provider session) and get back the `redirect_to` URL pointing at the app's `post_logout_redirect_uri`
- **`c:reject_logout(challenge)`** — for "stay signed in" UIs that let the user cancel the logout

Three wiremock tests cover the new methods.

## 2. Active-tab visibility fix

The active-page rule added in #25 was working (correct body class set per page, correct CSS rule deployed) but too subtle to notice — colour change + bold weight alone wasn't enough. Adds a 2px accent-coloured bottom border under the active link.

## 3. Library hygiene cleanup

Several artifacts had drifted from the principle that **assay is a general-purpose library and must have zero knowledge of any specific application that uses it**. Tests, doc comments, the changelog entry, and built-in module docs were referencing specific consumer applications, role conventions, and namespaces. Cleaned up everywhere with generic placeholders (`example-app`, `app.example.com`, `namespace1:role-a`, `demo-project`, `MyWorkflow`, etc.), and added a permanent rule to `AGENTS.md` under **Library hygiene: no application-domain leakage** so future agents and contributors don't reintroduce it.

Files touched in the cleanup:

- `tests/stdlib_hydra.rs` — generic client IDs and hostnames
- `tests/stdlib_keto.rs` — generic role objects
- `tests/stdlib_unleash.rs` — generic project IDs
- `stdlib/keto.lua` — generic example in the `get_user_roles` doc comment
- `src/lua/builtins/temporal.rs` — generic example in the module docstring
- `CHANGELOG.md` — strip consumer-specific tail from the 0.8.2 entry
- `AGENTS.md` — new "Library hygiene" section codifying the rule

## Test plan

- [x] `cargo test` (full suite passing)
- [x] `cargo test --test stdlib_hydra` (12/12 — 9 existing + 3 new logout)
- [x] `cargo test --test stdlib_keto` (9/9 with renamed role objects)
- [x] `cargo test --test stdlib_unleash` (32/32 with renamed project IDs)
- [x] `cargo clippy --all-targets -- -D warnings` (clean)
- [x] No remaining application-domain leakage anywhere in the repo (verified with grep sweep)
- [ ] CI green

## Changelog

`0.8.2` entry under **Added** documents the new logout methods.