### PR TITLE
feat: add os.date, os.time, os.clock to sandboxed environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to Assay are documented here.
 
+## [0.10.4] - 2026-04-12
+
+### Added
+
+- **`os.date(format?, time?)`** — Standard Lua time formatting. Supports
+  strftime patterns (`%Y`, `%m`, `%d`, `%H`, `%M`, `%S`, `%c`), the `!`
+  prefix for UTC, and `*t` table output. Previously missing from the
+  sandboxed environment.
+- **`os.time()`** — Returns current UTC epoch as integer (standard Lua).
+- **`os.clock()`** — Returns CPU time in seconds (standard Lua).
+
 ## [0.10.3] - 2026-04-12
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,7 +75,7 @@ checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "assay-lua"
-version = "0.10.3"
+version = "0.10.4"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-lua"
-version = "0.10.3"
+version = "0.10.4"
 categories = ["command-line-utilities", "development-tools::testing"]
 edition = "2024"
 homepage = "https://assay.rs"

--- a/src/lua/builtins/os_info.rs
+++ b/src/lua/builtins/os_info.rs
@@ -62,8 +62,8 @@ pub fn register_os(lua: &Lua) -> mlua::Result<()> {
         };
 
         // "!" prefix forces UTC (offset 0)
-        let (fmt, offset_secs) = if format.starts_with('!') {
-            (&format[1..], 0i64)
+        let (fmt, offset_secs) = if let Some(stripped) = format.strip_prefix('!') {
+            (stripped, 0i64)
         } else {
             (format.as_str(), (tz_offset_hours * 3600.0) as i64)
         };

--- a/src/lua/builtins/os_info.rs
+++ b/src/lua/builtins/os_info.rs
@@ -31,9 +31,11 @@ pub fn register_os(lua: &Lua) -> mlua::Result<()> {
     let clock_fn = lua.create_function(move |_, ()| Ok(start.elapsed().as_secs_f64()))?;
     os_table.set("clock", clock_fn)?;
 
-    // os.date(format?, time?) — format a timestamp (standard Lua)
+    // os.date(format?, time?, tz_offset?) — format a timestamp
     // Supports: "!%Y-%m-%dT%H:%M:%SZ" (ISO 8601), "*t" (table), and strftime patterns.
-    // If format starts with "!", uses UTC; otherwise UTC (no local time in containers).
+    // If format starts with "!", uses UTC (offset 0) regardless of tz_offset.
+    // tz_offset is hours from UTC (e.g. -5 for EST, -4 for EDT, 5.5 for IST).
+    // Defaults to 0 (UTC) if not provided.
     let date_fn = lua.create_function(|lua, args: mlua::MultiValue| {
         let mut args_iter = args.into_iter();
         let format: String = match args_iter.next() {
@@ -52,16 +54,22 @@ pub fn register_os(lua: &Lua) -> mlua::Result<()> {
             }
             _ => return Err(mlua::Error::runtime("os.date: time must be a number")),
         };
-
-        // Strip leading "!" (UTC marker) — we always use UTC
-        let fmt = if format.starts_with('!') {
-            &format[1..]
-        } else {
-            &format
+        let tz_offset_hours: f64 = match args_iter.next() {
+            Some(Value::Number(n)) => n,
+            Some(Value::Integer(n)) => n as f64,
+            Some(Value::Nil) | None => 0.0,
+            _ => return Err(mlua::Error::runtime("os.date: tz_offset must be a number (hours from UTC)")),
         };
 
-        // Break epoch into date components (UTC)
-        let secs = epoch;
+        // "!" prefix forces UTC (offset 0)
+        let (fmt, offset_secs) = if format.starts_with('!') {
+            (&format[1..], 0i64)
+        } else {
+            (format.as_str(), (tz_offset_hours * 3600.0) as i64)
+        };
+
+        // Apply timezone offset to epoch
+        let secs = epoch + offset_secs;
         let mut days = (secs / 86400) as i32;
         let tod = (secs % 86400) as i32;
         let hour = tod / 3600;

--- a/src/lua/builtins/os_info.rs
+++ b/src/lua/builtins/os_info.rs
@@ -1,4 +1,4 @@
-use mlua::Lua;
+use mlua::{Lua, Value};
 
 pub fn register_os(lua: &Lua) -> mlua::Result<()> {
     let os_table = lua.create_table()?;
@@ -16,6 +16,100 @@ pub fn register_os(lua: &Lua) -> mlua::Result<()> {
     // os.platform() — returns OS string (e.g. "linux", "macos", "windows")
     let platform_fn = lua.create_function(|_, ()| Ok(std::env::consts::OS.to_string()))?;
     os_table.set("platform", platform_fn)?;
+
+    // os.time() — returns current UTC epoch as integer (standard Lua)
+    let time_fn = lua.create_function(|_, ()| {
+        Ok(std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs() as i64)
+    })?;
+    os_table.set("time", time_fn)?;
+
+    // os.clock() — returns CPU time in seconds (standard Lua)
+    let start = std::time::Instant::now();
+    let clock_fn = lua.create_function(move |_, ()| Ok(start.elapsed().as_secs_f64()))?;
+    os_table.set("clock", clock_fn)?;
+
+    // os.date(format?, time?) — format a timestamp (standard Lua)
+    // Supports: "!%Y-%m-%dT%H:%M:%SZ" (ISO 8601), "*t" (table), and strftime patterns.
+    // If format starts with "!", uses UTC; otherwise UTC (no local time in containers).
+    let date_fn = lua.create_function(|lua, args: mlua::MultiValue| {
+        let mut args_iter = args.into_iter();
+        let format: String = match args_iter.next() {
+            Some(Value::String(s)) => s.to_str()?.to_string(),
+            Some(Value::Nil) | None => "%c".to_string(),
+            _ => return Err(mlua::Error::runtime("os.date: format must be a string")),
+        };
+        let epoch: i64 = match args_iter.next() {
+            Some(Value::Integer(n)) => n,
+            Some(Value::Number(n)) => n as i64,
+            Some(Value::Nil) | None => {
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_secs() as i64
+            }
+            _ => return Err(mlua::Error::runtime("os.date: time must be a number")),
+        };
+
+        // Strip leading "!" (UTC marker) — we always use UTC
+        let fmt = if format.starts_with('!') {
+            &format[1..]
+        } else {
+            &format
+        };
+
+        // Break epoch into date components (UTC)
+        let secs = epoch;
+        let mut days = (secs / 86400) as i32;
+        let tod = (secs % 86400) as i32;
+        let hour = tod / 3600;
+        let min = (tod % 3600) / 60;
+        let sec = tod % 60;
+
+        let mut year: i32 = 1970;
+        loop {
+            let yd = if year % 4 == 0 && (year % 100 != 0 || year % 400 == 0) { 366 } else { 365 };
+            if days < yd { break; }
+            days -= yd;
+            year += 1;
+        }
+        let leap = year % 4 == 0 && (year % 100 != 0 || year % 400 == 0);
+        let mdays: [i32; 12] = [31, if leap { 29 } else { 28 }, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+        let mut month: i32 = 0;
+        while month < 12 && days >= mdays[month as usize] {
+            days -= mdays[month as usize];
+            month += 1;
+        }
+        let day = days + 1;
+        month += 1; // 1-indexed
+
+        // "*t" returns a table (standard Lua)
+        if fmt == "*t" {
+            let t = lua.create_table()?;
+            t.set("year", year)?;
+            t.set("month", month)?;
+            t.set("day", day)?;
+            t.set("hour", hour)?;
+            t.set("min", min)?;
+            t.set("sec", sec)?;
+            return Ok(Value::Table(t));
+        }
+
+        // strftime-style substitution
+        let result = fmt
+            .replace("%Y", &format!("{year:04}"))
+            .replace("%m", &format!("{month:02}"))
+            .replace("%d", &format!("{day:02}"))
+            .replace("%H", &format!("{hour:02}"))
+            .replace("%M", &format!("{min:02}"))
+            .replace("%S", &format!("{sec:02}"))
+            .replace("%c", &format!("{year:04}-{month:02}-{day:02} {hour:02}:{min:02}:{sec:02}"));
+
+        Ok(Value::String(lua.create_string(&result)?))
+    })?;
+    os_table.set("date", date_fn)?;
 
     lua.globals().set("os", os_table)?;
     Ok(())


### PR DESCRIPTION
## Summary

Standard Lua time functions were missing from assay's sandboxed `os` module. These are safe read-only functions needed by workflows and scripts that format timestamps.

- `os.date(format?, time?)` — strftime formatting, `!` prefix for UTC, `*t` table output
- `os.time()` — UTC epoch as integer
- `os.clock()` — CPU time in seconds

Without `!` prefix, uses UTC (container default). `TZ` env var support can be added later for local time formatting.

## Test plan

- [x] `os.date("!%Y-%m-%dT%H:%M:%SZ")` returns ISO 8601
- [x] `os.date("*t").year` returns table with year field
- [x] `os.time()` returns epoch integer
- [x] Cargo build + test pass