### PR TITLE
fix: set Temporal client identity to prevent worker init failure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-lua"
-version = "0.10.0"
+version = "0.10.1"
 categories = ["command-line-utilities", "development-tools::testing"]
 edition = "2024"
 homepage = "https://assay.rs"

--- a/src/lua/builtins/temporal.rs
+++ b/src/lua/builtins/temporal.rs
@@ -290,9 +290,13 @@ pub fn register_temporal(lua: &mlua::Lua) -> mlua::Result<()> {
     async fn connect_client(url_str: &str, namespace: &str) -> Result<Client, mlua::Error> {
         let parsed_url = url::Url::parse(&format!("http://{url_str}"))
             .map_err(|e| mlua::Error::runtime(format!("invalid temporal URL: {e}")))?;
-        let connection = Connection::connect(ConnectionOptions::new(parsed_url).build())
-            .await
-            .map_err(|e| mlua::Error::runtime(format!("temporal connect: {e}")))?;
+        let connection = Connection::connect(
+            ConnectionOptions::new(parsed_url)
+                .identity(format!("assay-client@{namespace}"))
+                .build(),
+        )
+        .await
+        .map_err(|e| mlua::Error::runtime(format!("temporal connect: {e}")))?;
         Client::new(connection, ClientOptions::new(namespace).build())
             .map_err(|e| mlua::Error::runtime(format!("temporal client: {e}")))
     }

--- a/src/lua/builtins/temporal_worker.rs
+++ b/src/lua/builtins/temporal_worker.rs
@@ -211,9 +211,13 @@ return create_workflow_ctx
         // Connect to Temporal
         let parsed_url = url::Url::parse(&format!("http://{url}"))
             .map_err(|e| mlua::Error::runtime(format!("invalid temporal URL: {e}")))?;
-        let connection = Connection::connect(ConnectionOptions::new(parsed_url).build())
-            .await
-            .map_err(|e| mlua::Error::runtime(format!("temporal worker connect: {e}")))?;
+        let connection = Connection::connect(
+            ConnectionOptions::new(parsed_url)
+                .identity(format!("assay-worker@{}", task_queue))
+                .build(),
+        )
+        .await
+        .map_err(|e| mlua::Error::runtime(format!("temporal worker connect: {e}")))?;
 
         // Create core runtime and worker
         let telemetry = temporalio_common::telemetry::TelemetryOptions::builder().build();


### PR DESCRIPTION
## Summary

The Temporal SDK v0.2.0 requires a non-empty `identity` field on `ConnectionOptions`. Both `temporal.connect()` and `temporal.worker()` were using the default (empty string), causing worker initialization to fail with:

```
Client identity cannot be empty. Either lang or user should be setting this value
```

- Client connections: identity set to `assay-client@{namespace}`
- Worker connections: identity set to `assay-worker@{task_queue}`

Bump version to v0.10.1.