### PR TITLE
fix(ci): add workflow_dispatch and self-trigger to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,7 @@
 name: Deploy to Cloudflare Pages
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -19,6 +20,7 @@ on:
       - "stdlib/**"
       - "CHANGELOG.md"
       - "wrangler.toml"
+      - ".github/workflows/deploy.yml"
 
 concurrency:
   group: cloudflare-pages-deploy


### PR DESCRIPTION
## Summary

- Add `workflow_dispatch` so the deploy can be triggered manually from the Actions tab
- Add `.github/workflows/deploy.yml` to trigger paths so changes to the workflow itself trigger a deploy

This also triggers the deploy on merge, rebuilding the site with the protoc fix from PR #30.

## Test plan

- [ ] Deploy workflow triggers on merge and succeeds