### PR TITLE
fix: Docker image + v0.11.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to Assay are documented here.
 
+## [0.11.2] - 2026-04-16
+
+### Fixed
+
+- **Docker image build** — `Dockerfile` now `COPY crates/` so the `assay-workflow` workspace
+  member's manifest is in the build context. Without this, the v0.11.1 release.yml docker job failed
+  with `failed to read /app/crates/assay-workflow/Cargo.toml` and no
+  `ghcr.io/developerinlondon/assay:v0.11.1` image was published. v0.11.2 republishes everything
+  (binaries / crates.io / npm / docker) so `:latest` points at a working image again.
+
+### Notes
+
+- No source-level changes versus v0.11.1 — `assay-lua` and `assay-workflow` crates are
+  byte-identical to v0.11.1 except for the version bumps. Existing v0.11.1 binaries, crates.io
+  packages, and npm packages remain valid; only the GHCR image was missing.
+
 ## [0.11.1] - 2026-04-16
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,7 @@ checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "assay-lua"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "assay-workflow",
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "assay-workflow"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "crates/assay-workflow"]
 
 [package]
 name = "assay-lua"
-version = "0.11.1"
+version = "0.11.2"
 categories = ["command-line-utilities", "development-tools::testing"]
 edition = "2024"
 homepage = "https://assay.rs"

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /app
 COPY Cargo.toml Cargo.lock ./
 COPY src/ src/
 COPY stdlib/ stdlib/
+COPY crates/ crates/
 RUN cargo build --release --target x86_64-unknown-linux-musl
 
 # Runtime

--- a/crates/assay-workflow/Cargo.toml
+++ b/crates/assay-workflow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-workflow"
-version = "0.1.0"
+version = "0.1.1"
 categories = ["asynchronous", "database"]
 edition = "2024"
 keywords = ["workflow", "durable-execution", "orchestration", "task-queue"]


### PR DESCRIPTION
## Summary

v0.11.1's release.yml ran 5/6 jobs successfully (binaries / crates.io / npm / GitHub Release) but the **docker** job failed:

```
failed to load manifest for dependency `assay-workflow`
failed to read `/app/crates/assay-workflow/Cargo.toml`
No such file or directory (os error 2)
```

The Dockerfile didn't `COPY crates/` so the workspace member's manifest wasn't in the build context once `assay-lua` started depending on `assay-workflow`. Other release jobs use the full repo, so they were unaffected.

This PR:

1. `Dockerfile`: adds `COPY crates/ crates/`. One-line fix.
2. `Cargo.toml` (root): bumps `assay-lua` 0.11.1 → 0.11.2.
3. `crates/assay-workflow/Cargo.toml`: bumps `assay-workflow` 0.1.0 → 0.1.1 (functionally identical — required because crates.io rejects republishing the same version, and `release.yml` publishes both in sequence).
4. `CHANGELOG.md`: adds a `[0.11.2]` entry explaining this is a Docker-build-only fix; existing v0.11.1 binaries / crates / npm packages are still valid.

After merge, tag `v0.11.2` → release.yml fires fresh → 6/6 jobs green this time → `ghcr.io/developerinlondon/assay:v0.11.2` published + `:latest` refreshed.

## Test plan

- [x] `cargo build` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] CI on this PR
- [ ] Tag v0.11.2 after merge → confirm all 6 release.yml jobs green this time