### PR TITLE
feat(kratos): add flows:get_login_admin for server-side flow fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to Assay are documented here.
 
+## [0.10.2] - 2026-04-12
+
+### Added
+
+- **`kratos.flows:get_login_admin(flow_id)`** — Fetch a login flow via
+  the Kratos admin API (no CSRF cookie required). Server-side components
+  like hydra-auth should use this instead of `get_login()` which requires
+  browser cookies that may not be available across different cookie domains.
+
 ## [0.10.1] - 2026-04-12
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to Assay are documented here.
 
+## [0.10.1] - 2026-04-12
+
+### Fixed
+
+- **Temporal worker identity** — `temporal.worker()` and `temporal.connect()`
+  now set a non-empty `identity` on `ConnectionOptions`. The Temporal SDK v0.2.0
+  requires this field; without it, `init_worker` fails with "Client identity
+  cannot be empty". Identity is set to `assay-worker@{task_queue}` for workers
+  and `assay-client@{namespace}` for clients.
+
 ## [0.10.0] - 2026-04-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "assay-lua"
-version = "0.10.0"
+version = "0.10.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-lua"
-version = "0.10.1"
+version = "0.10.2"
 categories = ["command-line-utilities", "development-tools::testing"]
 edition = "2024"
 homepage = "https://assay.rs"

--- a/stdlib/ory/kratos.lua
+++ b/stdlib/ory/kratos.lua
@@ -6,7 +6,8 @@
 --- @quickref c.sessions:list(identity_id) -> [session] | List active sessions for an identity
 --- @quickref c.sessions:revoke(identity_id) -> nil | Revoke all sessions for an identity
 --- @quickref c.flows:create_login(opts?) -> flow | Create a browser login flow
---- @quickref c.flows:get_login(id, cookie?) -> flow | Fetch an existing login flow
+--- @quickref c.flows:get_login(id, cookie?) -> flow | Fetch an existing login flow (public API, needs CSRF cookie)
+--- @quickref c.flows:get_login_admin(id) -> flow | Fetch a login flow via admin API (no cookies needed)
 --- @quickref c.flows:submit_login(flow_id, payload, cookie?) -> {session, ...} | Submit a login flow
 --- @quickref c.flows:create_registration(opts?) -> flow | Create a registration flow
 --- @quickref c.flows:get_registration(id, cookie?) -> flow | Fetch a registration flow
@@ -162,6 +163,10 @@ function M.client(opts)
 
   function c.flows:get_login(flow_id, cookie)
     return public_get("/self-service/login/flows?id=" .. urlencode(flow_id), cookie)
+  end
+
+  function c.flows:get_login_admin(flow_id)
+    return admin_get("/admin/self-service/login/flows?id=" .. urlencode(flow_id))
   end
 
   function c.flows:submit_login(flow_id, payload, cookie)


### PR DESCRIPTION
## Summary

- Adds `kratos.flows:get_login_admin(flow_id)` — fetches login flows via the Kratos admin API without requiring browser CSRF cookies
- Needed by server-side components like hydra-auth where the cookie domain doesn't cover the auth bridge hostname (prod vanity domain issue)
- Bumps version to 0.10.2
- Updates changelog

## Test plan

- [ ] Existing `get_login` still works (no regression)
- [ ] `get_login_admin` fetches flows without cookies from hydra-auth