### PR TITLE
fix(ci): add protoc to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Install protoc
+        uses: arduino/setup-protoc@v3
+
       - name: Cache cargo build
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
## Summary

- Add `arduino/setup-protoc@v3` to the deploy workflow — `prost-wkt-types` build script needs `protoc`

The deploy failed on the v0.9.0 merge because the deploy workflow builds assay from source but didn't have protoc installed.

## Test plan

- [ ] Deploy workflow succeeds after merge