### PR TITLE
feat(ory): namespace stdlib under assay.ory.* + RBAC engine + jwt_decode (v0.8.3)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ exception is the copyright holder's name in `LICENSE`/`NOTICE`/`CLA.md`.
 
 General-purpose enhanced Lua runtime. Single ~9 MB static binary with batteries included: HTTP
 client/server, JSON/YAML/TOML, crypto, database, WebSocket, filesystem, shell execution, process
-management, async, and 33 embedded stdlib modules for infrastructure services (Kubernetes,
+management, async, and 34 embedded stdlib modules for infrastructure services (Kubernetes,
 Prometheus, Vault, ArgoCD, etc.) and AI agent integrations (OpenClaw, GitHub, Gmail, Google
 Calendar).
 
@@ -175,7 +175,7 @@ and `id` must not contain newlines. `data` handles multi-line automatically.
 
 ## Stdlib Modules
 
-33 embedded Lua modules loaded via `require("assay.<name>")`:
+34 embedded Lua modules loaded via `require("assay.<name>")`:
 
 | Module                | Description                                                                       |
 | --------------------- | --------------------------------------------------------------------------------- |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,7 +110,7 @@ Available as globals in all `.lua` scripts — no `require` needed:
 | HTTP           | `http.get(url, opts?)`, `http.post(url, body, opts?)`, `http.put(url, body, opts?)`, `http.patch(url, body, opts?)`, `http.delete(url, opts?)`, `http.serve(port, routes)` — `http.serve` response handlers accept array header values to emit the same header name multiple times (e.g., multiple `Set-Cookie`) |
 | JSON/YAML/TOML | `json.parse(str)`, `json.encode(tbl)`, `yaml.parse(str)`, `yaml.encode(tbl)`, `toml.parse(str)`, `toml.encode(tbl)`                                                                                                                                                 |
 | Filesystem     | `fs.read(path)`, `fs.write(path, str)`, `fs.remove(path)`, `fs.list(path)`, `fs.stat(path)`, `fs.mkdir(path)`, `fs.exists(path)`, `fs.copy(src, dst)`, `fs.rename(src, dst)`, `fs.glob(pattern)`, `fs.tempdir()`, `fs.chmod(path, mode)`, `fs.readdir(path, opts?)` |
-| Crypto         | `crypto.jwt_sign(claims, key, alg, opts?)`, `crypto.hash(str, alg)`, `crypto.hmac(key, data, alg?, raw?)`, `crypto.random(len)`                                                                                                                                     |
+| Crypto         | `crypto.jwt_sign(claims, key, alg, opts?)`, `crypto.jwt_decode(token)` (decode without verifying), `crypto.hash(str, alg)`, `crypto.hmac(key, data, alg?, raw?)`, `crypto.random(len)`                                                                                |
 | Base64         | `base64.encode(str)`, `base64.decode(str)`                                                                                                                                                                                                                          |
 | Regex          | `regex.match(pat, str)`, `regex.find(pat, str)`, `regex.find_all(pat, str)`, `regex.replace(pat, str, repl)`                                                                                                                                                        |
 | Database       | `db.connect(url)`, `db.query(conn, sql, params?)`, `db.execute(conn, sql, params?)`, `db.close(conn)`                                                                                                                                                               |
@@ -197,7 +197,8 @@ and `id` must not contain newlines. `data` handles multi-line automatically.
 | `assay.ory.kratos`        | Ory Kratos identity — login/registration/recovery/settings flows, identities, sessions, schemas |
 | `assay.ory.hydra`         | Ory Hydra OAuth2/OIDC — clients, authorize URLs, tokens, login/consent, introspection, JWKs |
 | `assay.ory.keto`          | Ory Keto ReBAC — relation tuples, permission checks, role/group membership, expand |
-| `assay.ory`           | Convenience wrapper re-exporting kratos/hydra/keto with `ory.connect(opts)`       |
+| `assay.ory.rbac`          | Capability-based RBAC engine over Keto — define roles + capabilities, query users, manage memberships, separation of duties |
+| `assay.ory`           | Convenience wrapper re-exporting kratos/hydra/keto/rbac with `ory.connect(opts)`  |
 | `assay.crossplane`    | Providers, XRDs, compositions, managed resources                                  |
 | `assay.velero`        | Backups, restores, schedules, storage locations                                   |
 | `assay.temporal`      | Workflows, task queues, schedules, signals + native gRPC client (temporal feature) |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,9 +194,9 @@ and `id` must not contain newlines. `data` handles multi-line automatically.
 | `assay.eso`           | ExternalSecrets, SecretStores, ClusterSecretStores                                |
 | `assay.dex`           | OIDC discovery, JWKS, health                                                      |
 | `assay.zitadel`       | OIDC identity management with JWT machine auth                                    |
-| `assay.kratos`        | Ory Kratos identity — login/registration/recovery/settings flows, identities, sessions, schemas |
-| `assay.hydra`         | Ory Hydra OAuth2/OIDC — clients, authorize URLs, tokens, login/consent, introspection, JWKs |
-| `assay.keto`          | Ory Keto ReBAC — relation tuples, permission checks, role/group membership, expand |
+| `assay.ory.kratos`        | Ory Kratos identity — login/registration/recovery/settings flows, identities, sessions, schemas |
+| `assay.ory.hydra`         | Ory Hydra OAuth2/OIDC — clients, authorize URLs, tokens, login/consent, introspection, JWKs |
+| `assay.ory.keto`          | Ory Keto ReBAC — relation tuples, permission checks, role/group membership, expand |
 | `assay.ory`           | Convenience wrapper re-exporting kratos/hydra/keto with `ory.connect(opts)`       |
 | `assay.crossplane`    | Providers, XRDs, compositions, managed resources                                  |
 | `assay.velero`        | Backups, restores, schedules, storage locations                                   |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,13 @@ All notable changes to Assay are documented here.
     - `p:reset_role(role)` — for bootstrap/seed scripts
     - `p:require_capability(cap, handler)` — http.serve middleware
 
+- **`crypto.jwt_decode(token)`** — decode a JWT WITHOUT verifying its
+  signature. Returns `{header, claims}` parsed from the base64url
+  segments. Useful when the JWT travels through a trusted channel
+  (your own session cookie set over TLS) and you just need to read
+  the claims rather than verify them. For untrusted JWTs, verify the
+  signature with a JWKS-aware verifier instead.
+
 - **Nested stdlib module loading**: `require("assay.ory.kratos")` now
   resolves to `stdlib/ory/kratos.lua`. The stdlib and filesystem
   loaders translate dotted module paths into directory paths and try

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,54 @@
 
 All notable changes to Assay are documented here.
 
+## [0.8.3] - 2026-04-07
+
+### Added
+
+- **`assay.ory.rbac`** — capability-based RBAC engine layered on top of
+  Ory Keto. Define a policy once (role → capability set) and get user
+  lookups, capability checks, and membership management for free.
+  Users can hold multiple roles and the effective capability set is
+  the union, which means proper separation of duties is enforceable
+  at the authorization layer (e.g. an "approver" role can have
+  `approve` without also getting `trigger`, even if it's listed
+  above an "operator" role with `trigger`).
+
+  Public surface:
+    - `rbac.policy({namespace, keto, roles, default_role?})`
+    - `p:user_roles(user_id)` — sorted by rank, highest first
+    - `p:user_primary_role(user_id)` — for compact UI badges
+    - `p:user_capabilities(user_id)` — union set
+    - `p:user_has_capability(user_id, cap)` — single check
+    - `p:add(user_id, role)` / `p:remove(user_id, role)` — idempotent
+    - `p:list_members(role)` / `p:list_all_memberships()`
+    - `p:reset_role(role)` — for bootstrap/seed scripts
+    - `p:require_capability(cap, handler)` — http.serve middleware
+
+- **Nested stdlib module loading**: `require("assay.ory.kratos")` now
+  resolves to `stdlib/ory/kratos.lua`. The stdlib and filesystem
+  loaders translate dotted module paths into directory paths and try
+  both `<path>.lua` and `<path>/init.lua`, matching standard Lua
+  package loading conventions.
+
+### Changed
+
+- **BREAKING: Ory stack modules moved under `assay.ory.*`**. The flat
+  top-level `assay.kratos`, `assay.hydra`, and `assay.keto` modules
+  are now `assay.ory.kratos`, `assay.ory.hydra`, and `assay.ory.keto`.
+  The convenience wrapper `require("assay.ory")` is unchanged and
+  still returns `{kratos, hydra, keto, rbac}`.
+
+  Migration: replace
+    `require("assay.kratos")` → `require("assay.ory.kratos")`
+    `require("assay.hydra")`  → `require("assay.ory.hydra")`
+    `require("assay.keto")`   → `require("assay.ory.keto")`
+
+  This is the right architectural shape: Ory-specific modules sit
+  under the `assay.ory.*` umbrella alongside the new
+  `assay.ory.rbac`, leaving room for `assay.<other-vendor>.*` later
+  without polluting the top-level namespace.
+
 ## [0.8.2] - 2026-04-07
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "assay-lua"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-lua"
-version = "0.8.2"
+version = "0.8.3"
 categories = ["command-line-utilities", "development-tools::testing"]
 edition = "2024"
 homepage = "https://assay.rs"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Assay
 
-Replaces your entire infrastructure scripting toolchain. One 9 MB binary, 50 modules.
+Replaces your entire infrastructure scripting toolchain. One 9 MB binary, 51 modules.
 
 [![CI](https://github.com/developerinlondon/assay/actions/workflows/ci.yml/badge.svg)](https://github.com/developerinlondon/assay/actions/workflows/ci.yml)
 [![Crates.io](https://img.shields.io/crates/v/assay-lua.svg)](https://crates.io/crates/assay-lua)
@@ -10,7 +10,7 @@ Replaces your entire infrastructure scripting toolchain. One 9 MB binary, 50 mod
 
 A single ~9 MB static binary that replaces 50-250 MB Python/Node/kubectl containers in Kubernetes.
 Full-featured Lua 5.5 runtime with HTTP client/server, database, WebSocket, JWT, templates, native
-Temporal gRPC workflows, and 33 embedded stdlib modules for Kubernetes, monitoring, security, and
+Temporal gRPC workflows, and 34 embedded stdlib modules for Kubernetes, monitoring, security, and
 AI agent integrations.
 
 ```bash
@@ -18,7 +18,7 @@ assay script.lua     # Run Lua with all builtins
 assay checks.yaml    # Structured checks with retry/backoff/JSON output
 assay exec -e 'log.info("hello")'   # Inline evaluation
 assay context "grafana"              # LLM-ready module docs
-assay modules                        # List all 50+ modules
+assay modules                        # List all 51 modules
 ```
 
 Scripts that call `http.serve()` become web services. Scripts that call `http.get()` and exit are
@@ -132,7 +132,7 @@ All 17 Rust builtins are available globally in `.lua` scripts — no `require` n
 
 ## Stdlib Modules
 
-33 embedded Lua modules loaded via `require("assay.<name>")`. All follow the client pattern:
+34 embedded Lua modules loaded via `require("assay.<name>")`. All follow the client pattern:
 `M.client(url, opts)` then `c:method()`.
 
 | Module | Description |
@@ -297,7 +297,7 @@ Find the right module before writing code:
 ```bash
 assay context "grafana"   # Returns method signatures for LLM prompts
 assay context "vault"     # Exact API docs, no hallucination
-assay modules             # List all 50+ modules
+assay modules             # List all 51 modules
 ```
 
 Custom modules: place `.lua` files in `./modules/` (project) or `~/.assay/modules/` (global).

--- a/README.md
+++ b/README.md
@@ -154,10 +154,11 @@ All 17 Rust builtins are available globally in `.lua` scripts — no `require` n
 | `assay.eso` | ExternalSecrets, SecretStores |
 | `assay.dex` | OIDC discovery, JWKS |
 | `assay.zitadel` | OIDC identity, JWT machine auth |
-| `assay.kratos` | Ory Kratos — login/registration/recovery flows, identities, sessions |
-| `assay.hydra` | Ory Hydra — OAuth2/OIDC clients, authorize, tokens, login/consent |
-| `assay.keto` | Ory Keto — ReBAC relation tuples, permission checks, expand |
-| `assay.ory` | Ory stack wrapper — `ory.connect()` builds kratos/hydra/keto in one call |
+| `assay.ory.kratos` | Ory Kratos — login/registration/recovery flows, identities, sessions |
+| `assay.ory.hydra` | Ory Hydra — OAuth2/OIDC clients, authorize, tokens, login/consent/logout |
+| `assay.ory.keto` | Ory Keto — ReBAC relation tuples, permission checks, expand |
+| `assay.ory.rbac` | Capability-based RBAC engine over Keto — define roles + capabilities, query users, manage memberships |
+| `assay.ory` | Ory stack umbrella — `ory.connect()` builds kratos/hydra/keto in one call; also re-exports `rbac` |
 | **Infrastructure** | |
 | `assay.crossplane` | Providers, XRDs, compositions |
 | `assay.velero` | Backups, restores, schedules |

--- a/SKILL.md
+++ b/SKILL.md
@@ -164,12 +164,13 @@ String header values still work as before.
 
 ### Cryptography
 
-| Function                             | Description                                     |
-| ------------------------------------ | ----------------------------------------------- |
-| `crypto.jwt_sign(claims, key, alg)`  | Sign JWT — alg: HS256, RS256/384/512, ES256/384 |
-| `crypto.hash(str, alg)`              | Hash string (sha256, sha384, sha512, md5)       |
-| `crypto.hmac(key, data, alg?, raw?)` | HMAC (sha256 default, raw=true for binary)      |
-| `crypto.random(len)`                 | Secure random hex string of length `len`        |
+| Function                             | Description                                                   |
+| ------------------------------------ | ------------------------------------------------------------- |
+| `crypto.jwt_sign(claims, key, alg)`  | Sign JWT — alg: HS256, RS256/384/512, ES256/384               |
+| `crypto.jwt_decode(token)`           | Decode `{header, claims}` WITHOUT verifying — trusted channel |
+| `crypto.hash(str, alg)`              | Hash string (sha256, sha384, sha512, md5)                     |
+| `crypto.hmac(key, data, alg?, raw?)` | HMAC (sha256 default, raw=true for binary)                    |
+| `crypto.random(len)`                 | Secure random hex string of length `len`                      |
 
 ### Regex
 
@@ -274,7 +275,8 @@ All 33 modules follow `require("assay.<name>")` then `M.client(url, opts)`.
 | `assay.ory.kratos`        | Ory Kratos — login/registration/recovery/settings flows, identities, sessions |
 | `assay.ory.hydra`         | Ory Hydra OAuth2/OIDC — clients, authorize URLs, tokens, login/consent, JWKs |
 | `assay.ory.keto`          | Ory Keto ReBAC — relation tuples, permission checks, expand                |
-| `assay.ory`           | Convenience wrapper — `ory.connect()` builds kratos/hydra/keto clients together |
+| `assay.ory.rbac`          | Capability-based RBAC engine over Keto — roles + capabilities, separation of duties |
+| `assay.ory`           | Convenience wrapper — `ory.connect()` builds kratos/hydra/keto clients together; also re-exports `rbac` |
 | `assay.crossplane`    | Providers, XRDs, compositions, managed resources                           |
 | `assay.velero`        | Backups, restores, schedules, storage locations                            |
 | `assay.temporal`      | Workflows, task queues, schedules, signals + native gRPC (temporal feature)|

--- a/SKILL.md
+++ b/SKILL.md
@@ -271,9 +271,9 @@ All 33 modules follow `require("assay.<name>")` then `M.client(url, opts)`.
 | `assay.eso`           | ExternalSecrets, SecretStores, ClusterSecretStores sync status             |
 | `assay.dex`           | OIDC discovery, JWKS, health, configuration validation                     |
 | `assay.zitadel`       | OIDC identity management with JWT machine auth                             |
-| `assay.kratos`        | Ory Kratos — login/registration/recovery/settings flows, identities, sessions |
-| `assay.hydra`         | Ory Hydra OAuth2/OIDC — clients, authorize URLs, tokens, login/consent, JWKs |
-| `assay.keto`          | Ory Keto ReBAC — relation tuples, permission checks, expand                |
+| `assay.ory.kratos`        | Ory Kratos — login/registration/recovery/settings flows, identities, sessions |
+| `assay.ory.hydra`         | Ory Hydra OAuth2/OIDC — clients, authorize URLs, tokens, login/consent, JWKs |
+| `assay.ory.keto`          | Ory Keto ReBAC — relation tuples, permission checks, expand                |
 | `assay.ory`           | Convenience wrapper — `ory.connect()` builds kratos/hydra/keto clients together |
 | `assay.crossplane`    | Providers, XRDs, compositions, managed resources                           |
 | `assay.velero`        | Backups, restores, schedules, storage locations                            |

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: assay
-description: Infrastructure scripting runtime — 50 modules for Kubernetes, ArgoCD, Vault, Prometheus, HTTP servers, AI agents, databases. Replaces kubectl, Python, Node.js, curl, jq in one 9 MB binary.
+description: Infrastructure scripting runtime — 51 modules for Kubernetes, ArgoCD, Vault, Prometheus, HTTP servers, AI agents, databases. Replaces kubectl, Python, Node.js, curl, jq in one 9 MB binary.
 metadata:
   author: developerinlondon
   version: "0.6.1"
@@ -44,7 +44,7 @@ assay modules
 | `assay exec -e 'lua code'`  | Evaluate Lua inline                           |
 | `assay exec script.lua`     | Run Lua file via exec subcommand              |
 | `assay context "<keyword>"` | Find modules matching keyword, shows quickref |
-| `assay modules`             | List all 50 modules (33 stdlib + 17 builtins) |
+| `assay modules`             | List all 51 modules (34 stdlib + 17 builtins) |
 
 ## Discovering Modules
 
@@ -253,7 +253,7 @@ Available when built with `--features temporal`. Native gRPC client for Temporal
 
 ## Stdlib Modules Quick Reference
 
-All 33 modules follow `require("assay.<name>")` then `M.client(url, opts)`.
+All 34 modules follow `require("assay.<name>")` then `M.client(url, opts)`.
 
 | Module                | Description                                                                |
 | --------------------- | -------------------------------------------------------------------------- |
@@ -494,7 +494,7 @@ hardcode credentials in scripts.
 **Shebang scripts**: Add `#!/usr/bin/assay` as the first line and `chmod +x script.lua` to run
 scripts directly without the `assay` prefix.
 
-**Module not found**: All 33 stdlib modules are embedded in the binary. If `require("assay.foo")`
+**Module not found**: All 34 stdlib modules are embedded in the binary. If `require("assay.foo")`
 fails, run `assay modules` to see the exact module names.
 
 **Lua 5.5 specifics**: Assay uses Lua 5.5 (not LuaJIT). Integer division is `//`, bitwise ops use
@@ -586,7 +586,7 @@ Today: use `assay context <query>` from terminal and paste output into agent con
 
 ## MCP-Serve Vision (v0.6.0)
 
-`assay mcp-serve` will expose all 50 modules (33 stdlib + 17 builtins) as MCP tools over stdio/SSE transport:
+`assay mcp-serve` will expose all 51 modules (34 stdlib + 17 builtins) as MCP tools over stdio/SSE transport:
 
 - Each stdlib module becomes an MCP tool (e.g., `grafana_health`, `k8s_pods`)
 - Each builtin becomes an MCP tool (e.g., `http_get`, `crypto_jwt_sign`)

--- a/site/agent-guides.html
+++ b/site/agent-guides.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Assay — AI Agent Integration Guides</title>
-  <meta name="description" content="Integration guides for Claude Code, Cursor, Windsurf, Cline, and OpenCode — use Assay's 50 modules in your AI coding agent.">
+  <meta name="description" content="Integration guides for Claude Code, Cursor, Windsurf, Cline, and OpenCode — use Assay's 51 modules in your AI coding agent.">
   <link rel="stylesheet" href="style.css">
 </head>
 <body class="page-agents">
@@ -13,7 +13,7 @@ __HEADER__
   <main>
     <h1>AI Agent Integration Guides</h1>
     <p style="font-size: 1.15rem; color: var(--text-secondary); margin-bottom: 2rem;">
-      Use Assay's 50 modules in Claude Code, Cursor, Windsurf, Cline, and OpenCode.
+      Use Assay's 51 modules in Claude Code, Cursor, Windsurf, Cline, and OpenCode.
     </p>
 
     <h2>How It Works</h2>
@@ -154,7 +154,7 @@ assert.not_nil(result)
 assay script.lua</code></pre>
 
     <p>
-      All 33 stdlib modules follow the same pattern: <code>require</code>, <code>client()</code>,
+      All 34 stdlib modules follow the same pattern: <code>require</code>, <code>client()</code>,
       <code>c:method()</code>. Learn one, know them all.
     </p>
 

--- a/site/index.html
+++ b/site/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Assay — Infrastructure Testing &amp; Automation Runtime</title>
-  <meta name="description" content="Assay is a 9 MB Lua runtime for infrastructure testing, Kubernetes automation, HTTP servers, and AI agent integration. 50 modules. Replaces kubectl, Python, Node.js, curl, jq.">
+  <meta name="description" content="Assay is a 9 MB Lua runtime for infrastructure testing, Kubernetes automation, HTTP servers, and AI agent integration. 51 modules. Replaces kubectl, Python, Node.js, curl, jq.">
   <link rel="stylesheet" href="style.css">
 </head>
 <body class="page-home">
@@ -15,7 +15,7 @@ __HEADER__
     <div style="padding: 1.5rem 0 1rem; border-bottom: 1px solid var(--border); margin-bottom: 1rem;">
       <div style="font-size: 1.4rem; font-weight: 700; margin-bottom: 0.3rem;">Replaces your entire infrastructure scripting toolchain.</div>
       <div style="display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 0.75rem;">
-        <span class="text-muted">One 9 MB binary. 50 modules. Linux, macOS, Docker, <a href="https://crates.io/crates/assay-lua">Rust crate</a>.</span>
+        <span class="text-muted">One 9 MB binary. 51 modules. Linux, macOS, Docker, <a href="https://crates.io/crates/assay-lua">Rust crate</a>.</span>
         <div style="display: flex; gap: 0.5rem; flex-shrink: 0;">
           <a href="modules.html" style="display: inline-block; background-color: var(--accent); color: #fff; padding: 0.4rem 1rem; border-radius: 4px; font-size: 0.85rem; font-weight: 600; text-decoration: none;">Modules</a>
           <a href="#install" style="display: inline-block; color: var(--accent); border: 1px solid var(--accent); padding: 0.4rem 1rem; border-radius: 4px; font-size: 0.85rem; font-weight: 600; text-decoration: none;">Install</a>
@@ -106,7 +106,7 @@ __HEADER__
         <div style="font-size: 0.7rem;" class="text-muted">OIDC identity</div>
       </a>
       <a href="modules.html" class="card" style="text-align: center; text-decoration: none; color: var(--accent); padding: 1rem 0.5rem;">
-        <div style="font-size: 1.4rem; font-weight: 700; margin-bottom: 0.3rem;">+33</div>
+        <div style="font-size: 1.4rem; font-weight: 700; margin-bottom: 0.3rem;">+34</div>
         <div style="font-weight: 600; font-size: 0.8rem;">More</div>
         <div style="font-size: 0.7rem;">View all &rarr;</div>
       </a>
@@ -119,7 +119,7 @@ __HEADER__
         <div class="text-muted" style="font-size: 0.8rem;">Static binary</div>
       </div>
       <div style="text-align: center; padding: 1rem; border: 1px solid var(--border); border-radius: 8px;">
-        <div style="font-size: 1.8rem; font-weight: 700; color: var(--accent);">50</div>
+        <div style="font-size: 1.8rem; font-weight: 700; color: var(--accent);">51</div>
         <div class="text-muted" style="font-size: 0.8rem;">Modules</div>
       </div>
       <div style="text-align: center; padding: 1rem; border: 1px solid var(--border); border-radius: 8px;">

--- a/site/llms-full.txt
+++ b/site/llms-full.txt
@@ -736,7 +736,7 @@ local app = c:ensure_oidc_app(proj.id, {
 })
 ```
 
-## assay.kratos
+## assay.ory.kratos
 
 Ory Kratos identity management. Self-service login, registration, recovery and settings flows,
 identity CRUD via the admin API, session introspection (whoami), and identity schemas.
@@ -759,7 +759,7 @@ Client: `kratos.client({public_url="...", admin_url="..."})`.
 
 Example:
 ```lua
-local kratos = require("assay.kratos")
+local kratos = require("assay.ory.kratos")
 local c = kratos.client({
   public_url = "http://kratos-public:4433",
   admin_url = "http://kratos-admin:4434",
@@ -768,7 +768,7 @@ local session = c:whoami(cookie)
 log.info("Logged in as: " .. session.identity.traits.email)
 ```
 
-## assay.hydra
+## assay.ory.hydra
 
 Ory Hydra OAuth2 and OpenID Connect server. OAuth2 client CRUD via the admin API,
 authorize URL builder, token exchange, accept/reject login and consent challenges,
@@ -792,7 +792,7 @@ Client: `hydra.client({public_url="...", admin_url="..."})`.
 
 Example:
 ```lua
-local hydra = require("assay.hydra")
+local hydra = require("assay.ory.hydra")
 local c = hydra.client({
   public_url = "https://hydra.example.com",
   admin_url = "http://hydra-admin:4445",
@@ -804,7 +804,7 @@ local client = c:create_client({
 })
 ```
 
-## assay.keto
+## assay.ory.keto
 
 Ory Keto relationship-based access control (Zanzibar-style ReBAC). Relation-tuple CRUD,
 permission checks, role/group membership queries, and the expand API.
@@ -819,7 +819,7 @@ Client: `keto.client({read_url="...", write_url="..."})`.
 
 Example:
 ```lua
-local keto = require("assay.keto")
+local keto = require("assay.ory.keto")
 local c = keto.client({
   read_url = "http://keto-read:4466",
   write_url = "http://keto-write:4467",
@@ -833,12 +833,12 @@ assert(c:check("apps", "cc", "admin", "user:alice"))
 
 ## assay.ory
 
-Convenience wrapper re-exporting `assay.kratos`, `assay.hydra`, and `assay.keto`, with
+Convenience wrapper re-exporting `assay.ory.kratos`, `assay.ory.hydra`, and `assay.ory.keto`, with
 `ory.connect(opts)` to build all three clients in a single call.
 
-- `M.kratos` — re-export of `assay.kratos`
-- `M.hydra` — re-export of `assay.hydra`
-- `M.keto` — re-export of `assay.keto`
+- `M.kratos` — re-export of `assay.ory.kratos`
+- `M.hydra` — re-export of `assay.ory.hydra`
+- `M.keto` — re-export of `assay.ory.keto`
 - `M.connect(opts)` → `{kratos, hydra, keto}` — Build all three clients. `opts`: `{kratos_public, kratos_admin, hydra_public, hydra_admin, keto_read, keto_write}`
 
 Example:

--- a/site/llms-full.txt
+++ b/site/llms-full.txt
@@ -89,6 +89,10 @@ Cryptography utilities. No `require()` needed.
   - `key`: string — signing key (secret or PEM private key)
   - `alg`: `"HS256"` | `"HS384"` | `"HS512"` | `"RS256"` | `"RS384"` | `"RS512"`
   - `opts`: `{kid = "key-id"}` — optional key ID header
+- `crypto.jwt_decode(token)` → `{header, claims}` — Decode a JWT WITHOUT verifying its signature
+  - Returns `header` and `claims` parsed from the base64url segments
+  - Use when the JWT travels through a trusted channel (your own session cookie over TLS) and you just need to read the claims
+  - For untrusted JWTs, verify the signature with a JWKS-aware verifier instead
 - `crypto.hash(str, alg)` → string — Hash string (hex output)
   - `alg`: `"sha256"` | `"sha384"` | `"sha512"` | `"md5"`
 - `crypto.hmac(key, data, alg?, raw?)` → string — HMAC signature
@@ -831,14 +835,65 @@ c:create_tuple({
 assert(c:check("apps", "cc", "admin", "user:alice"))
 ```
 
+## assay.ory.rbac
+
+Capability-based RBAC engine layered on top of Ory Keto. Define a policy once
+(role → capability set) and get user lookups, capability checks, and membership
+management for free. Users can hold multiple roles and the effective capability
+set is the union, so separation of duties is enforceable at the authorization
+layer (an `approver` role can have `approve` without also getting `trigger`,
+even if listed above an `operator` role with `trigger`).
+
+Policy: `rbac.policy({namespace, keto, roles, default_role?})`. `namespace`
+filters Keto tuples (e.g. `"command-center"`); `keto` is a Keto client;
+`roles` maps role names to `{rank, capabilities, label?, description?}`;
+`default_role` is the role assumed for users with no memberships.
+
+- `p:user_roles(user_id)` → `{role}` — held roles, sorted by rank descending
+- `p:user_primary_role(user_id)` → role — highest-ranked, for compact UI badges
+- `p:user_capabilities(user_id)` → `{cap=true,...}` — union over all held roles, falls back to `default_role` caps when empty
+- `p:user_has_capability(user_id, cap)` → bool — single capability check
+- `p:add(user_id, role)` — idempotent membership add (no-op if already a member)
+- `p:remove(user_id, role)` — membership remove (swallows 404)
+- `p:list_members(role)` → `{user_id}` — direct members of a role
+- `p:list_all_memberships()` → `{[role]={user_id,...}}` — full snapshot
+- `p:reset_role(role)` — delete all members of a role (for bootstrap/seed scripts)
+- `p:require_capability(cap, handler)` → handler — `http.serve` middleware that 403s callers without `cap`
+
+Example:
+```lua
+local keto = require("assay.ory.keto")
+local rbac = require("assay.ory.rbac")
+
+local kc = keto.client({ read_url = "http://keto-read:4466", write_url = "http://keto-write:4467" })
+local policy = rbac.policy({
+  namespace = "command-center",
+  keto = kc,
+  default_role = "viewer",
+  roles = {
+    owner    = { rank = 5, capabilities = { "manage_roles", "approve", "trigger", "view" } },
+    admin    = { rank = 4, capabilities = { "manage_roles", "approve", "trigger", "view" } },
+    approver = { rank = 3, capabilities = { "approve", "view" } },
+    operator = { rank = 2, capabilities = { "trigger", "view" } },
+    viewer   = { rank = 1, capabilities = { "view" } },
+  },
+})
+
+policy:add("user:alice", "approver")
+assert(policy:user_has_capability("user:alice", "approve"))
+assert(not policy:user_has_capability("user:alice", "trigger"))
+```
+
 ## assay.ory
 
-Convenience wrapper re-exporting `assay.ory.kratos`, `assay.ory.hydra`, and `assay.ory.keto`, with
-`ory.connect(opts)` to build all three clients in a single call.
+Convenience wrapper re-exporting `assay.ory.kratos`, `assay.ory.hydra`,
+`assay.ory.keto`, and `assay.ory.rbac`, with `ory.connect(opts)` to build
+all three Ory clients in a single call.
 
 - `M.kratos` — re-export of `assay.ory.kratos`
 - `M.hydra` — re-export of `assay.ory.hydra`
 - `M.keto` — re-export of `assay.ory.keto`
+- `M.rbac` — re-export of `assay.ory.rbac`
 - `M.connect(opts)` → `{kratos, hydra, keto}` — Build all three clients. `opts`: `{kratos_public, kratos_admin, hydra_public, hydra_admin, keto_read, keto_write}`
 
 Example:

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -18,7 +18,7 @@
 - [yaml](https://assay.rs/modules.html#yaml): YAML parse and encode
 - [toml](https://assay.rs/modules.html#toml): TOML parse and encode
 - [fs](https://assay.rs/modules.html#fs): Filesystem — fs.read/write
-- [crypto](https://assay.rs/modules.html#crypto): JWT signing, HMAC, hashing, random — crypto.jwt_sign/hash/hmac/random
+- [crypto](https://assay.rs/modules.html#crypto): JWT signing/decoding, HMAC, hashing, random — crypto.jwt_sign/jwt_decode/hash/hmac/random
 - [base64](https://assay.rs/modules.html#base64): Base64 encode/decode
 - [regex](https://assay.rs/modules.html#regex): Regex match, find, replace
 - [db](https://assay.rs/modules.html#db): SQL database — Postgres, MySQL, SQLite — db.connect/query/execute
@@ -54,7 +54,8 @@
 - [assay.ory.kratos](https://assay.rs/modules.html#ory): Ory Kratos identity — login/registration/recovery flows, identities, sessions, schemas
 - [assay.ory.hydra](https://assay.rs/modules.html#ory): Ory Hydra OAuth2/OIDC — clients, authorize URLs, tokens, login/consent, introspection, JWKs
 - [assay.ory.keto](https://assay.rs/modules.html#ory): Ory Keto ReBAC — relation tuples, permission checks, role/group queries, expand
-- [assay.ory](https://assay.rs/modules.html#ory): Ory stack wrapper — `ory.connect()` builds kratos/hydra/keto clients together
+- [assay.ory.rbac](https://assay.rs/modules.html#ory): Capability-based RBAC engine over Keto — define roles + capabilities, query users, manage memberships
+- [assay.ory](https://assay.rs/modules.html#ory): Ory stack wrapper — `ory.connect()` builds kratos/hydra/keto clients together; also re-exports `rbac`
 
 ## Infrastructure
 - [assay.crossplane](https://assay.rs/modules.html#crossplane): Crossplane providers, XRDs, compositions

--- a/site/llms.txt
+++ b/site/llms.txt
@@ -51,9 +51,9 @@
 - [assay.eso](https://assay.rs/modules.html#eso): External Secrets Operator
 - [assay.dex](https://assay.rs/modules.html#dex): Dex OIDC discovery, JWKS, health
 - [assay.zitadel](https://assay.rs/modules.html#zitadel): Zitadel OIDC identity, JWT machine auth
-- [assay.kratos](https://assay.rs/modules.html#ory): Ory Kratos identity — login/registration/recovery flows, identities, sessions, schemas
-- [assay.hydra](https://assay.rs/modules.html#ory): Ory Hydra OAuth2/OIDC — clients, authorize URLs, tokens, login/consent, introspection, JWKs
-- [assay.keto](https://assay.rs/modules.html#ory): Ory Keto ReBAC — relation tuples, permission checks, role/group queries, expand
+- [assay.ory.kratos](https://assay.rs/modules.html#ory): Ory Kratos identity — login/registration/recovery flows, identities, sessions, schemas
+- [assay.ory.hydra](https://assay.rs/modules.html#ory): Ory Hydra OAuth2/OIDC — clients, authorize URLs, tokens, login/consent, introspection, JWKs
+- [assay.ory.keto](https://assay.rs/modules.html#ory): Ory Keto ReBAC — relation tuples, permission checks, role/group queries, expand
 - [assay.ory](https://assay.rs/modules.html#ory): Ory stack wrapper — `ory.connect()` builds kratos/hydra/keto clients together
 
 ## Infrastructure

--- a/site/modules.html
+++ b/site/modules.html
@@ -176,8 +176,8 @@ assay context "grafana health"   # get detailed docs for LLM</code></pre>
       <tbody>
         <tr>
           <td><code>crypto</code></td>
-          <td><code>crypto.jwt_sign/hash/hmac/random</code></td>
-          <td>JWT, hashing, HMAC</td>
+          <td><code>crypto.jwt_sign/jwt_decode/hash/hmac/random</code></td>
+          <td>JWT signing &amp; decoding, hashing, HMAC</td>
         </tr>
         <tr>
           <td><code>regex</code></td>
@@ -415,9 +415,15 @@ assay context "grafana health"   # get detailed docs for LLM</code></pre>
           <td><code>keto.client({read_url, write_url})</code></td>
         </tr>
         <tr>
+          <td><code>assay.ory.rbac</code></td>
+          <td><code>require("assay.ory.rbac")</code></td>
+          <td>Capability-based RBAC engine over Keto &mdash; roles + capabilities, separation of duties, idempotent membership management, http.serve middleware</td>
+          <td><code>rbac.policy({namespace, keto, roles, default_role})</code></td>
+        </tr>
+        <tr>
           <td><code>assay.ory</code></td>
           <td><code>require("assay.ory")</code></td>
-          <td>Ory stack wrapper &mdash; builds kratos/hydra/keto clients in one call</td>
+          <td>Ory stack wrapper &mdash; builds kratos/hydra/keto clients in one call; also re-exports <code>rbac</code></td>
           <td><code>ory.connect({kratos_public, hydra_admin, keto_read, ...})</code></td>
         </tr>
       </tbody>

--- a/site/modules.html
+++ b/site/modules.html
@@ -397,20 +397,20 @@ assay context "grafana health"   # get detailed docs for LLM</code></pre>
           <td><code>zitadel.client(url, opts)</code></td>
         </tr>
         <tr>
-          <td><code>assay.kratos</code></td>
-          <td><code>require("assay.kratos")</code></td>
+          <td><code>assay.ory.kratos</code></td>
+          <td><code>require("assay.ory.kratos")</code></td>
           <td>Ory Kratos identity &mdash; login flows, identities, sessions, schemas</td>
           <td><code>kratos.client({public_url, admin_url})</code></td>
         </tr>
         <tr>
-          <td><code>assay.hydra</code></td>
-          <td><code>require("assay.hydra")</code></td>
+          <td><code>assay.ory.hydra</code></td>
+          <td><code>require("assay.ory.hydra")</code></td>
           <td>Ory Hydra OAuth2/OIDC &mdash; clients, authorize, tokens, login/consent, JWKs</td>
           <td><code>hydra.client({public_url, admin_url})</code></td>
         </tr>
         <tr>
-          <td><code>assay.keto</code></td>
-          <td><code>require("assay.keto")</code></td>
+          <td><code>assay.ory.keto</code></td>
+          <td><code>require("assay.ory.keto")</code></td>
           <td>Ory Keto ReBAC &mdash; relation tuples, permission checks, expand</td>
           <td><code>keto.client({read_url, write_url})</code></td>
         </tr>

--- a/site/modules.html
+++ b/site/modules.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Assay — Module Reference</title>
-  <meta name="description" content="Complete reference for all 50+ Assay modules — 17 Rust builtins and 33 embedded Lua stdlib modules, zero dependencies.">
+  <meta name="description" content="Complete reference for all 51 Assay modules — 17 Rust builtins and 34 embedded Lua stdlib modules, zero dependencies.">
   <link rel="stylesheet" href="style.css">
 </head>
 <body class="page-modules">
@@ -13,7 +13,7 @@ __HEADER__
   <main>
     <h1>Module Reference</h1>
     <p style="font-size: 1.15rem; color: var(--text-secondary); margin-bottom: 1.5rem;">
-      50+ modules, zero dependencies. Use <code>assay context &lt;query&gt;</code> for LLM-ready docs on any module.
+      51 modules, zero dependencies. Use <code>assay context &lt;query&gt;</code> for LLM-ready docs on any module.
     </p>
 
     <pre><code>assay modules                    # list all modules
@@ -255,12 +255,12 @@ assay context "grafana health"   # get detailed docs for LLM</code></pre>
     </table>
 
     <!-- ============================================================ -->
-    <!-- STDLIB MODULES (33 modules)                                  -->
+    <!-- STDLIB MODULES (34 modules)                                  -->
     <!-- ============================================================ -->
 
     <h2>Stdlib Modules</h2>
     <p>
-      33 embedded Lua modules loaded via <code>require("assay.&lt;name&gt;")</code>.
+      34 embedded Lua modules loaded via <code>require("assay.&lt;name&gt;")</code>.
       All follow the client pattern: <code>M.client(url, opts)</code> &rarr; client object &rarr; <code>c:method()</code>.
     </p>
 

--- a/skills/assay/SKILL.md
+++ b/skills/assay/SKILL.md
@@ -164,12 +164,13 @@ String header values still work as before.
 
 ### Cryptography
 
-| Function                             | Description                                     |
-| ------------------------------------ | ----------------------------------------------- |
-| `crypto.jwt_sign(claims, key, alg)`  | Sign JWT — alg: HS256, RS256/384/512, ES256/384 |
-| `crypto.hash(str, alg)`              | Hash string (sha256, sha384, sha512, md5)       |
-| `crypto.hmac(key, data, alg?, raw?)` | HMAC (sha256 default, raw=true for binary)      |
-| `crypto.random(len)`                 | Secure random hex string of length `len`        |
+| Function                             | Description                                                   |
+| ------------------------------------ | ------------------------------------------------------------- |
+| `crypto.jwt_sign(claims, key, alg)`  | Sign JWT — alg: HS256, RS256/384/512, ES256/384               |
+| `crypto.jwt_decode(token)`           | Decode `{header, claims}` WITHOUT verifying — trusted channel |
+| `crypto.hash(str, alg)`              | Hash string (sha256, sha384, sha512, md5)                     |
+| `crypto.hmac(key, data, alg?, raw?)` | HMAC (sha256 default, raw=true for binary)                    |
+| `crypto.random(len)`                 | Secure random hex string of length `len`                      |
 
 ### Regex
 
@@ -274,7 +275,8 @@ All 33 modules follow `require("assay.<name>")` then `M.client(url, opts)`.
 | `assay.ory.kratos`        | Ory Kratos — login/registration/recovery/settings flows, identities, sessions |
 | `assay.ory.hydra`         | Ory Hydra OAuth2/OIDC — clients, authorize URLs, tokens, login/consent, JWKs |
 | `assay.ory.keto`          | Ory Keto ReBAC — relation tuples, permission checks, expand                |
-| `assay.ory`           | Convenience wrapper — `ory.connect()` builds kratos/hydra/keto clients together |
+| `assay.ory.rbac`          | Capability-based RBAC engine over Keto — roles + capabilities, separation of duties |
+| `assay.ory`           | Convenience wrapper — `ory.connect()` builds kratos/hydra/keto clients together; also re-exports `rbac` |
 | `assay.crossplane`    | Providers, XRDs, compositions, managed resources                           |
 | `assay.velero`        | Backups, restores, schedules, storage locations                            |
 | `assay.temporal`      | Workflows, task queues, schedules, signals + native gRPC (temporal feature)|

--- a/skills/assay/SKILL.md
+++ b/skills/assay/SKILL.md
@@ -271,9 +271,9 @@ All 33 modules follow `require("assay.<name>")` then `M.client(url, opts)`.
 | `assay.eso`           | ExternalSecrets, SecretStores, ClusterSecretStores sync status             |
 | `assay.dex`           | OIDC discovery, JWKS, health, configuration validation                     |
 | `assay.zitadel`       | OIDC identity management with JWT machine auth                             |
-| `assay.kratos`        | Ory Kratos — login/registration/recovery/settings flows, identities, sessions |
-| `assay.hydra`         | Ory Hydra OAuth2/OIDC — clients, authorize URLs, tokens, login/consent, JWKs |
-| `assay.keto`          | Ory Keto ReBAC — relation tuples, permission checks, expand                |
+| `assay.ory.kratos`        | Ory Kratos — login/registration/recovery/settings flows, identities, sessions |
+| `assay.ory.hydra`         | Ory Hydra OAuth2/OIDC — clients, authorize URLs, tokens, login/consent, JWKs |
+| `assay.ory.keto`          | Ory Keto ReBAC — relation tuples, permission checks, expand                |
 | `assay.ory`           | Convenience wrapper — `ory.connect()` builds kratos/hydra/keto clients together |
 | `assay.crossplane`    | Providers, XRDs, compositions, managed resources                           |
 | `assay.velero`        | Backups, restores, schedules, storage locations                            |

--- a/skills/assay/SKILL.md
+++ b/skills/assay/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: assay
-description: Infrastructure scripting runtime — 50 modules for Kubernetes, ArgoCD, Vault, Prometheus, HTTP servers, AI agents, databases. Replaces kubectl, Python, Node.js, curl, jq in one 9 MB binary.
+description: Infrastructure scripting runtime — 51 modules for Kubernetes, ArgoCD, Vault, Prometheus, HTTP servers, AI agents, databases. Replaces kubectl, Python, Node.js, curl, jq in one 9 MB binary.
 metadata:
   author: developerinlondon
   version: "0.6.1"
@@ -44,7 +44,7 @@ assay modules
 | `assay exec -e 'lua code'`  | Evaluate Lua inline                           |
 | `assay exec script.lua`     | Run Lua file via exec subcommand              |
 | `assay context "<keyword>"` | Find modules matching keyword, shows quickref |
-| `assay modules`             | List all 50 modules (33 stdlib + 17 builtins) |
+| `assay modules`             | List all 51 modules (34 stdlib + 17 builtins) |
 
 ## Discovering Modules
 
@@ -253,7 +253,7 @@ Available when built with `--features temporal`. Native gRPC client for Temporal
 
 ## Stdlib Modules Quick Reference
 
-All 33 modules follow `require("assay.<name>")` then `M.client(url, opts)`.
+All 34 modules follow `require("assay.<name>")` then `M.client(url, opts)`.
 
 | Module                | Description                                                                |
 | --------------------- | -------------------------------------------------------------------------- |
@@ -494,7 +494,7 @@ hardcode credentials in scripts.
 **Shebang scripts**: Add `#!/usr/bin/assay` as the first line and `chmod +x script.lua` to run
 scripts directly without the `assay` prefix.
 
-**Module not found**: All 33 stdlib modules are embedded in the binary. If `require("assay.foo")`
+**Module not found**: All 34 stdlib modules are embedded in the binary. If `require("assay.foo")`
 fails, run `assay modules` to see the exact module names.
 
 **Lua 5.5 specifics**: Assay uses Lua 5.5 (not LuaJIT). Integer division is `//`, bitwise ops use
@@ -586,7 +586,7 @@ Today: use `assay context <query>` from terminal and paste output into agent con
 
 ## MCP-Serve Vision (v0.6.0)
 
-`assay mcp-serve` will expose all 50 modules (33 stdlib + 17 builtins) as MCP tools over stdio/SSE transport:
+`assay mcp-serve` will expose all 51 modules (34 stdlib + 17 builtins) as MCP tools over stdio/SSE transport:
 
 - Each stdlib module becomes an MCP tool (e.g., `grafana_health`, `k8s_pods`)
 - Each builtin becomes an MCP tool (e.g., `http_get`, `crypto_jwt_sign`)

--- a/src/lua/builtins/crypto.rs
+++ b/src/lua/builtins/crypto.rs
@@ -1,4 +1,5 @@
-use super::json::lua_value_to_json;
+use super::json::{json_value_to_lua, lua_value_to_json};
+use data_encoding::BASE64URL_NOPAD;
 use digest::Digest;
 use jsonwebtoken::{Algorithm, EncodingKey, Header};
 use mlua::{Lua, Value};
@@ -76,6 +77,43 @@ pub fn register_crypto(lua: &Lua) -> mlua::Result<()> {
         Ok(token)
     })?;
     crypto_table.set("jwt_sign", jwt_sign_fn)?;
+
+    // crypto.jwt_decode(token) -> { header, claims }
+    //
+    // Decodes a JWT WITHOUT verifying its signature. Returns a table with
+    // `header` and `claims` sub-tables — both parsed from the base64url
+    // segments of the token. Useful when the JWT travels through a trusted
+    // channel (e.g. your own session cookie set over TLS) and you just
+    // need to read the claims. For untrusted JWTs, use a verifier instead.
+    let jwt_decode_fn = lua.create_function(|lua, token: String| {
+        let parts: Vec<&str> = token.split('.').collect();
+        if parts.len() != 3 {
+            return Err(mlua::Error::runtime(
+                "crypto.jwt_decode: token must have three '.'-separated segments (header.payload.signature)",
+            ));
+        }
+
+        let decode_segment = |segment: &str, label: &str| -> mlua::Result<serde_json::Value> {
+            // JWTs use unpadded base64url encoding per RFC 7515.
+            let bytes = BASE64URL_NOPAD.decode(segment.as_bytes()).map_err(|e| {
+                mlua::Error::runtime(format!(
+                    "crypto.jwt_decode: {label}: invalid base64url: {e}"
+                ))
+            })?;
+            serde_json::from_slice(&bytes).map_err(|e| {
+                mlua::Error::runtime(format!("crypto.jwt_decode: {label}: invalid JSON: {e}"))
+            })
+        };
+
+        let header = decode_segment(parts[0], "header")?;
+        let claims = decode_segment(parts[1], "payload")?;
+
+        let result = lua.create_table()?;
+        result.set("header", json_value_to_lua(lua, &header)?)?;
+        result.set("claims", json_value_to_lua(lua, &claims)?)?;
+        Ok(result)
+    })?;
+    crypto_table.set("jwt_decode", jwt_decode_fn)?;
 
     let hash_fn = lua.create_function(|_, args: mlua::MultiValue| {
         let mut args_iter = args.into_iter();

--- a/src/lua/builtins/http.rs
+++ b/src/lua/builtins/http.rs
@@ -486,7 +486,7 @@ async fn build_lua_request_and_call(
     // Parse query string into a params table with URL-decoded keys and values
     // (e.g. "a=1&b=hello%20world" -> {a="1", b="hello world"}).
     // Uses form_urlencoded which handles percent-encoding and `+` -> ` ` correctly,
-    // so consumers like assay.hydra get the raw value back rather than a doubly-encoded string.
+    // so consumers like assay.ory.hydra get the raw value back rather than a doubly-encoded string.
     let params_table = lua.create_table()?;
     if !query.is_empty() {
         for (key, value) in url::form_urlencoded::parse(query.as_bytes()) {

--- a/src/lua/mod.rs
+++ b/src/lua/mod.rs
@@ -55,30 +55,40 @@ fn register_stdlib_loader(lua: &Lua) -> mlua::Result<()> {
     let package: mlua::Table = lua.globals().get("package")?;
     let searchers: mlua::Table = package.get("searchers")?;
 
+    // Resolves `require("assay.ory.kratos")` -> "ory/kratos.lua" by replacing
+    // dots with slashes, matching standard Lua package loading convention.
+    // Tries "<path>.lua" first, then falls back to "<path>/init.lua" so
+    // both `stdlib/ory.lua` (flat convenience wrapper) and
+    // `stdlib/ory/kratos.lua` (nested submodule) resolve correctly.
     let stdlib_searcher = lua.create_function(|lua, module_name: String| {
-        let path = if let Some(rest) = module_name.strip_prefix("assay.") {
-            format!("{rest}.lua")
-        } else {
-            return Ok(mlua::Value::String(
-                lua.create_string(format!("not an assay.* module: {module_name}"))?,
-            ));
+        let rest = match module_name.strip_prefix("assay.") {
+            Some(r) => r,
+            None => {
+                return Ok(mlua::Value::String(
+                    lua.create_string(format!("not an assay.* module: {module_name}"))?,
+                ));
+            }
         };
 
-        match STDLIB_DIR.get_file(&path) {
-            Some(file) => {
-                let source = file
-                    .contents_utf8()
-                    .ok_or_else(|| mlua::Error::runtime(format!("stdlib {path}: invalid UTF-8")))?;
+        let base = rest.replace('.', "/");
+        let candidates = [format!("{base}.lua"), format!("{base}/init.lua")];
+
+        for path in &candidates {
+            if let Some(file) = STDLIB_DIR.get_file(path) {
+                let source = file.contents_utf8().ok_or_else(|| {
+                    mlua::Error::runtime(format!("stdlib {path}: invalid UTF-8"))
+                })?;
                 let loader = lua
                     .load(source)
                     .set_name(format!("@assay/{path}"))
                     .into_function()?;
-                Ok(mlua::Value::Function(loader))
+                return Ok(mlua::Value::Function(loader));
             }
-            None => Ok(mlua::Value::String(
-                lua.create_string(format!("no embedded stdlib file: {path}"))?,
-            )),
         }
+
+        Ok(mlua::Value::String(
+            lua.create_string(format!("no embedded stdlib file: {}", candidates[0]))?,
+        ))
     })?;
 
     let len = searchers.len()?;
@@ -91,26 +101,40 @@ fn register_fs_loader(lua: &Lua, global_modules_path: Option<String>) -> mlua::R
     let package: mlua::Table = lua.globals().get("package")?;
     let searchers: mlua::Table = package.get("searchers")?;
 
+    // Same dotted-path resolution as the stdlib loader: `assay.ory.kratos`
+    // -> "ory/kratos.lua", falling back to "ory/kratos/init.lua".
     let fs_searcher = lua.create_function(move |lua, module_name: String| {
-        let filename = if let Some(rest) = module_name.strip_prefix("assay.") {
-            format!("{rest}.lua")
-        } else {
-            return Ok(mlua::Value::String(
-                lua.create_string(format!("not an assay.* module: {module_name}"))?,
-            ));
+        let rest = match module_name.strip_prefix("assay.") {
+            Some(r) => r,
+            None => {
+                return Ok(mlua::Value::String(
+                    lua.create_string(format!("not an assay.* module: {module_name}"))?,
+                ));
+            }
+        };
+        let base = rest.replace('.', "/");
+        let candidates = [format!("{base}.lua"), format!("{base}/init.lua")];
+
+        let try_load = |dir: &std::path::Path| -> Option<(std::path::PathBuf, String)> {
+            for rel in &candidates {
+                let full = dir.join(rel);
+                if let Ok(source) = std::fs::read_to_string(&full) {
+                    return Some((full, source));
+                }
+            }
+            None
         };
 
-        // Priority 1: ./modules/<name>.lua (per-project)
-        let project_path = std::path::Path::new("./modules").join(&filename);
-        if let Ok(source) = std::fs::read_to_string(&project_path) {
+        // Priority 1: ./modules/<path>.lua (per-project)
+        if let Some((full, source)) = try_load(std::path::Path::new("./modules")) {
             let loader = lua
                 .load(source)
-                .set_name(format!("@{}", project_path.display()))
+                .set_name(format!("@{}", full.display()))
                 .into_function()?;
             return Ok(mlua::Value::Function(loader));
         }
 
-        // Priority 2: ~/.assay/modules/<name>.lua (global user) or $ASSAY_MODULES_PATH
+        // Priority 2: $ASSAY_MODULES_PATH or ~/.assay/modules/<path>.lua
         let global_path = if let Some(ref custom_path) = global_modules_path {
             std::path::PathBuf::from(custom_path)
         } else if let Ok(modules_env) = std::env::var(MODULES_PATH_ENV) {
@@ -118,19 +142,17 @@ fn register_fs_loader(lua: &Lua, global_modules_path: Option<String>) -> mlua::R
         } else if let Ok(home) = std::env::var("HOME") {
             std::path::Path::new(&home).join(".assay/modules")
         } else {
-            // No home directory available, skip global path
             std::path::PathBuf::new()
         };
 
-        if !global_path.as_os_str().is_empty() {
-            let global_file_path = global_path.join(&filename);
-            if let Ok(source) = std::fs::read_to_string(&global_file_path) {
-                let loader = lua
-                    .load(source)
-                    .set_name(format!("@{}", global_file_path.display()))
-                    .into_function()?;
-                return Ok(mlua::Value::Function(loader));
-            }
+        if !global_path.as_os_str().is_empty()
+            && let Some((full, source)) = try_load(&global_path)
+        {
+            let loader = lua
+                .load(source)
+                .set_name(format!("@{}", full.display()))
+                .into_function()?;
+            return Ok(mlua::Value::Function(loader));
         }
 
         // Priority 3: Built-in modules are handled by register_stdlib_loader

--- a/stdlib/ory.lua
+++ b/stdlib/ory.lua
@@ -1,19 +1,22 @@
 --- @module assay.ory
---- @description Convenience wrapper that re-exports all three Ory stack modules (kratos, hydra, keto). Prefer requiring the individual modules directly if you only need one.
---- @keywords ory, stack, kratos, hydra, keto, identity, oauth2, oidc, authz, zanzibar
+--- @description Convenience umbrella for the Ory stack submodules (kratos, hydra, keto, rbac). Prefer requiring the individual submodules directly (e.g. assay.ory.kratos) if you only need one.
+--- @keywords ory, stack, kratos, hydra, keto, rbac, identity, oauth2, oidc, authz, zanzibar, capability
 --- @quickref ory.kratos.client(opts) -> kratos client | Kratos identity management
 --- @quickref ory.hydra.client(opts) -> hydra client | Hydra OAuth2 and OIDC
 --- @quickref ory.keto.client(read_url, opts?) -> keto client | Keto authorization (Zanzibar-style ReBAC)
+--- @quickref ory.rbac.policy(opts) -> policy | Capability-based RBAC engine over Keto
 --- @quickref ory.connect(opts) -> {kratos, hydra, keto} | Build all three clients in one call
 
-local kratos = require("assay.kratos")
-local hydra = require("assay.hydra")
-local keto = require("assay.keto")
+local kratos = require("assay.ory.kratos")
+local hydra = require("assay.ory.hydra")
+local keto = require("assay.ory.keto")
+local rbac = require("assay.ory.rbac")
 
 local M = {
   kratos = kratos,
   hydra = hydra,
   keto = keto,
+  rbac = rbac,
 }
 
 -- Convenience: build all three clients from a single options table.

--- a/stdlib/ory/hydra.lua
+++ b/stdlib/ory/hydra.lua
@@ -1,4 +1,4 @@
---- @module assay.hydra
+--- @module assay.ory.hydra
 --- @description Ory Hydra OAuth2 and OpenID Connect — client CRUD, authorize URL builder, token exchange, login/consent/logout challenges, introspection, JWK endpoint.
 --- @keywords hydra, ory, oauth2, oidc, openid, authentication, clients, tokens, login_challenge, consent_challenge, logout_challenge, jwk, authorize, introspect
 --- @quickref hydra.client(opts) -> client | Create a Hydra client. opts: {public_url, admin_url}

--- a/stdlib/ory/keto.lua
+++ b/stdlib/ory/keto.lua
@@ -1,4 +1,4 @@
---- @module assay.keto
+--- @module assay.ory.keto
 --- @description Ory Keto authorization — relation-tuple CRUD, permission checks, role membership queries. Implements relationship-based access control (ReBAC, Google Zanzibar-style).
 --- @keywords keto, ory, authorization, authz, rbac, rebac, permissions, roles, relation-tuples, zanzibar, access-control, members, groups
 --- @quickref keto.client(read_url, opts?) -> client | Create a Keto client (read endpoint)

--- a/stdlib/ory/kratos.lua
+++ b/stdlib/ory/kratos.lua
@@ -1,4 +1,4 @@
---- @module assay.kratos
+--- @module assay.ory.kratos
 --- @description Ory Kratos identity management — login/registration/recovery flows, identity CRUD via admin API, session introspection, schemas.
 --- @keywords kratos, ory, identity, authentication, login, registration, recovery, settings, sessions, identities, schemas, whoami
 --- @quickref kratos.client(opts) -> client | Create a Kratos client. opts: {public_url, admin_url}

--- a/stdlib/ory/rbac.lua
+++ b/stdlib/ory/rbac.lua
@@ -1,0 +1,291 @@
+--- @module assay.ory.rbac
+--- @description Capability-based RBAC engine layered on top of Ory Keto. Define a policy once (role -> capabilities map) and get user lookups, capability checks, and membership management helpers. A user can hold multiple roles; their effective capability set is the union of all assigned roles. Each role also has a rank so a single "primary" role can be shown for display.
+--- @keywords rbac, roles, permissions, capabilities, authz, authorization, keto, ory, zanzibar, policy
+--- @quickref rbac.policy(opts) -> policy | Build a policy from a role map and a Keto client. opts: { namespace, keto, roles, default_role? }
+--- @quickref p:user_roles(user_id) -> [role_name] | All roles a user holds, sorted by rank (highest first)
+--- @quickref p:user_primary_role(user_id) -> role_name | Highest-ranked role (for UI badges)
+--- @quickref p:user_capabilities(user_id) -> {cap=true, ...} | Union of capabilities from every role the user holds
+--- @quickref p:user_has_capability(user_id, cap) -> bool | Check whether the user holds a given capability
+--- @quickref p:add(user_id, role_name) -> nil | Add the user to a role (idempotent)
+--- @quickref p:remove(user_id, role_name) -> nil | Remove the user from a role (idempotent)
+--- @quickref p:list_members(role_name) -> [user_id] | List every user assigned to a specific role
+--- @quickref p:list_all_memberships() -> {role_name=[user_id]} | Full snapshot of every role and its members
+--- @quickref p:reset_role(role_name) -> nil | Delete every member of a role (for bootstrap/seed scripts)
+--- @quickref p:roles() -> [role_name] | All configured role names, highest rank first
+--- @quickref p:role(role_name) -> {rank, capabilities} | Role metadata from the policy definition
+--- @quickref p:require_capability(cap, handler) -> handler | http.serve wrapper returning 403 when the caller lacks the capability
+
+local M = {}
+
+local KETO_NAMESPACE = "Role"
+
+local function strip_user_prefix(subject)
+  if type(subject) ~= "string" then return subject end
+  local stripped = subject:match("^user:(.+)$")
+  return stripped or subject
+end
+
+local function ensure_user_subject(user_id)
+  if type(user_id) ~= "string" or user_id == "" then
+    error("assay.ory.rbac: user_id must be a non-empty string")
+  end
+  if user_id:match("^user:") then
+    return user_id
+  end
+  return "user:" .. user_id
+end
+
+-- Build a policy from a role map and a Keto client.
+--
+-- opts: {
+--   namespace    = "command-center",    -- object prefix; tuples look like
+--                                       --   Role:command-center:<role>@user:<id>
+--   keto         = keto.client(...),    -- assay.ory.keto client with write_url set
+--   roles        = {                    -- role map keyed by role name
+--     owner    = { rank = 5, capabilities = {"read","trigger","approve"} },
+--     admin    = { rank = 4, capabilities = {"read","trigger","approve"} },
+--     operator = { rank = 2, capabilities = {"read","trigger"} },
+--     viewer   = { rank = 1, capabilities = {"read"} },
+--   },
+--   default_role = "viewer",            -- optional; role returned when a
+--                                       -- user has no explicit memberships
+-- }
+function M.policy(opts)
+  opts = opts or {}
+  if type(opts.namespace) ~= "string" or opts.namespace == "" then
+    error("assay.ory.rbac.policy: namespace is required")
+  end
+  if type(opts.keto) ~= "table" then
+    error("assay.ory.rbac.policy: keto client is required")
+  end
+  if type(opts.roles) ~= "table" or next(opts.roles) == nil then
+    error("assay.ory.rbac.policy: roles map is required and must not be empty")
+  end
+
+  -- Normalise each role to { rank, capability_set } where capability_set is
+  -- a {cap=true} lookup for O(1) checks.
+  local roles = {}
+  for name, def in pairs(opts.roles) do
+    local rank = tonumber(def.rank or 0) or 0
+    local caps = {}
+    for _, c in ipairs(def.capabilities or {}) do
+      caps[c] = true
+    end
+    roles[name] = { rank = rank, capabilities = caps }
+  end
+
+  -- Precompute a list of role names sorted by rank (highest first) so
+  -- user_roles / user_primary_role / roles() can return stable ordering.
+  local ranked_role_names = {}
+  for name, _ in pairs(roles) do
+    ranked_role_names[#ranked_role_names + 1] = name
+  end
+  table.sort(ranked_role_names, function(a, b)
+    if roles[a].rank == roles[b].rank then
+      return a < b
+    end
+    return roles[a].rank > roles[b].rank
+  end)
+
+  local p = {
+    _namespace = opts.namespace,
+    _keto = opts.keto,
+    _roles = roles,
+    _ranked_role_names = ranked_role_names,
+    _default_role = opts.default_role,
+  }
+
+  local function object_for(role_name)
+    return p._namespace .. ":" .. role_name
+  end
+
+  -- ========== Query methods ==========
+
+  function p:roles()
+    local out = {}
+    for i, name in ipairs(self._ranked_role_names) do
+      out[i] = name
+    end
+    return out
+  end
+
+  function p:role(role_name)
+    local def = self._roles[role_name]
+    if not def then return nil end
+    local caps = {}
+    for c, _ in pairs(def.capabilities) do
+      caps[#caps + 1] = c
+    end
+    table.sort(caps)
+    return { rank = def.rank, capabilities = caps }
+  end
+
+  -- Get all role names the user holds, sorted by rank (highest first).
+  -- Only roles defined in the policy are returned; tuples that reference
+  -- unknown role names are silently ignored so an out-of-date Keto row
+  -- can't grant an undefined capability.
+  function p:user_roles(user_id)
+    local subject = ensure_user_subject(user_id)
+    local tuples = self._keto:get_user_roles(subject, KETO_NAMESPACE)
+    local seen = {}
+    local held = {}
+    for _, t in ipairs(tuples) do
+      local role_name = t.object:match("^" .. self._namespace:gsub("%-", "%%-") .. ":(.+)$")
+      if role_name and self._roles[role_name] and not seen[role_name] then
+        seen[role_name] = true
+        held[#held + 1] = role_name
+      end
+    end
+    table.sort(held, function(a, b)
+      if self._roles[a].rank == self._roles[b].rank then
+        return a < b
+      end
+      return self._roles[a].rank > self._roles[b].rank
+    end)
+    return held
+  end
+
+  -- Highest-ranked role the user holds, or the configured default_role
+  -- (or nil) if the user has none. Used for compact UI badges where
+  -- only one label fits.
+  function p:user_primary_role(user_id)
+    local held = self:user_roles(user_id)
+    if #held > 0 then return held[1] end
+    return self._default_role
+  end
+
+  -- Union of capabilities from every role the user holds, returned as
+  -- a set ({cap=true, ...}) for O(1) checks by the caller.
+  function p:user_capabilities(user_id)
+    local held = self:user_roles(user_id)
+    local set = {}
+    if #held == 0 and self._default_role then
+      local def = self._roles[self._default_role]
+      if def then
+        for c, _ in pairs(def.capabilities) do set[c] = true end
+      end
+      return set
+    end
+    for _, role_name in ipairs(held) do
+      for c, _ in pairs(self._roles[role_name].capabilities) do
+        set[c] = true
+      end
+    end
+    return set
+  end
+
+  function p:user_has_capability(user_id, cap)
+    return self:user_capabilities(user_id)[cap] == true
+  end
+
+  -- ========== Membership management ==========
+
+  -- Add a user to a role. Idempotent: if the user is already a member,
+  -- this is a no-op. Requires the Keto client to be configured with a
+  -- write_url.
+  function p:add(user_id, role_name)
+    if not self._roles[role_name] then
+      error("assay.ory.rbac: unknown role " .. tostring(role_name))
+    end
+    local members = self:list_members(role_name)
+    local target = strip_user_prefix(ensure_user_subject(user_id))
+    for _, existing in ipairs(members) do
+      if existing == target then return end
+    end
+    self._keto:create({
+      namespace = KETO_NAMESPACE,
+      object = object_for(role_name),
+      relation = "members",
+      subject_id = ensure_user_subject(user_id),
+    })
+  end
+
+  -- Remove a user from a role. Idempotent: if the user isn't a member,
+  -- this is a no-op.
+  function p:remove(user_id, role_name)
+    if not self._roles[role_name] then
+      error("assay.ory.rbac: unknown role " .. tostring(role_name))
+    end
+    local ok, err = pcall(function()
+      self._keto:delete({
+        namespace = KETO_NAMESPACE,
+        object = object_for(role_name),
+        relation = "members",
+        subject_id = ensure_user_subject(user_id),
+      })
+    end)
+    if not ok and not tostring(err):match("404") then
+      error(err)
+    end
+  end
+
+  -- List every user (without the "user:" prefix) assigned to a role.
+  function p:list_members(role_name)
+    if not self._roles[role_name] then
+      error("assay.ory.rbac: unknown role " .. tostring(role_name))
+    end
+    local result = self._keto:list({
+      namespace = KETO_NAMESPACE,
+      object = object_for(role_name),
+      relation = "members",
+    })
+    local out = {}
+    local seen = {}
+    for _, t in ipairs(result.relation_tuples or {}) do
+      local uid = strip_user_prefix(t.subject_id)
+      if uid and not seen[uid] then
+        seen[uid] = true
+        out[#out + 1] = uid
+      end
+    end
+    return out
+  end
+
+  -- Snapshot of every role and its members. Handy for admin UIs.
+  function p:list_all_memberships()
+    local out = {}
+    for _, name in ipairs(self._ranked_role_names) do
+      out[name] = self:list_members(name)
+    end
+    return out
+  end
+
+  -- Delete every member of a role. Used by bootstrap/seed scripts that
+  -- want to reset the policy to a known state. Keto's PUT is not
+  -- idempotent at the tuple level so re-running a seed without a reset
+  -- creates duplicates.
+  function p:reset_role(role_name)
+    if not self._roles[role_name] then
+      error("assay.ory.rbac: unknown role " .. tostring(role_name))
+    end
+    self._keto:delete_all({
+      namespace = KETO_NAMESPACE,
+      object = object_for(role_name),
+      relation = "members",
+    })
+  end
+
+  -- ========== http.serve helper ==========
+
+  -- Wrap an http.serve handler so the request is rejected (with the
+  -- configured HTTP status, default 403) if the authenticated user
+  -- doesn't hold the required capability. The caller is responsible
+  -- for setting `req.user_id` on the request table before this runs
+  -- (e.g. via an earlier auth middleware).
+  function p:require_capability(cap, handler)
+    return function(req)
+      local user_id = req.user_id
+      if not user_id or user_id == "" then
+        return { status = 401, json = { error = "Authentication required" } }
+      end
+      if not self:user_has_capability(user_id, cap) then
+        return { status = 403, json = { error = cap .. " capability required" } }
+      end
+      return handler(req)
+    end
+  end
+
+  return p
+end
+
+return M

--- a/tests/crypto.rs
+++ b/tests/crypto.rs
@@ -112,6 +112,90 @@ async fn test_jwt_sign_invalid_key() {
 }
 
 #[tokio::test]
+async fn test_jwt_decode_basic_claims() {
+    // JWT with header {"alg":"RS256","typ":"JWT"} and claims
+    // {"sub":"user:alice","email":"alice@example.com","role":"admin","groups":["a","b"]}
+    // Signature is fake (jwt_decode doesn't verify).
+    run_lua(
+        r#"
+        local token = "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ1c2VyOmFsaWNlIiwiZW1haWwiOiJhbGljZUBleGFtcGxlLmNvbSIsInJvbGUiOiJhZG1pbiIsImdyb3VwcyI6WyJhIiwiYiJdfQ.fake-signature"
+        local out = crypto.jwt_decode(token)
+        assert.eq(out.header.alg, "RS256")
+        assert.eq(out.header.typ, "JWT")
+        assert.eq(out.claims.sub, "user:alice")
+        assert.eq(out.claims.email, "alice@example.com")
+        assert.eq(out.claims.role, "admin")
+        assert.eq(#out.claims.groups, 2)
+        assert.eq(out.claims.groups[1], "a")
+        assert.eq(out.claims.groups[2], "b")
+        "#,
+    )
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn test_jwt_decode_roundtrip_with_jwt_sign() {
+    // Sign a JWT with crypto.jwt_sign, then decode it with jwt_decode
+    // and verify all the claims round-trip correctly.
+    let pem = std::fs::read_to_string("tests/fixtures/test_rsa.pem").unwrap();
+
+    let vm = create_vm();
+    vm.globals()
+        .set("test_pem", vm.create_string(&pem).unwrap())
+        .unwrap();
+
+    vm.load(
+        r#"
+        local token = crypto.jwt_sign({
+          sub = "user:alice",
+          email = "alice@example.com",
+          role = "admin",
+          groups = {"a", "b", "c"},
+        }, test_pem, "RS256", { kid = "test-key-1" })
+
+        local decoded = crypto.jwt_decode(token)
+        assert.eq(decoded.header.alg, "RS256")
+        assert.eq(decoded.header.typ, "JWT")
+        assert.eq(decoded.header.kid, "test-key-1")
+        assert.eq(decoded.claims.sub, "user:alice")
+        assert.eq(decoded.claims.email, "alice@example.com")
+        assert.eq(decoded.claims.role, "admin")
+        assert.eq(#decoded.claims.groups, 3)
+        assert.eq(decoded.claims.groups[1], "a")
+        assert.eq(decoded.claims.groups[3], "c")
+        "#,
+    )
+    .exec_async()
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn test_jwt_decode_rejects_malformed_token() {
+    // Not three segments
+    let result = run_lua(r#"crypto.jwt_decode("only.two")"#).await;
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("three '.'-separated segments"), "got: {err}");
+
+    // Invalid base64url in payload
+    let result = run_lua(r#"crypto.jwt_decode("eyJhbGciOiJSUzI1NiJ9.!!!notbase64.sig")"#).await;
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("invalid base64url") || err.contains("payload"),
+        "got: {err}"
+    );
+
+    // Valid base64url but invalid JSON in payload (base64url of "not json")
+    let result = run_lua(r#"crypto.jwt_decode("eyJhbGciOiJSUzI1NiJ9.bm90LWpzb24.sig")"#).await;
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("invalid JSON") || err.contains("payload"), "got: {err}");
+}
+
+#[tokio::test]
 async fn test_sha256_default() {
     let result: String = eval_lua(r#"return crypto.hash("hello")"#).await;
     assert_eq!(

--- a/tests/http_serve.rs
+++ b/tests/http_serve.rs
@@ -357,7 +357,7 @@ async fn test_http_serve_query_params() {
 async fn test_http_serve_url_encoded_query_params() {
     // Regression test: req.params must contain URL-decoded values, not raw
     // percent-encoded strings. Otherwise consumers that re-encode (e.g.
-    // assay.hydra) end up double-encoding values like "g=" -> "g%3D" -> "g%253D".
+    // assay.ory.hydra) end up double-encoding values like "g=" -> "g%3D" -> "g%253D".
     run_lua_local(
         r#"
         local server = async.spawn(function()

--- a/tests/stdlib_ory_hydra.rs
+++ b/tests/stdlib_ory_hydra.rs
@@ -7,7 +7,7 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 #[tokio::test]
 async fn test_hydra_require() {
     let script = r#"
-        local hydra = require("assay.hydra")
+        local hydra = require("assay.ory.hydra")
         assert.not_nil(hydra)
         assert.not_nil(hydra.client)
     "#;
@@ -28,7 +28,7 @@ async fn test_hydra_list_clients() {
 
     let script = format!(
         r#"
-        local hydra = require("assay.hydra")
+        local hydra = require("assay.ory.hydra")
         local h = hydra.client({{ admin_url = "{}" }})
         local clients = h:list_clients()
         assert.eq(#clients, 2)
@@ -54,7 +54,7 @@ async fn test_hydra_update_client() {
 
     let script = format!(
         r#"
-        local hydra = require("assay.hydra")
+        local hydra = require("assay.ory.hydra")
         local h = hydra.client({{ admin_url = "{}" }})
         local client = h:update_client("example-app", {{
           client_name = "Example App",
@@ -75,7 +75,7 @@ async fn test_hydra_update_client() {
 #[tokio::test]
 async fn test_hydra_build_authorize_url() {
     let script = r#"
-        local hydra = require("assay.hydra")
+        local hydra = require("assay.ory.hydra")
         local h = hydra.client({ public_url = "https://hydra.example.com" })
         local url = h:build_authorize_url("example-app", {
           redirect_uri = "https://app.example.com/auth/callback",
@@ -109,7 +109,7 @@ async fn test_hydra_exchange_code() {
 
     let script = format!(
         r#"
-        local hydra = require("assay.hydra")
+        local hydra = require("assay.ory.hydra")
         local h = hydra.client({{ public_url = "{}" }})
         local tokens = h:exchange_code({{
           code = "abc",
@@ -139,7 +139,7 @@ async fn test_hydra_accept_login() {
 
     let script = format!(
         r#"
-        local hydra = require("assay.hydra")
+        local hydra = require("assay.ory.hydra")
         local h = hydra.client({{ admin_url = "{}" }})
         local result = h:accept_login("abc123", "user:alice", {{ remember = true, remember_for = 86400 }})
         assert.contains(result.redirect_to, "hydra.example.com")
@@ -163,7 +163,7 @@ async fn test_hydra_accept_consent_with_claims() {
 
     let script = format!(
         r#"
-        local hydra = require("assay.hydra")
+        local hydra = require("assay.ory.hydra")
         local h = hydra.client({{ admin_url = "{}" }})
         local result = h:accept_consent("xyz789", {{
           grant_scope = {{"openid", "profile", "email"}},
@@ -200,7 +200,7 @@ async fn test_hydra_get_logout_request() {
 
     let script = format!(
         r#"
-        local hydra = require("assay.hydra")
+        local hydra = require("assay.ory.hydra")
         local h = hydra.client({{ admin_url = "{}" }})
         local req = h:get_logout_request("logout-abc")
         assert.eq(req.subject, "user:alice")
@@ -226,7 +226,7 @@ async fn test_hydra_accept_logout() {
 
     let script = format!(
         r#"
-        local hydra = require("assay.hydra")
+        local hydra = require("assay.ory.hydra")
         local h = hydra.client({{ admin_url = "{}" }})
         local result = h:accept_logout("logout-abc")
         assert.contains(result.redirect_to, "app.example.com")
@@ -248,7 +248,7 @@ async fn test_hydra_reject_logout() {
 
     let script = format!(
         r#"
-        local hydra = require("assay.hydra")
+        local hydra = require("assay.ory.hydra")
         local h = hydra.client({{ admin_url = "{}" }})
         h:reject_logout("logout-abc")
         "#,
@@ -272,7 +272,7 @@ async fn test_hydra_introspect() {
 
     let script = format!(
         r#"
-        local hydra = require("assay.hydra")
+        local hydra = require("assay.ory.hydra")
         local h = hydra.client({{ admin_url = "{}" }})
         local info = h:introspect("access.jwt")
         assert.eq(info.active, true)
@@ -298,7 +298,7 @@ async fn test_hydra_well_known() {
 
     let script = format!(
         r#"
-        local hydra = require("assay.hydra")
+        local hydra = require("assay.ory.hydra")
         local h = hydra.client({{ public_url = "{}" }})
         local wk = h:well_known()
         assert.contains(wk.issuer, "hydra.example.com")

--- a/tests/stdlib_ory_keto.rs
+++ b/tests/stdlib_ory_keto.rs
@@ -7,7 +7,7 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 #[tokio::test]
 async fn test_keto_require() {
     let script = r#"
-        local keto = require("assay.keto")
+        local keto = require("assay.ory.keto")
         assert.not_nil(keto)
         assert.not_nil(keto.client)
     "#;
@@ -36,7 +36,7 @@ async fn test_keto_list() {
 
     let script = format!(
         r#"
-        local keto = require("assay.keto")
+        local keto = require("assay.ory.keto")
         local k = keto.client("{}")
         local result = k:list({{ namespace = "Role" }})
         assert.eq(#result.relation_tuples, 1)
@@ -60,7 +60,7 @@ async fn test_keto_check_allowed() {
 
     let script = format!(
         r#"
-        local keto = require("assay.keto")
+        local keto = require("assay.ory.keto")
         local k = keto.client("{}")
         local ok = k:check("apps", "cc", "admin", "user:alice")
         assert.eq(ok, true)
@@ -83,7 +83,7 @@ async fn test_keto_check_denied() {
 
     let script = format!(
         r#"
-        local keto = require("assay.keto")
+        local keto = require("assay.ory.keto")
         local k = keto.client("{}")
         local ok = k:check("apps", "cc", "admin", "user:bob")
         assert.eq(ok, false)
@@ -122,7 +122,7 @@ async fn test_keto_get_user_roles() {
 
     let script = format!(
         r#"
-        local keto = require("assay.keto")
+        local keto = require("assay.ory.keto")
         local k = keto.client("{}")
         local roles = k:get_user_roles("alice")
         assert.eq(#roles, 2)
@@ -154,7 +154,7 @@ async fn test_keto_user_has_any_role() {
 
     let script = format!(
         r#"
-        local keto = require("assay.keto")
+        local keto = require("assay.ory.keto")
         local k = keto.client("{}")
         local has_admin = k:user_has_any_role("bob", {{"namespace1:role-a", "namespace2:role-a"}})
         assert.eq(has_admin, false)
@@ -185,7 +185,7 @@ async fn test_keto_expand() {
 
     let script = format!(
         r#"
-        local keto = require("assay.keto")
+        local keto = require("assay.ory.keto")
         local k = keto.client("{}")
         local tree = k:expand("Role", "namespace1:role-a", "members")
         assert.eq(tree.type, "union")
@@ -207,7 +207,7 @@ async fn test_keto_create_tuple() {
 
     let script = format!(
         r#"
-        local keto = require("assay.keto")
+        local keto = require("assay.ory.keto")
         local k = keto.client("{}", {{ write_url = "{}" }})
         k:create({{
           namespace = "Role",
@@ -228,7 +228,7 @@ async fn test_keto_write_requires_write_url() {
 
     let script = format!(
         r#"
-        local keto = require("assay.keto")
+        local keto = require("assay.ory.keto")
         local k = keto.client("{}")
         local ok, err = pcall(function()
           k:create({{ namespace = "Role", object = "x", relation = "members", subject_id = "user:y" }})

--- a/tests/stdlib_ory_kratos.rs
+++ b/tests/stdlib_ory_kratos.rs
@@ -7,7 +7,7 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 #[tokio::test]
 async fn test_kratos_require() {
     let script = r#"
-        local kratos = require("assay.kratos")
+        local kratos = require("assay.ory.kratos")
         assert.not_nil(kratos)
         assert.not_nil(kratos.client)
     "#;
@@ -36,7 +36,7 @@ async fn test_kratos_whoami_authenticated() {
 
     let script = format!(
         r#"
-        local kratos = require("assay.kratos")
+        local kratos = require("assay.ory.kratos")
         local k = kratos.client({{ public_url = "{}" }})
         local session = k:whoami("ory_session_abc=xyz")
         assert.not_nil(session)
@@ -60,7 +60,7 @@ async fn test_kratos_whoami_unauthenticated() {
 
     let script = format!(
         r#"
-        local kratos = require("assay.kratos")
+        local kratos = require("assay.ory.kratos")
         local k = kratos.client({{ public_url = "{}" }})
         local session = k:whoami("bogus=cookie")
         assert.eq(session, nil)
@@ -88,7 +88,7 @@ async fn test_kratos_get_identity() {
 
     let script = format!(
         r#"
-        local kratos = require("assay.kratos")
+        local kratos = require("assay.ory.kratos")
         local k = kratos.client({{ admin_url = "{}" }})
         local identity = k:get_identity("user-123")
         assert.eq(identity.id, "user-123")
@@ -113,7 +113,7 @@ async fn test_kratos_list_identities() {
 
     let script = format!(
         r#"
-        local kratos = require("assay.kratos")
+        local kratos = require("assay.ory.kratos")
         local k = kratos.client({{ admin_url = "{}" }})
         local identities = k:list_identities()
         assert.eq(#identities, 2)
@@ -138,7 +138,7 @@ async fn test_kratos_create_identity() {
 
     let script = format!(
         r#"
-        local kratos = require("assay.kratos")
+        local kratos = require("assay.ory.kratos")
         local k = kratos.client({{ admin_url = "{}" }})
         local identity = k:create_identity({{
           schema_id = "default",
@@ -171,7 +171,7 @@ async fn test_kratos_get_login_flow() {
 
     let script = format!(
         r#"
-        local kratos = require("assay.kratos")
+        local kratos = require("assay.ory.kratos")
         local k = kratos.client({{ public_url = "{}" }})
         local flow = k:get_login_flow("flow-abc")
         assert.eq(flow.id, "flow-abc")

--- a/tests/stdlib_ory_rbac.rs
+++ b/tests/stdlib_ory_rbac.rs
@@ -1,0 +1,437 @@
+mod common;
+
+use common::run_lua;
+use wiremock::matchers::{body_string_contains, method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+// Helper that produces a Lua snippet which builds a standard test policy
+// against a provided keto read URL and (optionally) a write URL. Keeps
+// the per-test setup compact.
+fn build_policy_snippet(read_url: &str, write_url: Option<&str>) -> String {
+    let write_part = match write_url {
+        Some(w) => format!(", write_url = \"{w}\""),
+        None => String::new(),
+    };
+    format!(
+        r#"
+        local rbac = require("assay.ory.rbac")
+        local keto = require("assay.ory.keto")
+        local k = keto.client("{read_url}", {{ {write_part} }})
+        local p = rbac.policy({{
+          namespace = "demo-app",
+          keto = k,
+          default_role = "viewer",
+          roles = {{
+            owner    = {{ rank = 5, capabilities = {{"read","trigger","approve","configure","manage_roles"}} }},
+            admin    = {{ rank = 4, capabilities = {{"read","trigger","approve","configure"}} }},
+            approver = {{ rank = 3, capabilities = {{"read","approve"}} }},
+            operator = {{ rank = 2, capabilities = {{"read","trigger"}} }},
+            viewer   = {{ rank = 1, capabilities = {{"read"}} }},
+          }},
+        }})
+        "#,
+        read_url = read_url,
+        write_part = write_part.trim_start_matches(", "),
+    )
+}
+
+// Mock the standard Keto list endpoint with the given relation tuples.
+async fn mock_user_role_list(server: &MockServer, subject: &str, tuples: serde_json::Value) {
+    Mock::given(method("GET"))
+        .and(path("/relation-tuples"))
+        .and(query_param("namespace", "Role"))
+        .and(query_param("relation", "members"))
+        .and(query_param("subject_id", subject))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "relation_tuples": tuples,
+            "next_page_token": "",
+        })))
+        .mount(server)
+        .await;
+}
+
+#[tokio::test]
+async fn test_rbac_require() {
+    let script = r#"
+        local rbac = require("assay.ory.rbac")
+        assert.not_nil(rbac)
+        assert.not_nil(rbac.policy)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_rbac_user_with_no_roles_gets_default() {
+    let server = MockServer::start().await;
+    mock_user_role_list(&server, "user:alice", serde_json::json!([])).await;
+
+    let script = format!(
+        r#"
+        {policy}
+        local roles = p:user_roles("alice")
+        assert.eq(#roles, 0)
+        assert.eq(p:user_primary_role("alice"), "viewer")
+        local caps = p:user_capabilities("alice")
+        assert.eq(caps.read, true)
+        assert.eq(caps.trigger, nil)
+        assert.eq(caps.approve, nil)
+        "#,
+        policy = build_policy_snippet(&server.uri(), None)
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_rbac_user_with_single_role() {
+    let server = MockServer::start().await;
+    mock_user_role_list(
+        &server,
+        "user:bob",
+        serde_json::json!([
+            {
+                "namespace": "Role",
+                "object": "demo-app:operator",
+                "relation": "members",
+                "subject_id": "user:bob"
+            }
+        ]),
+    )
+    .await;
+
+    let script = format!(
+        r#"
+        {policy}
+        local roles = p:user_roles("bob")
+        assert.eq(#roles, 1)
+        assert.eq(roles[1], "operator")
+        assert.eq(p:user_primary_role("bob"), "operator")
+        local caps = p:user_capabilities("bob")
+        assert.eq(caps.read, true)
+        assert.eq(caps.trigger, true)
+        assert.eq(caps.approve, nil)
+        assert.eq(p:user_has_capability("bob", "trigger"), true)
+        assert.eq(p:user_has_capability("bob", "approve"), false)
+        "#,
+        policy = build_policy_snippet(&server.uri(), None)
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_rbac_user_with_multiple_roles_unions_capabilities() {
+    let server = MockServer::start().await;
+    // Carol is both an approver AND an operator — so the union of her
+    // capabilities includes BOTH trigger (from operator) and approve
+    // (from approver), even though neither role grants both alone.
+    mock_user_role_list(
+        &server,
+        "user:carol",
+        serde_json::json!([
+            { "namespace": "Role", "object": "demo-app:approver", "relation": "members", "subject_id": "user:carol" },
+            { "namespace": "Role", "object": "demo-app:operator", "relation": "members", "subject_id": "user:carol" }
+        ]),
+    )
+    .await;
+
+    let script = format!(
+        r#"
+        {policy}
+        local roles = p:user_roles("carol")
+        assert.eq(#roles, 2)
+        -- highest rank first
+        assert.eq(roles[1], "approver")
+        assert.eq(roles[2], "operator")
+        assert.eq(p:user_primary_role("carol"), "approver")
+        local caps = p:user_capabilities("carol")
+        assert.eq(caps.read, true)
+        assert.eq(caps.trigger, true)
+        assert.eq(caps.approve, true)
+        assert.eq(caps.configure, nil)
+        "#,
+        policy = build_policy_snippet(&server.uri(), None)
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_rbac_ignores_unknown_roles() {
+    // If Keto returns a tuple for a role the policy doesn't define
+    // (e.g. left over from an old deployment) we silently ignore it.
+    let server = MockServer::start().await;
+    mock_user_role_list(
+        &server,
+        "user:dave",
+        serde_json::json!([
+            { "namespace": "Role", "object": "demo-app:legacy-role", "relation": "members", "subject_id": "user:dave" },
+            { "namespace": "Role", "object": "demo-app:viewer",      "relation": "members", "subject_id": "user:dave" }
+        ]),
+    )
+    .await;
+
+    let script = format!(
+        r#"
+        {policy}
+        local roles = p:user_roles("dave")
+        assert.eq(#roles, 1)
+        assert.eq(roles[1], "viewer")
+        "#,
+        policy = build_policy_snippet(&server.uri(), None)
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_rbac_ignores_other_namespaces() {
+    // Tuples from a different app (e.g. platform:admin) should not
+    // count as demo-app roles.
+    let server = MockServer::start().await;
+    mock_user_role_list(
+        &server,
+        "user:eve",
+        serde_json::json!([
+            { "namespace": "Role", "object": "platform:admin",   "relation": "members", "subject_id": "user:eve" },
+            { "namespace": "Role", "object": "demo-app:operator", "relation": "members", "subject_id": "user:eve" }
+        ]),
+    )
+    .await;
+
+    let script = format!(
+        r#"
+        {policy}
+        local roles = p:user_roles("eve")
+        assert.eq(#roles, 1)
+        assert.eq(roles[1], "operator")
+        "#,
+        policy = build_policy_snippet(&server.uri(), None)
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_rbac_list_members() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/relation-tuples"))
+        .and(query_param("namespace", "Role"))
+        .and(query_param("object", "demo-app:admin"))
+        .and(query_param("relation", "members"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "relation_tuples": [
+                { "namespace": "Role", "object": "demo-app:admin", "relation": "members", "subject_id": "user:alice" },
+                { "namespace": "Role", "object": "demo-app:admin", "relation": "members", "subject_id": "user:bob" }
+            ],
+            "next_page_token": ""
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        {policy}
+        local members = p:list_members("admin")
+        assert.eq(#members, 2)
+        assert.eq(members[1], "alice")
+        assert.eq(members[2], "bob")
+        "#,
+        policy = build_policy_snippet(&server.uri(), None)
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_rbac_add_member() {
+    let read = MockServer::start().await;
+    let write = MockServer::start().await;
+
+    // Empty initial list so the idempotency check sees no existing member.
+    Mock::given(method("GET"))
+        .and(path("/relation-tuples"))
+        .and(query_param("object", "demo-app:approver"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "relation_tuples": [], "next_page_token": ""
+        })))
+        .mount(&read)
+        .await;
+
+    Mock::given(method("PUT"))
+        .and(path("/admin/relation-tuples"))
+        .and(body_string_contains("demo-app:approver"))
+        .and(body_string_contains("user:seth"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({})))
+        .mount(&write)
+        .await;
+
+    let script = format!(
+        r#"
+        {policy}
+        p:add("seth", "approver")
+        "#,
+        policy = build_policy_snippet(&read.uri(), Some(&write.uri()))
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_rbac_add_member_is_idempotent() {
+    // The list call returns Seth already, so add() should NOT issue a
+    // PUT — wiremock will fail the test if it does because we don't
+    // mount a PUT mock.
+    let read = MockServer::start().await;
+    let write = MockServer::start().await;
+
+    Mock::given(method("GET"))
+        .and(path("/relation-tuples"))
+        .and(query_param("object", "demo-app:approver"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "relation_tuples": [
+                { "namespace": "Role", "object": "demo-app:approver", "relation": "members", "subject_id": "user:seth" }
+            ],
+            "next_page_token": ""
+        })))
+        .mount(&read)
+        .await;
+
+    let script = format!(
+        r#"
+        {policy}
+        p:add("seth", "approver")
+        "#,
+        policy = build_policy_snippet(&read.uri(), Some(&write.uri()))
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_rbac_remove_member() {
+    let read = MockServer::start().await;
+    let write = MockServer::start().await;
+
+    Mock::given(method("DELETE"))
+        .and(path("/admin/relation-tuples"))
+        .and(query_param("object", "demo-app:operator"))
+        .and(query_param("subject_id", "user:bob"))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(&write)
+        .await;
+
+    let script = format!(
+        r#"
+        {policy}
+        p:remove("bob", "operator")
+        "#,
+        policy = build_policy_snippet(&read.uri(), Some(&write.uri()))
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_rbac_reset_role() {
+    let read = MockServer::start().await;
+    let write = MockServer::start().await;
+
+    Mock::given(method("DELETE"))
+        .and(path("/admin/relation-tuples"))
+        .and(query_param("namespace", "Role"))
+        .and(query_param("object", "demo-app:owner"))
+        .and(query_param("relation", "members"))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(&write)
+        .await;
+
+    let script = format!(
+        r#"
+        {policy}
+        p:reset_role("owner")
+        "#,
+        policy = build_policy_snippet(&read.uri(), Some(&write.uri()))
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_rbac_unknown_role_errors() {
+    let server = MockServer::start().await;
+    let script = format!(
+        r#"
+        {policy}
+        local ok, err = pcall(function() p:list_members("not-a-real-role") end)
+        assert.eq(ok, false)
+        assert.contains(tostring(err), "unknown role")
+        "#,
+        policy = build_policy_snippet(&server.uri(), None)
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_rbac_roles_returned_in_rank_order() {
+    let server = MockServer::start().await;
+    let script = format!(
+        r#"
+        {policy}
+        local rs = p:roles()
+        assert.eq(#rs, 5)
+        assert.eq(rs[1], "owner")
+        assert.eq(rs[2], "admin")
+        assert.eq(rs[3], "approver")
+        assert.eq(rs[4], "operator")
+        assert.eq(rs[5], "viewer")
+        "#,
+        policy = build_policy_snippet(&server.uri(), None)
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_rbac_role_metadata_lookup() {
+    let server = MockServer::start().await;
+    let script = format!(
+        r#"
+        {policy}
+        local r = p:role("approver")
+        assert.eq(r.rank, 3)
+        assert.eq(#r.capabilities, 2)
+        -- capabilities are returned sorted alphabetically
+        assert.eq(r.capabilities[1], "approve")
+        assert.eq(r.capabilities[2], "read")
+        "#,
+        policy = build_policy_snippet(&server.uri(), None)
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_rbac_policy_validation() {
+    // Missing namespace
+    let script = r#"
+        local rbac = require("assay.ory.rbac")
+        local ok, err = pcall(function()
+          rbac.policy({ keto = {}, roles = { viewer = { rank = 1, capabilities = {"read"} } } })
+        end)
+        assert.eq(ok, false)
+        assert.contains(tostring(err), "namespace is required")
+    "#;
+    run_lua(script).await.unwrap();
+
+    // Missing keto
+    let script = r#"
+        local rbac = require("assay.ory.rbac")
+        local ok, err = pcall(function()
+          rbac.policy({ namespace = "x", roles = { viewer = { rank = 1, capabilities = {"read"} } } })
+        end)
+        assert.eq(ok, false)
+        assert.contains(tostring(err), "keto client is required")
+    "#;
+    run_lua(script).await.unwrap();
+
+    // Empty roles
+    let script = r#"
+        local rbac = require("assay.ory.rbac")
+        local ok, err = pcall(function()
+          rbac.policy({ namespace = "x", keto = {}, roles = {} })
+        end)
+        assert.eq(ok, false)
+        assert.contains(tostring(err), "roles map is required")
+    "#;
+    run_lua(script).await.unwrap();
+}


### PR DESCRIPTION
## Summary

- **Breaking**: Move Ory stdlib modules under `assay.ory.*` namespace (`assay.kratos` → `assay.ory.kratos`, etc.). The `assay.ory` umbrella module is unchanged.
- **New**: `assay.ory.rbac` — capability-based RBAC policy engine over Keto with multiple roles per user, union of capabilities, default-role fallback, namespace filtering, idempotent membership management, and a `require_capability` middleware for `http.serve`.
- **New**: `crypto.jwt_decode(token)` — decode a JWT WITHOUT verifying its signature; returns `{ header, claims }`. Useful for trusted-channel scenarios (own session cookies over TLS).
- **Internal**: Stdlib + filesystem loaders now translate dotted module paths into directory paths (`<path>.lua` then `<path>/init.lua`), enabling nested namespaces like `assay.ory.kratos`.

## Migration

```diff
- local kratos = require("assay.kratos")
+ local kratos = require("assay.ory.kratos")
- local hydra  = require("assay.hydra")
+ local hydra  = require("assay.ory.hydra")
- local keto   = require("assay.keto")
+ local keto   = require("assay.ory.keto")
```

Code using `require("assay.ory")` for the umbrella is unaffected.

## Why capability-based RBAC?

Linear hierarchies (`owner > admin > approver > operator > viewer`) collapse separation of duties: an admin who can both *trigger* and *approve* a deploy defeats the point of having an approver role. Capability-based roles let an approver approve without triggering, and an operator trigger without approving — which is the whole point of the role split.

## Test plan

- [x] `cargo test` — all suites pass (including new `tests/stdlib_ory_rbac.rs` and `tests/crypto.rs::test_jwt_decode_*`)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] Renamed test files (`tests/stdlib_{kratos,hydra,keto}.rs` → `tests/stdlib_ory_*.rs`) updated to new require paths and pass
- [ ] Bump consumer projects (gitops command-center, hydra-auth) to v0.8.3 base image after release