### PR TITLE
v0.11.3 — engine features + stdlib completeness + CLI fill-stubs

### DIFF
--- a/.claude/plans/04-v0.11.3-workflow-enhancements.md
+++ b/.claude/plans/04-v0.11.3-workflow-enhancements.md
@@ -1,0 +1,333 @@
+# Plan: v0.11.3 — Workflow engine enhancements
+
+## Why this plan exists
+
+v0.11.1 shipped a native durable workflow engine. Production use has surfaced a
+short list of capabilities the engine is missing relative to what consumers
+typically need from a durable workflow engine:
+
+1. No way to expose rich live workflow state to external clients — today, only
+   coarse status + event log are readable via REST.
+2. `continue_as_new` engine method exists but has no worker-side Lua surface, so
+   workflows can't loop indefinitely without the event log growing unbounded.
+3. Schedule management is create-or-delete only: no PATCH (update cron or
+   input), no pause/resume. Operators have to delete and recreate.
+4. Cron expressions are evaluated in UTC with no way to express wall-clock
+   schedules in local time zones.
+5. No primitive for running activities in parallel; workflows have to use child
+   workflows or sequential scheduling even when activities are independent.
+6. No way to index or filter workflows by custom application-level metadata
+   beyond the built-in `status` and `workflow_type` filters.
+7. Completed workflows live in the primary database forever; there's no
+   retention / archival story for compliance or cost control.
+
+This plan delivers all seven as v0.11.3. No language-specific SDKs — the REST
+API + OpenAPI spec already allows any language to interact with the engine.
+
+## Acceptance contract
+
+The release is done when all of the following are true:
+
+1. `cargo test` passes, `cargo clippy --all-targets -- -D warnings` passes,
+   `cargo fmt --check` passes.
+2. New orchestration tests pass (listed per feature below).
+3. New API integration tests pass.
+4. Postgres parity tests (testcontainers-backed) pass for any new store methods.
+5. CHANGELOG updated with a v0.11.3 entry describing each feature in generic
+   terms (no application-domain leakage).
+6. OpenAPI spec regenerates cleanly via `utoipa` annotations.
+7. Every new public API has a docstring and at least one example.
+
+## Features
+
+### F1. `ctx:register_query` — live workflow state
+
+**Problem.** External clients need to read rich application-level workflow
+state (stages, logs, progress) without reconstructing it from the event log.
+
+**Design.** Workflow code registers named query handlers. After each workflow
+run (yield or return), the worker invokes all registered handlers, serialises
+results, and submits them to the engine as a `RecordSnapshot` command. The
+engine persists the snapshot (the snapshot infrastructure already exists in
+the store as `create_snapshot`/`get_latest_snapshot`). A new REST endpoint
+exposes the latest snapshot for a workflow.
+
+**Lua API.**
+
+```lua
+workflow.define("MyWorkflow", function(ctx, input)
+    local state = { stage = "init", progress = 0 }
+    ctx:register_query("state", function() return state end)
+    state.stage = "running"
+    local r = ctx:execute_activity("step1", {})
+    state.progress = 0.5
+    ...
+end)
+```
+
+**REST API.**
+
+```
+GET /api/v1/workflows/{id}/state        → { "state": <latest snapshot> }
+GET /api/v1/workflows/{id}/state/{name} → { "value": <query result> }
+```
+
+**Replay semantics.** On every replay, the workflow handler re-executes
+deterministically. The closures captured by `register_query` see the latest
+state because they close over the local variable by reference. The worker
+re-serialises and re-submits snapshots on every replay; the engine writes the
+latest as a new snapshot row keyed by (workflow_id, event_seq).
+
+**Tests.**
+- `lua_workflow_register_query_exposes_live_state` — workflow registers a query,
+  worker writes snapshot, REST returns it.
+- `lua_workflow_register_query_multiple` — multiple named queries coexist.
+- `lua_workflow_register_query_survives_crash` — state still queryable after
+  worker SIGKILL + replay.
+
+### F2. `ctx:continue_as_new` — Lua surface
+
+**Problem.** Long-running workflows (polling loops, schedulers) grow their
+event log forever. `continue_as_new` is the standard Temporal pattern for
+resetting history; the engine method exists but workflows can't call it.
+
+**Design.** Lua ctx yields a `ContinueAsNew` command; the engine's existing
+`continue_as_new` method handles it (completes the current workflow, starts a
+new run with the same type/queue/namespace and the caller-supplied input).
+
+**Lua API.**
+
+```lua
+workflow.define("Poller", function(ctx, input)
+    local items = ctx:execute_activity("poll", input)
+    if #items > 0 then
+        ctx:execute_activity("process", { items = items })
+    end
+    ctx:sleep(60)
+    return ctx:continue_as_new({ cursor = items[#items].id })
+end)
+```
+
+**Tests.**
+- `lua_workflow_continue_as_new_starts_fresh_run` — first run completes, second
+  run observable with new input and empty history.
+
+### F3. Schedule PATCH / pause / resume
+
+**Problem.** Schedules today are create-or-delete. Operators can't change a
+cron expression, update a schedule's input, or pause/resume without losing
+history.
+
+**Design.**
+
+**Store additions.**
+```rust
+fn update_schedule(
+    &self,
+    namespace: &str,
+    name: &str,
+    patch: SchedulePatch,
+) -> impl Future<Output = Result<Option<WorkflowSchedule>>> + Send;
+
+fn set_schedule_paused(
+    &self,
+    namespace: &str,
+    name: &str,
+    paused: bool,
+) -> impl Future<Output = Result<Option<WorkflowSchedule>>> + Send;
+```
+
+Where `SchedulePatch` has `Option<String>` fields for each mutable attribute
+(`cron_expr`, `timezone`, `input`, `task_queue`, `overlap_policy`).
+
+**REST API.**
+
+```
+PATCH /api/v1/schedules/{name}           body: { cron_expr?, timezone?, input?, task_queue?, overlap_policy? }
+POST  /api/v1/schedules/{name}/pause
+POST  /api/v1/schedules/{name}/resume
+```
+
+**Scheduler semantics.** An updated cron expression takes effect on the next
+scheduler tick (≤15s). Paused schedules are skipped. Resume re-computes
+`next_run_at` from the current time.
+
+**Tests.**
+- `api_schedule_patch_updates_cron`
+- `api_schedule_pause_skips_evaluation`
+- `api_schedule_resume_restarts_fires`
+- `pg_schedule_patch` (Postgres parity)
+
+### F4. Cron timezone
+
+**Problem.** Cron is UTC-only; wall-clock schedules ("nightly at 02:00 local
+time") require offline arithmetic.
+
+**Design.** Add `timezone: Option<String>` to `WorkflowSchedule`. Default
+`"UTC"`. Scheduler parses via `chrono-tz`'s `Tz`; `compute_next_run` uses the
+schedule's timezone for `schedule.upcoming(tz).next()`.
+
+**Dependencies.** Add `chrono-tz = "0.10"` to `assay-workflow` Cargo.toml.
+
+**Schema migration.** `workflow_schedules` gets a new `timezone TEXT NOT NULL
+DEFAULT 'UTC'` column. Idempotent `ALTER TABLE ADD COLUMN IF NOT EXISTS` on
+Postgres; SQLite equivalent via `PRAGMA table_info` check.
+
+**Tests.**
+- `schedule_with_non_utc_timezone_fires_at_local_time` — a fake clock proves
+  the next fire is computed in the configured tz.
+
+### F5. Parallel activities — `ctx:execute_parallel`
+
+**Problem.** Independent activities can't be scheduled together in a single
+replay; workflows fan out via child workflows or serialise unnecessarily.
+
+**Design.** Lua yields a **batch** of `ScheduleActivity` commands when
+`ctx:execute_parallel` is called. The engine's `submit_workflow_commands`
+already iterates a slice of commands, and `schedule_activity` is already
+idempotent on `(workflow_id, seq)` — no engine change needed.
+
+The worker's `_handle_workflow_task` is extended to recognise a batch yield
+(a table whose first element has a `type` field) and return it as-is.
+
+On replay, `execute_parallel` checks history for each sub-activity's completion.
+If all are present, return results in order. If any are missing, yield the
+batch of `ScheduleActivity` commands (the idempotent schedule_activity makes
+this a no-op for already-scheduled activities).
+
+**Lua API.**
+
+```lua
+local results = ctx:execute_parallel({
+    { name = "check_a", input = { ... }, opts = { start_to_close_secs = 30 } },
+    { name = "check_b", input = { ... } },
+    { name = "check_c", input = { ... } },
+})
+-- results[1] is check_a's result, results[2] is check_b's, etc.
+-- If any fails after retries, the whole call raises.
+```
+
+**Tests.**
+- `lua_workflow_execute_parallel_three_activities`
+- `lua_workflow_execute_parallel_one_fails_raises`
+- `lua_workflow_execute_parallel_is_deterministic_on_replay`
+
+### F6. Search attributes
+
+**Problem.** Callers can't filter workflows by application-level metadata
+(e.g. environment, tenant, pipeline stage). Today they must list all and
+filter client-side.
+
+**Design.**
+
+**Schema.** New column `search_attributes TEXT` on `workflows` (JSON object
+payload). Postgres uses JSONB for native indexing; SQLite uses TEXT with
+`json_extract` in queries.
+
+**API.**
+- `StartWorkflowRequest` accepts optional `search_attributes: { [key]: any }`
+  object.
+- `GET /workflows?search[key]=value&search[key2]=value2` filters by exact match.
+  Multiple keys AND-joined.
+- New Lua ctx method `ctx:upsert_search_attributes({ progress = 0.5 })` that
+  yields an `UpsertSearchAttributes` command so workflows can update their own
+  attrs.
+
+**Schema migration.** Add column idempotently on both backends.
+
+**Tests.**
+- `api_list_workflows_filter_by_search_attributes`
+- `lua_workflow_upsert_search_attributes_reflects_in_list`
+- `pg_search_attributes_jsonb_query` (Postgres JSONB path)
+
+### F7. S3 archival
+
+**Problem.** Completed workflows accumulate in Postgres indefinitely. No
+retention / compliance story.
+
+**Design.** An optional background task that:
+
+1. Iterates workflows in terminal states older than the retention cutoff.
+2. Bundles `{record, events, activities, signals, snapshots}` as JSON.
+3. Uploads the bundle to `s3://bucket/prefix/{namespace}/{workflow_id}.json`
+   using `aws-sdk-s3`.
+4. Deletes the database rows.
+5. Records `archived_at` + `archive_uri` on a lightweight stub row retained in
+   the `workflows` table (so `GET /workflows/{id}` still resolves with a
+   pointer to the archived bundle).
+
+**Config.** Behind a `s3-archival` cargo feature (default-off to keep the
+non-archival binary lean). When enabled, runtime controlled by env vars:
+- `ASSAY_ARCHIVE_S3_BUCKET` (required to enable)
+- `ASSAY_ARCHIVE_S3_PREFIX` (default `"assay/"`)
+- `ASSAY_ARCHIVE_RETENTION_DAYS` (default `30`)
+- `ASSAY_ARCHIVE_POLL_SECS` (default `3600`)
+
+AWS credentials resolved via the SDK's default chain (env → shared config →
+IRSA pod identity via web identity token).
+
+**Store additions.**
+```rust
+fn list_archivable_workflows(&self, cutoff: f64, limit: i64)
+    -> impl Future<Output = Result<Vec<WorkflowRecord>>> + Send;
+
+fn mark_archived(&self, workflow_id: &str, archive_uri: &str, archived_at: f64)
+    -> impl Future<Output = Result<()>> + Send;
+
+fn delete_archived_children(&self, workflow_id: &str)
+    -> impl Future<Output = Result<()>> + Send;
+```
+
+**Tests.**
+- `archival_moves_completed_workflows_to_stub` — with a mock S3 endpoint
+  (wiremock), verify upload + deletion + stub retention.
+- Feature-gated: only runs when `--features s3-archival`.
+
+## Shared changes
+
+### CHANGELOG
+
+New section `## [0.11.3] - <date>` with subsections per feature. No
+application-domain references — all features described in generic workflow
+terms.
+
+### Version bumps
+
+- `Cargo.toml` (root, `assay-lua`): `0.11.2` → `0.11.3`
+- `crates/assay-workflow/Cargo.toml`: `0.1.1` → `0.1.2`
+
+### OpenAPI spec
+
+Every new endpoint (`GET /workflows/{id}/state`, `GET /workflows/{id}/state/{name}`,
+`PATCH /schedules/{name}`, `POST /schedules/{name}/pause`, `POST /schedules/{name}/resume`)
+carries `utoipa::path` annotations and is registered in
+`crates/assay-workflow/src/api/openapi.rs`.
+
+### Dashboard
+
+Out of scope for this release — dashboard updates land in a follow-up.
+
+## Implementation order
+
+Features ship as separate commits on `feat/v0.11.3-workflow-enhancements`:
+
+1. `feat(workflow): ctx:register_query for live state exposure`
+2. `feat(workflow): ctx:continue_as_new Lua surface`
+3. `feat(workflow): schedule PATCH / pause / resume endpoints`
+4. `feat(workflow): cron timezone support`
+5. `feat(workflow): ctx:execute_parallel for batched activity scheduling`
+6. `feat(workflow): search attributes on workflows`
+7. `feat(workflow): optional S3 archival for completed workflows`
+8. `chore: v0.11.3 release (version bumps + CHANGELOG)`
+
+## Out of scope
+
+- Language-specific SDKs (Go, TS, Python). The REST API + OpenAPI spec already
+  support auto-generated clients in any language.
+- Dashboard UI updates for new features.
+- Query handlers returning structured streaming data (only scalar-result query
+  handlers in this release).
+- Cross-namespace signals.
+- Workflow versioning (`ctx.workflow.version()` equivalent).
+- Batch cancel / terminate API.
+- Pause/resume for in-flight workflows (only schedules).

--- a/.claude/plans/04-v0.11.3-workflow-enhancements.md
+++ b/.claude/plans/04-v0.11.3-workflow-enhancements.md
@@ -2,39 +2,39 @@
 
 ## Why this plan exists
 
-v0.11.1 shipped a native durable workflow engine. Production use has surfaced a
-short list of capabilities the engine is missing relative to what consumers
-typically need from a durable workflow engine:
+v0.11.1 shipped a native durable workflow engine. Production use has surfaced a short list of
+capabilities the engine is missing relative to what consumers typically need from a durable workflow
+engine:
 
-1. No way to expose rich live workflow state to external clients — today, only
-   coarse status + event log are readable via REST.
-2. `continue_as_new` engine method exists but has no worker-side Lua surface, so
-   workflows can't loop indefinitely without the event log growing unbounded.
-3. Schedule management is create-or-delete only: no PATCH (update cron or
-   input), no pause/resume. Operators have to delete and recreate.
-4. Cron expressions are evaluated in UTC with no way to express wall-clock
-   schedules in local time zones.
-5. No primitive for running activities in parallel; workflows have to use child
-   workflows or sequential scheduling even when activities are independent.
-6. No way to index or filter workflows by custom application-level metadata
-   beyond the built-in `status` and `workflow_type` filters.
-7. Completed workflows live in the primary database forever; there's no
-   retention / archival story for compliance or cost control.
+1. No way to expose rich live workflow state to external clients — today, only coarse status + event
+   log are readable via REST.
+2. `continue_as_new` engine method exists but has no worker-side Lua surface, so workflows can't
+   loop indefinitely without the event log growing unbounded.
+3. Schedule management is create-or-delete only: no PATCH (update cron or input), no pause/resume.
+   Operators have to delete and recreate.
+4. Cron expressions are evaluated in UTC with no way to express wall-clock schedules in local time
+   zones.
+5. No primitive for running activities in parallel; workflows have to use child workflows or
+   sequential scheduling even when activities are independent.
+6. No way to index or filter workflows by custom application-level metadata beyond the built-in
+   `status` and `workflow_type` filters.
+7. Completed workflows live in the primary database forever; there's no retention / archival story
+   for compliance or cost control.
 
-This plan delivers all seven as v0.11.3. No language-specific SDKs — the REST
-API + OpenAPI spec already allows any language to interact with the engine.
+This plan delivers all seven as v0.11.3. No language-specific SDKs — the REST API + OpenAPI spec
+already allows any language to interact with the engine.
 
 ## Acceptance contract
 
 The release is done when all of the following are true:
 
-1. `cargo test` passes, `cargo clippy --all-targets -- -D warnings` passes,
-   `cargo fmt --check` passes.
+1. `cargo test` passes, `cargo clippy --all-targets -- -D warnings` passes, `cargo fmt --check`
+   passes.
 2. New orchestration tests pass (listed per feature below).
 3. New API integration tests pass.
 4. Postgres parity tests (testcontainers-backed) pass for any new store methods.
-5. CHANGELOG updated with a v0.11.3 entry describing each feature in generic
-   terms (no application-domain leakage).
+5. CHANGELOG updated with a v0.11.3 entry describing each feature in generic terms (no
+   application-domain leakage).
 6. OpenAPI spec regenerates cleanly via `utoipa` annotations.
 7. Every new public API has a docstring and at least one example.
 
@@ -42,15 +42,14 @@ The release is done when all of the following are true:
 
 ### F1. `ctx:register_query` — live workflow state
 
-**Problem.** External clients need to read rich application-level workflow
-state (stages, logs, progress) without reconstructing it from the event log.
+**Problem.** External clients need to read rich application-level workflow state (stages, logs,
+progress) without reconstructing it from the event log.
 
-**Design.** Workflow code registers named query handlers. After each workflow
-run (yield or return), the worker invokes all registered handlers, serialises
-results, and submits them to the engine as a `RecordSnapshot` command. The
-engine persists the snapshot (the snapshot infrastructure already exists in
-the store as `create_snapshot`/`get_latest_snapshot`). A new REST endpoint
-exposes the latest snapshot for a workflow.
+**Design.** Workflow code registers named query handlers. After each workflow run (yield or return),
+the worker invokes all registered handlers, serialises results, and submits them to the engine as a
+`RecordSnapshot` command. The engine persists the snapshot (the snapshot infrastructure already
+exists in the store as `create_snapshot`/`get_latest_snapshot`). A new REST endpoint exposes the
+latest snapshot for a workflow.
 
 **Lua API.**
 
@@ -72,28 +71,28 @@ GET /api/v1/workflows/{id}/state        → { "state": <latest snapshot> }
 GET /api/v1/workflows/{id}/state/{name} → { "value": <query result> }
 ```
 
-**Replay semantics.** On every replay, the workflow handler re-executes
-deterministically. The closures captured by `register_query` see the latest
-state because they close over the local variable by reference. The worker
-re-serialises and re-submits snapshots on every replay; the engine writes the
-latest as a new snapshot row keyed by (workflow_id, event_seq).
+**Replay semantics.** On every replay, the workflow handler re-executes deterministically. The
+closures captured by `register_query` see the latest state because they close over the local
+variable by reference. The worker re-serialises and re-submits snapshots on every replay; the engine
+writes the latest as a new snapshot row keyed by (workflow_id, event_seq).
 
 **Tests.**
-- `lua_workflow_register_query_exposes_live_state` — workflow registers a query,
-  worker writes snapshot, REST returns it.
+
+- `lua_workflow_register_query_exposes_live_state` — workflow registers a query, worker writes
+  snapshot, REST returns it.
 - `lua_workflow_register_query_multiple` — multiple named queries coexist.
-- `lua_workflow_register_query_survives_crash` — state still queryable after
-  worker SIGKILL + replay.
+- `lua_workflow_register_query_survives_crash` — state still queryable after worker SIGKILL +
+  replay.
 
 ### F2. `ctx:continue_as_new` — Lua surface
 
-**Problem.** Long-running workflows (polling loops, schedulers) grow their
-event log forever. `continue_as_new` is the standard Temporal pattern for
-resetting history; the engine method exists but workflows can't call it.
+**Problem.** Long-running workflows (polling loops, schedulers) grow their event log forever.
+`continue_as_new` is the standard Temporal pattern for resetting history; the engine method exists
+but workflows can't call it.
 
-**Design.** Lua ctx yields a `ContinueAsNew` command; the engine's existing
-`continue_as_new` method handles it (completes the current workflow, starts a
-new run with the same type/queue/namespace and the caller-supplied input).
+**Design.** Lua ctx yields a `ContinueAsNew` command; the engine's existing `continue_as_new` method
+handles it (completes the current workflow, starts a new run with the same type/queue/namespace and
+the caller-supplied input).
 
 **Lua API.**
 
@@ -109,18 +108,19 @@ end)
 ```
 
 **Tests.**
-- `lua_workflow_continue_as_new_starts_fresh_run` — first run completes, second
-  run observable with new input and empty history.
+
+- `lua_workflow_continue_as_new_starts_fresh_run` — first run completes, second run observable with
+  new input and empty history.
 
 ### F3. Schedule PATCH / pause / resume
 
-**Problem.** Schedules today are create-or-delete. Operators can't change a
-cron expression, update a schedule's input, or pause/resume without losing
-history.
+**Problem.** Schedules today are create-or-delete. Operators can't change a cron expression, update
+a schedule's input, or pause/resume without losing history.
 
 **Design.**
 
 **Store additions.**
+
 ```rust
 fn update_schedule(
     &self,
@@ -137,8 +137,8 @@ fn set_schedule_paused(
 ) -> impl Future<Output = Result<Option<WorkflowSchedule>>> + Send;
 ```
 
-Where `SchedulePatch` has `Option<String>` fields for each mutable attribute
-(`cron_expr`, `timezone`, `input`, `task_queue`, `overlap_policy`).
+Where `SchedulePatch` has `Option<String>` fields for each mutable attribute (`cron_expr`,
+`timezone`, `input`, `task_queue`, `overlap_policy`).
 
 **REST API.**
 
@@ -148,11 +148,11 @@ POST  /api/v1/schedules/{name}/pause
 POST  /api/v1/schedules/{name}/resume
 ```
 
-**Scheduler semantics.** An updated cron expression takes effect on the next
-scheduler tick (≤15s). Paused schedules are skipped. Resume re-computes
-`next_run_at` from the current time.
+**Scheduler semantics.** An updated cron expression takes effect on the next scheduler tick (≤15s).
+Paused schedules are skipped. Resume re-computes `next_run_at` from the current time.
 
 **Tests.**
+
 - `api_schedule_patch_updates_cron`
 - `api_schedule_pause_skips_evaluation`
 - `api_schedule_resume_restarts_fires`
@@ -160,40 +160,40 @@ scheduler tick (≤15s). Paused schedules are skipped. Resume re-computes
 
 ### F4. Cron timezone
 
-**Problem.** Cron is UTC-only; wall-clock schedules ("nightly at 02:00 local
-time") require offline arithmetic.
+**Problem.** Cron is UTC-only; wall-clock schedules ("nightly at 02:00 local time") require offline
+arithmetic.
 
-**Design.** Add `timezone: Option<String>` to `WorkflowSchedule`. Default
-`"UTC"`. Scheduler parses via `chrono-tz`'s `Tz`; `compute_next_run` uses the
-schedule's timezone for `schedule.upcoming(tz).next()`.
+**Design.** Add `timezone: Option<String>` to `WorkflowSchedule`. Default `"UTC"`. Scheduler parses
+via `chrono-tz`'s `Tz`; `compute_next_run` uses the schedule's timezone for
+`schedule.upcoming(tz).next()`.
 
 **Dependencies.** Add `chrono-tz = "0.10"` to `assay-workflow` Cargo.toml.
 
-**Schema migration.** `workflow_schedules` gets a new `timezone TEXT NOT NULL
-DEFAULT 'UTC'` column. Idempotent `ALTER TABLE ADD COLUMN IF NOT EXISTS` on
-Postgres; SQLite equivalent via `PRAGMA table_info` check.
+**Schema.** `workflow_schedules` gets a new `timezone TEXT NOT NULL DEFAULT
+'UTC'` column. Since no
+v0.11.x has been deployed against a real workload yet, the column lives in the baseline
+`CREATE TABLE` only — no ALTER migration for v0.11.3.
 
 **Tests.**
-- `schedule_with_non_utc_timezone_fires_at_local_time` — a fake clock proves
-  the next fire is computed in the configured tz.
+
+- `schedule_with_non_utc_timezone_fires_at_local_time` — a fake clock proves the next fire is
+  computed in the configured tz.
 
 ### F5. Parallel activities — `ctx:execute_parallel`
 
-**Problem.** Independent activities can't be scheduled together in a single
-replay; workflows fan out via child workflows or serialise unnecessarily.
+**Problem.** Independent activities can't be scheduled together in a single replay; workflows fan
+out via child workflows or serialise unnecessarily.
 
-**Design.** Lua yields a **batch** of `ScheduleActivity` commands when
-`ctx:execute_parallel` is called. The engine's `submit_workflow_commands`
-already iterates a slice of commands, and `schedule_activity` is already
-idempotent on `(workflow_id, seq)` — no engine change needed.
+**Design.** Lua yields a **batch** of `ScheduleActivity` commands when `ctx:execute_parallel` is
+called. The engine's `submit_workflow_commands` already iterates a slice of commands, and
+`schedule_activity` is already idempotent on `(workflow_id, seq)` — no engine change needed.
 
-The worker's `_handle_workflow_task` is extended to recognise a batch yield
-(a table whose first element has a `type` field) and return it as-is.
+The worker's `_handle_workflow_task` is extended to recognise a batch yield (a table whose first
+element has a `type` field) and return it as-is.
 
-On replay, `execute_parallel` checks history for each sub-activity's completion.
-If all are present, return results in order. If any are missing, yield the
-batch of `ScheduleActivity` commands (the idempotent schedule_activity makes
-this a no-op for already-scheduled activities).
+On replay, `execute_parallel` checks history for each sub-activity's completion. If all are present,
+return results in order. If any are missing, yield the batch of `ScheduleActivity` commands (the
+idempotent schedule_activity makes this a no-op for already-scheduled activities).
 
 **Lua API.**
 
@@ -208,65 +208,64 @@ local results = ctx:execute_parallel({
 ```
 
 **Tests.**
+
 - `lua_workflow_execute_parallel_three_activities`
 - `lua_workflow_execute_parallel_one_fails_raises`
 - `lua_workflow_execute_parallel_is_deterministic_on_replay`
 
 ### F6. Search attributes
 
-**Problem.** Callers can't filter workflows by application-level metadata
-(e.g. environment, tenant, pipeline stage). Today they must list all and
-filter client-side.
+**Problem.** Callers can't filter workflows by application-level metadata (e.g. environment, tenant,
+pipeline stage). Today they must list all and filter client-side.
 
 **Design.**
 
-**Schema.** New column `search_attributes TEXT` on `workflows` (JSON object
-payload). Postgres uses JSONB for native indexing; SQLite uses TEXT with
-`json_extract` in queries.
+**Schema.** New column `search_attributes TEXT` on `workflows` (JSON object payload). Postgres uses
+JSONB for native indexing; SQLite uses TEXT with `json_extract` in queries.
 
 **API.**
-- `StartWorkflowRequest` accepts optional `search_attributes: { [key]: any }`
-  object.
-- `GET /workflows?search[key]=value&search[key2]=value2` filters by exact match.
-  Multiple keys AND-joined.
-- New Lua ctx method `ctx:upsert_search_attributes({ progress = 0.5 })` that
-  yields an `UpsertSearchAttributes` command so workflows can update their own
-  attrs.
+
+- `StartWorkflowRequest` accepts optional `search_attributes: { [key]: any }` object.
+- `GET /workflows?search[key]=value&search[key2]=value2` filters by exact match. Multiple keys
+  AND-joined.
+- New Lua ctx method `ctx:upsert_search_attributes({ progress = 0.5 })` that yields an
+  `UpsertSearchAttributes` command so workflows can update their own attrs.
 
 **Schema migration.** Add column idempotently on both backends.
 
 **Tests.**
+
 - `api_list_workflows_filter_by_search_attributes`
 - `lua_workflow_upsert_search_attributes_reflects_in_list`
 - `pg_search_attributes_jsonb_query` (Postgres JSONB path)
 
 ### F7. S3 archival
 
-**Problem.** Completed workflows accumulate in Postgres indefinitely. No
-retention / compliance story.
+**Problem.** Completed workflows accumulate in Postgres indefinitely. No retention / compliance
+story.
 
 **Design.** An optional background task that:
 
 1. Iterates workflows in terminal states older than the retention cutoff.
 2. Bundles `{record, events, activities, signals, snapshots}` as JSON.
-3. Uploads the bundle to `s3://bucket/prefix/{namespace}/{workflow_id}.json`
-   using `aws-sdk-s3`.
+3. Uploads the bundle to `s3://bucket/prefix/{namespace}/{workflow_id}.json` using `aws-sdk-s3`.
 4. Deletes the database rows.
-5. Records `archived_at` + `archive_uri` on a lightweight stub row retained in
-   the `workflows` table (so `GET /workflows/{id}` still resolves with a
-   pointer to the archived bundle).
+5. Records `archived_at` + `archive_uri` on a lightweight stub row retained in the `workflows` table
+   (so `GET /workflows/{id}` still resolves with a pointer to the archived bundle).
 
-**Config.** Behind a `s3-archival` cargo feature (default-off to keep the
-non-archival binary lean). When enabled, runtime controlled by env vars:
+**Config.** Behind a `s3-archival` cargo feature (default-off to keep the non-archival binary lean).
+When enabled, runtime controlled by env vars:
+
 - `ASSAY_ARCHIVE_S3_BUCKET` (required to enable)
 - `ASSAY_ARCHIVE_S3_PREFIX` (default `"assay/"`)
 - `ASSAY_ARCHIVE_RETENTION_DAYS` (default `30`)
 - `ASSAY_ARCHIVE_POLL_SECS` (default `3600`)
 
-AWS credentials resolved via the SDK's default chain (env → shared config →
-IRSA pod identity via web identity token).
+AWS credentials resolved via the SDK's default chain (env → shared config → IRSA pod identity via
+web identity token).
 
 **Store additions.**
+
 ```rust
 fn list_archivable_workflows(&self, cutoff: f64, limit: i64)
     -> impl Future<Output = Result<Vec<WorkflowRecord>>> + Send;
@@ -279,17 +278,17 @@ fn delete_archived_children(&self, workflow_id: &str)
 ```
 
 **Tests.**
-- `archival_moves_completed_workflows_to_stub` — with a mock S3 endpoint
-  (wiremock), verify upload + deletion + stub retention.
+
+- `archival_moves_completed_workflows_to_stub` — with a mock S3 endpoint (wiremock), verify upload +
+  deletion + stub retention.
 - Feature-gated: only runs when `--features s3-archival`.
 
 ## Shared changes
 
 ### CHANGELOG
 
-New section `## [0.11.3] - <date>` with subsections per feature. No
-application-domain references — all features described in generic workflow
-terms.
+New section `## [0.11.3] - <date>` with subsections per feature. No application-domain references —
+all features described in generic workflow terms.
 
 ### Version bumps
 
@@ -299,9 +298,8 @@ terms.
 ### OpenAPI spec
 
 Every new endpoint (`GET /workflows/{id}/state`, `GET /workflows/{id}/state/{name}`,
-`PATCH /schedules/{name}`, `POST /schedules/{name}/pause`, `POST /schedules/{name}/resume`)
-carries `utoipa::path` annotations and is registered in
-`crates/assay-workflow/src/api/openapi.rs`.
+`PATCH /schedules/{name}`, `POST /schedules/{name}/pause`, `POST /schedules/{name}/resume`) carries
+`utoipa::path` annotations and is registered in `crates/assay-workflow/src/api/openapi.rs`.
 
 ### Dashboard
 
@@ -322,11 +320,11 @@ Features ship as separate commits on `feat/v0.11.3-workflow-enhancements`:
 
 ## Out of scope
 
-- Language-specific SDKs (Go, TS, Python). The REST API + OpenAPI spec already
-  support auto-generated clients in any language.
+- Language-specific SDKs (Go, TS, Python). The REST API + OpenAPI spec already support
+  auto-generated clients in any language.
 - Dashboard UI updates for new features.
-- Query handlers returning structured streaming data (only scalar-result query
-  handlers in this release).
+- Query handlers returning structured streaming data (only scalar-result query handlers in this
+  release).
 - Cross-namespace signals.
 - Workflow versioning (`ctx.workflow.version()` equivalent).
 - Batch cancel / terminate API.

--- a/.claude/plans/05-v0.11.3-cli-subcommands.md
+++ b/.claude/plans/05-v0.11.3-cli-subcommands.md
@@ -1,0 +1,242 @@
+# Plan: v0.11.3 — CLI subcommands for workflow engine management
+
+## Why this plan exists
+
+v0.11.3 delivers seven additive features to the workflow engine (plan 04). This plan extends the
+release with a full CLI for managing a running `assay serve` from a shell — start / signal / query
+workflows, manage schedules, inspect namespaces and workers — so operators don't need custom curl
+scripts or Lua clients to drive the engine.
+
+**Correcting a past mistake.** v0.11.1 shipped `assay workflow …` and `assay schedule …` as
+parser-only subcommands: clap accepted them, the dispatch handlers at `src/main.rs:342-351` just
+printed "not yet implemented (v0.11.1)" and exited 1. That was a bad practice — surfaces visible to
+users must actually work, or not be visible at all. This plan removes every stub by implementing it
+for real. Going forward the rule is: features land fully implemented across every layer (clap → REST
+→ store → Lua) before merge, or are hidden entirely until they do.
+
+Ships as additional commits on the existing `feat/v0.11.3-workflow-enhancements` branch so the
+v0.11.3 release bundles the CLI alongside the engine features.
+
+## Design principles
+
+| Principle          | Choice                                                                                                                                                                                                       |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Transport          | CLI is a plain HTTP client against the REST API — no direct store access. Same code paths as any third-party integration.                                                                                    |
+| Config discovery   | Global flags backed by env vars AND an optional YAML config file (see "Config file" below).                                                                                                                  |
+| Auth               | Bearer token (API key or JWT). CLI doesn't care which; it just passes the string through as `Authorization: Bearer <value>`.                                                                                 |
+| Output formats     | `table` (humans, column-aligned), `json` (single object/array, pipe into `jq`), `jsonl` (one per line, streaming), `yaml`. Default `table` on TTY, `json` when stdout is a pipe — detected via `IsTerminal`. |
+| JSON inputs        | Payloads accept `--input '{"k":"v"}'` literal, `--input @file.json` file, or `--input -` stdin.                                                                                                              |
+| Scripting-friendly | Non-zero exit codes for 404/5xx/validation; `workflow wait` for blocking on terminal state; `workflow events --follow` streams SSE.                                                                          |
+| Breaking scope     | All new. Existing stubs get real implementations; the parser surface extends with new subcommands.                                                                                                           |
+| Dependencies       | No new crates. Reuse `reqwest`, `clap`, `serde_json`, `serde_yml`, `tokio` already in tree. Column alignment is hand-rolled.                                                                                 |
+
+## Global config
+
+Every subcommand honours the same set of global options, discovered in this precedence order
+(highest wins):
+
+1. Explicit CLI flag (e.g. `--engine-url URL`)
+2. Environment variable (e.g. `ASSAY_ENGINE_URL`)
+3. Config file value
+4. Hardcoded default
+
+| CLI flag               | Env var              | Config key            | Default                           |
+| ---------------------- | -------------------- | --------------------- | --------------------------------- |
+| `--engine-url URL`     | `ASSAY_ENGINE_URL`   | `engine_url`          | `http://127.0.0.1:8080`           |
+| `--api-key KEY`        | `ASSAY_API_KEY`      | `api_key`             | (none)                            |
+| (via config file only) | `ASSAY_API_KEY_FILE` | `api_key_file`        | (none)                            |
+| `--namespace NS`       | `ASSAY_NAMESPACE`    | `namespace`           | `main`                            |
+| `--output FORMAT`      | `ASSAY_OUTPUT`       | `output`              | `table` on TTY, `json` when piped |
+| `--config PATH`        | `ASSAY_CONFIG_FILE`  | (n/a — file location) | see discovery order               |
+
+### Config file
+
+**Why:** operators deploy assay in a pod with a config file mounted at a well-known path. Inside the
+pod, `assay workflow list` "just works" without anyone needing to set env vars or flags. Avoids
+baking credentials into process environments, which leak into `ps` output and child processes.
+
+**Discovery order** (first one that exists wins):
+
+1. `--config PATH` (explicit)
+2. `ASSAY_CONFIG_FILE=PATH` (explicit override)
+3. `$XDG_CONFIG_HOME/assay/config.yaml` (user config, if XDG set)
+4. `~/.config/assay/config.yaml` (user config fallback)
+5. `/etc/assay/config.yaml` (system-wide; the pod case)
+
+**Format** — YAML (JSON parses too, since JSON is valid YAML):
+
+```yaml
+engine_url: https://assay.example.com
+api_key_file: /run/secrets/assay-api-key
+namespace: main
+output: table
+```
+
+**Key notes:**
+
+- `api_key_file` is preferred over `api_key` so the config file itself can be committed /
+  ConfigMap-d without the secret. The CLI reads the file at startup and uses its contents as the
+  bearer token. Trailing whitespace is trimmed.
+- If both `api_key` and `api_key_file` are present, `api_key_file` wins.
+- Unknown keys are ignored (forward compatibility).
+- A missing config file is not an error — the CLI falls through to flag / env / default precedence.
+
+**Future-compatible design:** the config file is a flat single profile. Multi-context support
+(kubectl-style `contexts:` + `current-context:`) is a clean later addition: existing single-profile
+files keep working because a top-level key like `engine_url` is distinguishable from `contexts:`.
+
+## Full command surface
+
+```
+assay workflow
+  start <type>       [--id ID] [--input JSON] [--queue Q]
+                     [--search-attrs JSON]
+                       → prints the new workflow id + run id
+  list               [--status S] [--type T] [--search-attrs JSON]
+                     [--limit N] [--offset N]
+                       → table: id, type, status, queue, created, completed
+  describe <id>        → full record + latest state snapshot if present
+  events <id>        [--follow] [--since SEQ]
+                       → --follow streams via SSE until the workflow terminates
+  state <id>         [<query-name>]
+                       → dumps latest snapshot (all queries, or one by name)
+  children <id>        → table of child workflows
+  signal <id> <name> [payload-as-json-or-@file-or--]
+  cancel <id>
+  terminate <id>     [--reason R]
+  continue-as-new <id> [--input JSON]
+  wait <id>          [--timeout SECS] [--target STATUS]
+                       → blocks until terminal (or specified target status)
+                       → exit 0 on success, 2 on timeout, 1 on workflow failure
+
+assay schedule
+  list
+  describe <name>
+  create <name>      --type T --cron EXPR [--timezone TZ]
+                     [--input JSON] [--queue Q] [--overlap POLICY]
+  patch <name>       [--cron EXPR] [--timezone TZ]
+                     [--input JSON] [--queue Q] [--overlap POLICY]
+  pause <name>
+  resume <name>
+  delete <name>
+
+assay namespace
+  list
+  create <name>
+  delete <name>
+  stats <name>         → workflow / worker / schedule counts
+
+assay worker
+  list                 → identity, queue, tasks, last heartbeat, age
+
+assay queue
+  stats                → pending / running activities per queue
+```
+
+Existing non-workflow subcommands — `assay serve`, `assay run`, `assay exec`, `assay modules`,
+`assay context`, `assay resume` — are untouched.
+
+## Exit codes
+
+| Code | Meaning                                                                                                                                         |
+| ---- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| 0    | Success                                                                                                                                         |
+| 1    | HTTP error (4xx/5xx), engine unreachable, validation error, or workflow completed with FAILED/CANCELLED/TIMED_OUT when `wait`-ing for COMPLETED |
+| 2    | `wait` timed out before reaching target status                                                                                                  |
+| 64   | Usage error (bad flags, unparseable JSON input) — matches `sysexits.h` EX_USAGE                                                                 |
+
+## Code layout
+
+| Path                            | Purpose                                                                                                                                                                   | Approx LOC |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| `src/cli/mod.rs`                | Module root + re-exports                                                                                                                                                  | ~10        |
+| `src/cli/config.rs`             | Global config resolver: flags → env → file → default. Loads and merges the optional config file.                                                                          | ~180       |
+| `src/cli/client.rs`             | `EngineClient` over `reqwest`: typed methods per REST endpoint; returns `anyhow::Result<T>` with HTTP status context on error.                                            | ~300       |
+| `src/cli/input.rs`              | `JsonInput::resolve(arg)` — literal / `@file` / `-` stdin parser.                                                                                                         | ~50        |
+| `src/cli/output.rs`             | `Printer` enum (Table/Json/Jsonl/Yaml) + `print_list` / `print_record` helpers. Table alignment is hand-rolled: compute column widths in one pass, print in the second.   | ~220       |
+| `src/cli/commands/workflow.rs`  | One async function per workflow subcommand.                                                                                                                               | ~250       |
+| `src/cli/commands/schedule.rs`  | One async function per schedule subcommand.                                                                                                                               | ~150       |
+| `src/cli/commands/namespace.rs` | Namespace subcommands.                                                                                                                                                    | ~80        |
+| `src/cli/commands/worker.rs`    | Worker list.                                                                                                                                                              | ~40        |
+| `src/cli/commands/queue.rs`     | Queue stats.                                                                                                                                                              | ~40        |
+| `src/main.rs`                   | Clap wiring; extended `WorkflowCommands` / `ScheduleCommands` enums; new `NamespaceCommands`, `WorkerCommands`, `QueueCommands` enums; dispatch from the top-level match. | +~200      |
+
+**Total:** ~1500 LOC Rust across new + modified files. Zero new crate dependencies.
+
+## Implementation phasing (commits)
+
+Each commit is independently shippable and testable:
+
+1. `feat(cli): config resolver and HTTP client` — `src/cli/{mod,config,client,input,output}.rs`.
+   Internal infrastructure only; no new clap subcommands yet. Adds a `GlobalOpts` struct threaded
+   through the command functions (to be introduced in subsequent commits).
+2. `feat(cli): assay workflow subcommands` — replace the stub for `Commands::Workflow`; wire
+   `start`, `list`, `describe`, `events`, `state`, `children`, `signal`, `cancel`, `terminate`,
+   `continue-as-new`, `wait`.
+3. `feat(cli): assay schedule subcommands` — replace the stub for `Commands::Schedule`; wire `list`,
+   `describe`, `create`, `patch`, `pause`, `resume`, `delete`.
+4. `feat(cli): assay namespace, worker, queue subcommands` — new clap subcommand trees; wire all
+   five.
+5. `docs: CLI section in README + CHANGELOG v0.11.3 entry` — one worked example per subcommand
+   (start / wait / signal being the most valuable); add a "CLI" section to CHANGELOG v0.11.3.
+
+## Testing
+
+**Unit tests** (colocated with the module):
+
+- `src/cli/config.rs` — precedence ordering (flag > env > file > default); `api_key_file` is read
+  and trimmed; config file missing is not an error; unknown keys ignored.
+- `src/cli/input.rs` — literal / `@file` / `-` stdin parsing; invalid JSON produces usage-error
+  (exit 64).
+- `src/cli/output.rs` — table column widths computed correctly for empty / sparse / wide records;
+  JSON/JSONL/YAML round-trip preserves numeric precision.
+
+**Integration tests** — new `tests/cli_integration.rs`:
+
+- Spawn `assay serve` on a random port with in-memory SQLite (reuse pattern from
+  `orchestration.rs`).
+- Run the compiled `assay` binary as a subprocess (locate via `target/{debug,release}/assay`; skip
+  with eprintln if absent).
+- Happy path per command group:
+  - workflow: `start` → `describe` → `signal` → `wait` → `list --status COMPLETED`
+  - schedule: `create` → `patch` → `pause` → `resume` → `delete`
+  - namespace: `create` → `list` → `stats` → `delete`
+  - worker + queue: `stats` (no registered workers)
+- Verify exit codes: `wait --timeout 1` on a hung workflow returns exit 2.
+- Verify output formats: `--output json` emits parseable JSON; `--output jsonl` emits one line per
+  record; default on TTY is table.
+
+**Pre-flight**: `cargo clippy --tests -- -D warnings` clean; `dprint check` clean on Markdown +
+TOML.
+
+## In scope (this PR)
+
+- All subcommands listed above
+- Global options (`--engine-url`, `--api-key`, `--namespace`, `--output`, `--config`) with env var +
+  config file backing
+- YAML config file with the documented discovery order and `api_key_file` indirection
+- Output formats: `table`, `json`, `jsonl`, `yaml`; TTY-adaptive default
+- JSON input indirection (`--input @file` and `--input -`)
+- SSE streaming for `events --follow`
+- `wait` helper
+- README CLI section + CHANGELOG v0.11.3 entry
+
+## Explicitly out of scope (deferred to a later release)
+
+- **Interactive `--watch` for `list` subcommands** (re-runs on interval). Low priority; `watch` (the
+  GNU utility) + `--output json | jq` covers 90% of this today.
+- **Colorized output.** Nice-to-have; not on the critical path. When added, wire through
+  `is_terminal::IsTerminal` with an `--color auto|always|never` flag (matches `ls`, `grep`).
+- **Multi-profile contexts** (kubectl-style `contexts:` + `current-context:`). Designed around in
+  this release (flat config is forward-compatible) but not implemented.
+- **CLI for live workflow-task inspection** (raw `/workflow-tasks/poll` etc). These endpoints are
+  for worker-internal dispatch; surfacing them via CLI would leak engine internals that legitimate
+  CLI users shouldn't need.
+- **Auto-completion scripts** (bash/zsh/fish/pwsh). The `clap_complete` crate makes this trivial
+  mechanically (`assay completion bash > /etc/bash_completion.d/assay`), but deferred pending your
+  guidance on whether to include it — the hook-up is a ~30 LOC addition when we decide to ship it.
+
+## Open questions
+
+None that block starting. Output default (`table` on TTY / `json` when piped) was confirmed in the
+preceding discussion.

--- a/.claude/plans/05-v0.11.3-cli-subcommands.md
+++ b/.claude/plans/05-v0.11.3-cli-subcommands.md
@@ -7,12 +7,13 @@ release with a full CLI for managing a running `assay serve` from a shell — st
 workflows, manage schedules, inspect namespaces and workers — so operators don't need custom curl
 scripts or Lua clients to drive the engine.
 
-**Correcting a past mistake.** v0.11.1 shipped `assay workflow …` and `assay schedule …` as
-parser-only subcommands: clap accepted them, the dispatch handlers at `src/main.rs:342-351` just
-printed "not yet implemented (v0.11.1)" and exited 1. That was a bad practice — surfaces visible to
-users must actually work, or not be visible at all. This plan removes every stub by implementing it
-for real. Going forward the rule is: features land fully implemented across every layer (clap → REST
-→ store → Lua) before merge, or are hidden entirely until they do.
+**Correcting a past mistake.** The currently-released v0.11.2 (source-identical republish of
+v0.11.1) ships `assay workflow …` and `assay schedule …` as parser-only subcommands: clap accepts
+them, the dispatch handlers at `src/main.rs:342-351` just print "not yet implemented (v0.11.1)" (a
+hard-coded deferral marker from when the stub was introduced) and exit 1. That was a bad practice —
+surfaces visible to users must actually work, or not be visible at all. This plan removes every stub
+by implementing it for real. Going forward the rule is: features land fully implemented across every
+layer (clap → REST → store → Lua) before merge, or are hidden entirely until they do.
 
 Ships as additional commits on the existing `feat/v0.11.3-workflow-enhancements` branch so the
 v0.11.3 release bundles the CLI alongside the engine features.
@@ -28,7 +29,7 @@ v0.11.3 release bundles the CLI alongside the engine features.
 | JSON inputs        | Payloads accept `--input '{"k":"v"}'` literal, `--input @file.json` file, or `--input -` stdin.                                                                                                              |
 | Scripting-friendly | Non-zero exit codes for 404/5xx/validation; `workflow wait` for blocking on terminal state; `workflow events --follow` streams SSE.                                                                          |
 | Breaking scope     | All new. Existing stubs get real implementations; the parser surface extends with new subcommands.                                                                                                           |
-| Dependencies       | No new crates. Reuse `reqwest`, `clap`, `serde_json`, `serde_yml`, `tokio` already in tree. Column alignment is hand-rolled.                                                                                 |
+| Dependencies       | One new crate: `clap_complete` (for `assay completion`). Otherwise reuses `reqwest`, `clap`, `serde_json`, `serde_yml`, `tokio` already in tree. Column alignment is hand-rolled.                            |
 
 ## Global config
 
@@ -131,6 +132,14 @@ assay worker
 
 assay queue
   stats                → pending / running activities per queue
+
+assay completion <shell>
+                       → write a completion script for bash|zsh|fish|pwsh|elvish to stdout
+                       → usage, per shell:
+                           bash:  assay completion bash > /etc/bash_completion.d/assay
+                           zsh:   assay completion zsh  > "${fpath[1]}/_assay"
+                           fish:  assay completion fish > ~/.config/fish/completions/assay.fish
+                           pwsh:  assay completion pwsh > $PROFILE.d/assay.ps1
 ```
 
 Existing non-workflow subcommands — `assay serve`, `assay run`, `assay exec`, `assay modules`,
@@ -147,21 +156,22 @@ Existing non-workflow subcommands — `assay serve`, `assay run`, `assay exec`, 
 
 ## Code layout
 
-| Path                            | Purpose                                                                                                                                                                   | Approx LOC |
-| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
-| `src/cli/mod.rs`                | Module root + re-exports                                                                                                                                                  | ~10        |
-| `src/cli/config.rs`             | Global config resolver: flags → env → file → default. Loads and merges the optional config file.                                                                          | ~180       |
-| `src/cli/client.rs`             | `EngineClient` over `reqwest`: typed methods per REST endpoint; returns `anyhow::Result<T>` with HTTP status context on error.                                            | ~300       |
-| `src/cli/input.rs`              | `JsonInput::resolve(arg)` — literal / `@file` / `-` stdin parser.                                                                                                         | ~50        |
-| `src/cli/output.rs`             | `Printer` enum (Table/Json/Jsonl/Yaml) + `print_list` / `print_record` helpers. Table alignment is hand-rolled: compute column widths in one pass, print in the second.   | ~220       |
-| `src/cli/commands/workflow.rs`  | One async function per workflow subcommand.                                                                                                                               | ~250       |
-| `src/cli/commands/schedule.rs`  | One async function per schedule subcommand.                                                                                                                               | ~150       |
-| `src/cli/commands/namespace.rs` | Namespace subcommands.                                                                                                                                                    | ~80        |
-| `src/cli/commands/worker.rs`    | Worker list.                                                                                                                                                              | ~40        |
-| `src/cli/commands/queue.rs`     | Queue stats.                                                                                                                                                              | ~40        |
-| `src/main.rs`                   | Clap wiring; extended `WorkflowCommands` / `ScheduleCommands` enums; new `NamespaceCommands`, `WorkerCommands`, `QueueCommands` enums; dispatch from the top-level match. | +~200      |
+| Path                             | Purpose                                                                                                                                                                                                          | Approx LOC |
+| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| `src/cli/mod.rs`                 | Module root + re-exports                                                                                                                                                                                         | ~10        |
+| `src/cli/config.rs`              | Global config resolver: flags → env → file → default. Loads and merges the optional config file.                                                                                                                 | ~180       |
+| `src/cli/client.rs`              | `EngineClient` over `reqwest`: typed methods per REST endpoint; returns `anyhow::Result<T>` with HTTP status context on error.                                                                                   | ~300       |
+| `src/cli/input.rs`               | `JsonInput::resolve(arg)` — literal / `@file` / `-` stdin parser.                                                                                                                                                | ~50        |
+| `src/cli/output.rs`              | `Printer` enum (Table/Json/Jsonl/Yaml) + `print_list` / `print_record` helpers. Table alignment is hand-rolled: compute column widths in one pass, print in the second.                                          | ~220       |
+| `src/cli/commands/workflow.rs`   | One async function per workflow subcommand.                                                                                                                                                                      | ~250       |
+| `src/cli/commands/schedule.rs`   | One async function per schedule subcommand.                                                                                                                                                                      | ~150       |
+| `src/cli/commands/namespace.rs`  | Namespace subcommands.                                                                                                                                                                                           | ~80        |
+| `src/cli/commands/worker.rs`     | Worker list.                                                                                                                                                                                                     | ~40        |
+| `src/cli/commands/queue.rs`      | Queue stats.                                                                                                                                                                                                     | ~40        |
+| `src/cli/commands/completion.rs` | Shell-completion generator using `clap_complete::generate` against the top-level `Cli::command()`. One async fn that writes to stdout.                                                                           | ~40        |
+| `src/main.rs`                    | Clap wiring; extended `WorkflowCommands` / `ScheduleCommands` enums; new `NamespaceCommands`, `WorkerCommands`, `QueueCommands` enums; `Completion { shell: Shell }` variant; dispatch from the top-level match. | +~200      |
 
-**Total:** ~1500 LOC Rust across new + modified files. Zero new crate dependencies.
+**Total:** ~1540 LOC Rust across new + modified files. One new crate dependency (`clap_complete`).
 
 ## Implementation phasing (commits)
 
@@ -177,8 +187,11 @@ Each commit is independently shippable and testable:
    `describe`, `create`, `patch`, `pause`, `resume`, `delete`.
 4. `feat(cli): assay namespace, worker, queue subcommands` — new clap subcommand trees; wire all
    five.
-5. `docs: CLI section in README + CHANGELOG v0.11.3 entry` — one worked example per subcommand
-   (start / wait / signal being the most valuable); add a "CLI" section to CHANGELOG v0.11.3.
+5. `feat(cli): assay completion subcommand` — add `clap_complete` dep; `assay completion <shell>`
+   writes a completion script for bash/zsh/fish/pwsh/elvish to stdout.
+6. `docs: CLI section in README + CHANGELOG v0.11.3 entry` — one worked example per subcommand
+   (start / wait / signal being the most valuable); add a "CLI" section to CHANGELOG v0.11.3
+   including the completion-install one-liners per shell.
 
 ## Testing
 
@@ -231,10 +244,8 @@ TOML.
   this release (flat config is forward-compatible) but not implemented.
 - **CLI for live workflow-task inspection** (raw `/workflow-tasks/poll` etc). These endpoints are
   for worker-internal dispatch; surfacing them via CLI would leak engine internals that legitimate
-  CLI users shouldn't need.
-- **Auto-completion scripts** (bash/zsh/fish/pwsh). The `clap_complete` crate makes this trivial
-  mechanically (`assay completion bash > /etc/bash_completion.d/assay`), but deferred pending your
-  guidance on whether to include it — the hook-up is a ~30 LOC addition when we decide to ship it.
+  CLI users shouldn't need. (Auto-completion is now in scope — see the `assay completion <shell>`
+  subcommand above.)
 
 ## Open questions
 

--- a/.claude/plans/06-v0.11.3-stdlib-completeness-and-cli-fill.md
+++ b/.claude/plans/06-v0.11.3-stdlib-completeness-and-cli-fill.md
@@ -17,8 +17,8 @@ This plan:
 
 1. Fills the `assay.workflow` stdlib to 1:1 parity with the REST API so every primitive is callable
    from Lua scripts and embedded CC code.
-2. Fills the CLI stubs left over from v0.11.1 with real implementations (no more "not yet
-   implemented" handlers).
+2. Fills the CLI stubs carried through v0.11.2 (registered in clap since v0.11.1, still "not yet
+   implemented" in v0.11.2) with real implementations.
 3. Defers the comprehensive CLI expansion (plan 05) until there's demand for it.
 
 Ships on the existing `feat/v0.11.3-workflow-enhancements` branch.

--- a/.claude/plans/06-v0.11.3-stdlib-completeness-and-cli-fill.md
+++ b/.claude/plans/06-v0.11.3-stdlib-completeness-and-cli-fill.md
@@ -1,0 +1,240 @@
+# Plan: v0.11.3 — Lua stdlib completeness + CLI stub fill
+
+## Why this plan exists
+
+Plan 05 sketched a comprehensive CLI (global config, output formats, `wait`, completion, five
+subcommand trees). On reflection, the consumer pattern in this ecosystem is **Lua-first**: CC is
+Lua, and Kubernetes Jobs that manage the engine are better as `assay run seed.lua` than as shell +
+curl + jq.
+
+In a Lua-first world, the CLI's unique value shrinks to "interactive UX for operators" — useful but
+not load-bearing. The load-bearing surface is the `assay.workflow` Lua stdlib, which is currently
+**incomplete**: it has worker-side APIs (`define`, `activity`, `listen`, the ctx object) and a
+handful of client ops (`start`, `signal`, `describe`, `cancel`), but is missing schedule management,
+workflow listing, event fetching, state queries, children, namespaces, workers, and queues.
+
+This plan:
+
+1. Fills the `assay.workflow` stdlib to 1:1 parity with the REST API so every primitive is callable
+   from Lua scripts and embedded CC code.
+2. Fills the CLI stubs left over from v0.11.1 with real implementations (no more "not yet
+   implemented" handlers).
+3. Defers the comprehensive CLI expansion (plan 05) until there's demand for it.
+
+Ships on the existing `feat/v0.11.3-workflow-enhancements` branch.
+
+## Scope
+
+**In**
+
+- All 12 REST endpoints from plan 04 exposed as Lua stdlib methods (`workflow.list`,
+  `workflow.schedules.patch`, …).
+- The 10 CLI subcommands already registered as clap stubs get real implementations. Two small
+  extensions to that clap surface where they are direct expressions of v0.11.3 features:
+  - `assay workflow state <id> [<query-name>]` (F1)
+  - `assay schedule patch <name> [flags…]` (F3)
+  - `assay schedule create --timezone <tz>` option (F4)
+- New orchestration tests covering the stdlib additions and CLI commands.
+- CHANGELOG v0.11.3 entry updated to mention the stdlib surface + CLI command availability.
+
+**Out** (deferred to plan 05 if/when demand materialises)
+
+- Global CLI config file (`~/.config/assay/config.yaml`, `/etc/assay/config.yaml`).
+- Output formats beyond a default table (`--output json|yaml|jsonl`).
+- `assay workflow wait` helper and `events --follow` SSE streaming from CLI.
+- `assay namespace`, `assay worker`, `assay queue` subcommand trees.
+- `assay completion <shell>` script generator.
+- TTY-adaptive output defaults.
+
+Rationale: anything not in the existing clap surface or not directly required by a plan-04 feature
+can wait. Lua scripts cover the automation use cases; operators can run the base CLI commands
+interactively for ad-hoc debugging.
+
+## Lua stdlib surface diff
+
+Existing top-level functions stay. New client-side methods added at the top level follow the same
+convention; new resource groups (schedules, namespaces, workers, queues) live under sub-tables for
+clarity:
+
+```lua
+-- Existing (worker + a few client ops) — unchanged
+workflow.connect(url, opts)
+workflow.define(name, handler)
+workflow.activity(name, handler)
+workflow.listen(opts)
+workflow.start(opts)
+workflow.signal(id, name, payload)
+workflow.describe(id)
+workflow.cancel(id)
+
+-- New top-level client ops (match existing naming convention)
+workflow.list(opts)                 -- GET /workflows?...
+workflow.terminate(id, reason)      -- POST /workflows/{id}/terminate
+workflow.get_events(id, opts)       -- GET /workflows/{id}/events
+workflow.get_state(id, name?)       -- GET /workflows/{id}/state[/{name}] — F1
+workflow.list_children(id)          -- GET /workflows/{id}/children
+workflow.continue_as_new(id, input) -- POST /workflows/{id}/continue-as-new
+                                    --   (client-side — distinct from
+                                    --    the worker-side `ctx:continue_as_new`)
+
+-- New sub-tables
+workflow.schedules = {
+    create   = function(opts) … end,      -- POST   /schedules
+    list     = function(opts) … end,      -- GET    /schedules
+    describe = function(name, opts) … end,-- GET    /schedules/{name}
+    patch    = function(name, patch, opts) … end, -- PATCH /schedules/{name} — F3
+    pause    = function(name, opts) … end,-- POST   /schedules/{name}/pause  — F3
+    resume   = function(name, opts) … end,-- POST   /schedules/{name}/resume — F3
+    delete   = function(name, opts) … end,-- DELETE /schedules/{name}
+}
+
+workflow.namespaces = {
+    create = function(name) … end,  -- POST   /namespaces
+    list   = function() … end,      -- GET    /namespaces
+    delete = function(name) … end,  -- DELETE /namespaces/{name}
+    stats  = function(name) … end,  -- GET    /namespaces/{name}
+                                    --   (same endpoint returns stats)
+}
+
+workflow.workers = {
+    list = function(opts) … end,    -- GET /workers
+}
+
+workflow.queues = {
+    stats = function(opts) … end,   -- GET /queues
+}
+```
+
+Every new function returns `{ok, data}` on success or raises `error()` with a message containing the
+HTTP status on failure — consistent with the existing `workflow.start / signal / describe / cancel`
+behaviour.
+
+Opts tables all accept `{ namespace = "..." }` where the REST endpoint takes a `?namespace=` query
+param, defaulting to `"main"`.
+
+## CLI fill-stubs surface diff
+
+Existing stubs that print "not yet implemented" get real implementations. Clap parser surface stays
+the same (flags unchanged) except for the three v0.11.3-feature extensions listed in scope.
+
+```
+assay workflow
+  list        [--status S] [--type T] [--limit N]         # existing
+  describe <id>                                           # existing
+  signal <id> <name> [payload]                            # existing
+  cancel <id>                                             # existing
+  terminate <id> [--reason R]                             # existing
+  state <id> [<query-name>]                               # NEW (F1)
+
+assay schedule
+  list                                                    # existing
+  create <name> --type T --cron EXPR [--input JSON]       # existing
+                [--queue Q] [--timezone TZ]               # NEW --timezone (F4)
+  patch <name> [--cron EXPR] [--timezone TZ]              # NEW (F3)
+               [--input JSON] [--queue Q] [--overlap POLICY]
+  pause <name>                                            # existing
+  resume <name>                                           # existing
+  delete <name>                                           # existing
+```
+
+Global flags (minimal — no config file in this release):
+
+- `--engine-url URL` / `ASSAY_ENGINE_URL` (default `http://127.0.0.1:8080`)
+- `--api-key KEY` / `ASSAY_API_KEY`
+- `--namespace NS` / `ASSAY_NAMESPACE` (default `main`)
+
+Output: plain-text table, one shape per subcommand. No `--output` flag — humans read the table,
+scripts use the Lua stdlib. That's the whole philosophy of the scope cut.
+
+## Code layout
+
+| Path                             | Purpose                                                                                                                                                  | Approx LOC |
+| -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| `stdlib/workflow.lua`            | Extend existing module with all new client ops + sub-tables. ~80 LOC of straightforward `_api(method, path, body)` wrappers.                             | +80        |
+| `src/cli/mod.rs`                 | New module root.                                                                                                                                         | ~10        |
+| `src/cli/client.rs`              | Minimal `EngineClient` wrapping `reqwest`: constructor reads `ASSAY_ENGINE_URL`/`--engine-url`, `ASSAY_API_KEY`/`--api-key`; typed method per endpoint.  | ~150       |
+| `src/cli/table.rs`               | Plain column-aligned table printer. Two-pass: compute widths, print rows.                                                                                | ~60        |
+| `src/cli/commands.rs`            | One async fn per subcommand, ~15 LOC each: build request, call client, print result.                                                                     | ~200       |
+| `src/main.rs`                    | Replace the two stub arms (Commands::Workflow, Commands::Schedule) with dispatch into `src/cli/commands.rs`. Extend clap enums with the new subcommands. | +60        |
+| `stdlib/workflow.lua.d.ts`-equiv | Inline docstrings on each new method (no separate doc file).                                                                                             | n/a        |
+
+**Total:** ~560 LOC Rust + ~80 LOC Lua + tests. Zero new crate deps.
+
+## Testing
+
+**Lua stdlib:** extend `tests/orchestration.rs` with a single Lua subprocess test that exercises the
+full management surface end-to-end:
+
+- create a namespace, then stats it
+- create a schedule, patch it, pause it, resume it, delete it
+- list workflows with filter args
+- get_events, get_state on a running workflow
+- terminate, continue_as_new (client-side)
+- list_children on a parent workflow
+
+**CLI:** new `tests/cli_integration.rs`:
+
+- Spawn `assay serve` with in-memory SQLite (reuse `start_test_server`).
+- Spawn compiled `assay` binary as subprocess per subcommand.
+- Happy path per subcommand, asserting exit code 0 and a key substring in stdout.
+- One 404 test (`assay workflow describe nonexistent-id` → exit 1).
+
+**Pre-flight:** `cargo clippy --tests -- -D warnings` clean; `dprint check` clean.
+
+## Implementation phasing (commits)
+
+1. `feat(stdlib): workflow management client ops` — all top-level + sub-table additions to
+   `stdlib/workflow.lua`. One orchestration test that exercises the new surface end-to-end via a Lua
+   subprocess.
+2. `feat(cli): implement workflow subcommands` — replace the `Commands::Workflow` stub; implement
+   list, describe, state (new), signal, cancel, terminate.
+3. `feat(cli): implement schedule subcommands` — replace the `Commands::Schedule` stub; implement
+   list, create (with --timezone), patch (new), pause, resume, delete.
+4. `docs(changelog): CLI + stdlib additions in v0.11.3` — update the existing v0.11.3 entry with
+   stdlib method list and CLI subcommand list.
+
+Each commit standalone-green. `cargo test` + clippy clean at every step.
+
+## Downstream impact (gitops repo, plan 13)
+
+Plan 13 phase 3 (schedule seed Job) becomes a Lua script in a Kubernetes Job, not shell + CLI:
+
+```lua
+-- /scripts/seed-schedules.lua  (gitops repo)
+local workflow = require("assay.workflow")
+
+workflow.connect(
+    env.get("ASSAY_ENGINE_URL"),
+    { token = env.get("ASSAY_API_KEY") }
+)
+
+local desired = json.parse(fs.read("/etc/schedules/schedules.json"))
+for _, s in ipairs(desired) do
+    local ok = pcall(function() workflow.schedules.describe(s.name) end)
+    if ok then
+        workflow.schedules.patch(s.name, {
+            cron_expr = s.cron_expr,
+            timezone  = s.timezone,
+            input     = s.input,
+        })
+    else
+        workflow.schedules.create(s)
+    end
+end
+```
+
+Plan 13 needs a one-line update to reflect this — handled in a separate gitops-repo commit, not in
+this PR.
+
+## Pending assumptions to verify before implementing
+
+- **`workflow.connect` already accepts `{ token = ... }`**: yes, verified at
+  `stdlib/workflow.lua:51-56`. No stdlib auth work needed.
+- **Engine exposes `/namespaces`, `/namespaces/{name}` (stats + delete)**: yes, confirmed at
+  `crates/assay-workflow/src/api/namespaces.rs:13-20`. `stats` and `describe` are the same endpoint
+  — the response body contains the counts.
+- **Engine exposes `/workers` and `/queues`**: yes, confirmed at
+  `crates/assay-workflow/src/api/workers.rs:13-15` and `crates/assay-workflow/src/api/queues.rs:13`.
+  No trailing `/stats` on the queues route.
+- **No REST endpoint changes needed for this plan**: correct — everything the stdlib needs already
+  exists.

--- a/.claude/plans/07-v0.11.3-tier1-dashboard.md
+++ b/.claude/plans/07-v0.11.3-tier1-dashboard.md
@@ -2,11 +2,11 @@
 
 ## Why this plan exists
 
-The dashboard shipped in v0.11.1 is read-only: it lists workflows / schedules / workers / queues but
-every mutation (start a workflow, pause a schedule, create a namespace, signal a workflow, cancel)
-requires the REST API, the CLI, or the Lua stdlib. That's a reasonable v1, but it splits the
-operator workflow awkwardly — you're in the UI looking at something, then shelling out to mutate it.
-This plan closes that gap.
+The dashboard shipped in v0.11.1 and unchanged through v0.11.2 is read-only: it lists workflows /
+schedules / workers / queues but every mutation (start a workflow, pause a schedule, create a
+namespace, signal a workflow, cancel) requires the REST API, the CLI, or the Lua stdlib. That's a
+reasonable v1, but it splits the operator workflow awkwardly — you're in the UI looking at
+something, then shelling out to mutate it. This plan closes that gap.
 
 Scope is deliberately **tier 1** from the three tiers in the strategic discussion: take every
 existing read view and add the matching mutations. No in-browser code editor, no workflow-type

--- a/.claude/plans/07-v0.11.3-tier1-dashboard.md
+++ b/.claude/plans/07-v0.11.3-tier1-dashboard.md
@@ -1,0 +1,142 @@
+# Plan: v0.11.3 — Tier-1 dashboard (operator control plane)
+
+## Why this plan exists
+
+The dashboard shipped in v0.11.1 is read-only: it lists workflows / schedules / workers / queues but
+every mutation (start a workflow, pause a schedule, create a namespace, signal a workflow, cancel)
+requires the REST API, the CLI, or the Lua stdlib. That's a reasonable v1, but it splits the
+operator workflow awkwardly — you're in the UI looking at something, then shelling out to mutate it.
+This plan closes that gap.
+
+Scope is deliberately **tier 1** from the three tiers in the strategic discussion: take every
+existing read view and add the matching mutations. No in-browser code editor, no workflow-type
+authoring, no tenancy. That's **tier 3** and a separate product direction; it is explicitly out of
+scope.
+
+Also: expose engine version via REST + show it in the UI, and add a search-attributes filter to the
+workflows list.
+
+Ships on `feat/v0.11.3-workflow-enhancements` so the full v0.11.3 bundle lands together.
+
+## Scope
+
+**In**
+
+- `GET /api/v1/version` endpoint returning `{ version, build_profile }`. Rendered in the dashboard
+  sidebar so operators know which build they're talking to.
+- Start-a-workflow form on the Workflows view: type, id (optional), input JSON, queue, search_attrs
+  JSON.
+- Action buttons on the workflow detail view: send signal (prompts for name + payload), cancel,
+  terminate (prompts for reason). All POST to the matching REST endpoint and refresh.
+- Schedule CRUD from the Schedules view: pause / resume toggle, delete (confirm), edit (patch form).
+- Namespace create / delete from the Settings view (current settings page already lists them; extend
+  it).
+- Search-attributes filter on the Workflows list — a JSON text input that feeds the `search_attrs`
+  query param.
+
+**Out** (explicitly deferred or a different release entirely)
+
+- Workflow-type authoring in the browser (tier 3)
+- In-browser Lua editor (tier 3)
+- Batch operations — cancel-many, terminate-many (tier 2)
+- Workflow reset-to-event (tier 2)
+- Calendar view for upcoming schedule fires (tier 2)
+- Dashboard RBAC — who can start vs. who can only view (deferred; today the dashboard has no auth of
+  its own and sits behind the same `AuthMode` as the REST API)
+- Colorized / themed output polish beyond what's needed for the controls
+
+## Design notes
+
+### Shape of every mutation
+
+Each mutation follows the same three-step pattern:
+
+1. User clicks a button or submits a form
+2. Dashboard JS does `fetch` to the existing REST endpoint
+3. On success, emit a toast + refresh the containing list/detail view
+
+No new WebSocket or SSE channels. The dashboard already polls + SSE-listens for list refreshes; the
+mutations just trigger a refresh faster than the poll interval.
+
+### Forms stay minimal
+
+A JSON textarea for input / search_attrs beats a fancy form builder. Tier 3 is where "form for each
+workflow type" lives. Tier 1 is "the operator already knows what JSON to send and just wants to not
+paste it into curl."
+
+### Version endpoint
+
+```rust
+#[derive(Serialize, ToSchema)]
+struct Version {
+    version: &'static str,     // env!("CARGO_PKG_VERSION") at compile time
+    build_profile: &'static str, // "release" or "debug"
+}
+```
+
+Expose at `GET /api/v1/version`. Dashboard JS fetches it once on load and stamps it into the sidebar
+footer. Also listed in the OpenAPI spec.
+
+### Namespace create/delete — where does it live?
+
+Current dashboard has a Settings tab that lists namespaces. Extending Settings with a create form +
+delete buttons per row keeps the mental model consistent. Don't introduce a new Namespaces tab just
+for this.
+
+### Start-workflow form — where does it live?
+
+On the Workflows view, a `+ Start workflow` button opens an inline form. Submitting POSTs to
+`/workflows`, closes the form, refreshes the list.
+
+## Code layout
+
+| Path                                                          | Change                                     |
+| ------------------------------------------------------------- | ------------------------------------------ |
+| `crates/assay-workflow/src/api/meta.rs` (new)                 | `/version` endpoint                        |
+| `crates/assay-workflow/src/api/mod.rs`                        | Register meta router                       |
+| `crates/assay-workflow/src/api/openapi.rs`                    | Add version path + schema                  |
+| `crates/assay-workflow/src/dashboard/components/workflows.js` | Start-workflow form + search_attrs filter  |
+| `crates/assay-workflow/src/dashboard/components/detail.js`    | Signal / cancel / terminate buttons        |
+| `crates/assay-workflow/src/dashboard/components/schedules.js` | Pause/resume/delete/edit controls          |
+| `crates/assay-workflow/src/dashboard/components/settings.js`  | Namespace create/delete                    |
+| `crates/assay-workflow/src/dashboard/index.html`              | Version stamp in sidebar                   |
+| `crates/assay-workflow/src/dashboard/app.js`                  | Fetch version on load; shared toast helper |
+| `crates/assay-workflow/src/dashboard/style.css`               | Form + button styles (minimal)             |
+
+Approx ~600 LOC total: 60 Rust (version endpoint), 540 JS/HTML/CSS.
+
+## Testing
+
+The dashboard is plain HTML/JS/CSS — no build step. For this tier we don't need browser-driven tests
+(Playwright etc.) if:
+
+- Version endpoint has an `api_integration` test asserting the response shape.
+- All mutations go through REST endpoints already covered by orchestration
+  - API integration tests. Dashboard JS is a thin wrapper over fetch; wiring correctness is easy to
+    verify manually.
+
+Manual smoke test checklist (documented in the plan for the v0.11.4 follow-up to automate if we
+want):
+
+- [ ] Version shows in sidebar, matches `assay --version`
+- [ ] Start a workflow via form; it appears in the list
+- [ ] Signal / cancel / terminate buttons all round-trip
+- [ ] Schedule pause / resume / delete / edit all round-trip
+- [ ] Namespace create / delete round-trips
+- [ ] Search_attrs filter on workflows list filters correctly
+
+## Implementation phasing (commits)
+
+1. `feat(api): /version endpoint + dashboard version stamp` — Rust + HTML
+2. `feat(dashboard): start-workflow form + search_attrs filter` — JS + CSS
+3. `feat(dashboard): workflow detail signal/cancel/terminate controls` — JS
+4. `feat(dashboard): schedule CRUD (pause/resume/delete/edit)` — JS
+5. `feat(dashboard): namespace create/delete` — JS
+6. `docs(changelog): tier-1 dashboard + /version endpoint` — CHANGELOG
+
+## Pending verifications
+
+- **`assay --version` already works** — clap's `version` attribute picks up `CARGO_PKG_VERSION`.
+  Output: `assay 0.11.3`. No CLI change needed.
+- **Dashboard source is `crates/assay-workflow/src/dashboard/`** — plain HTML + JS + CSS included
+  into the binary via `include_str!`, served by `api/dashboard.rs`. No build step, no bundler.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,13 +58,60 @@ Use cases:
 - **Crate**: [crates.io/crates/assay-lua](https://crates.io/crates/assay-lua)
 - **Stack**: Rust (2024 edition), Tokio, Lua 5.5 (mlua), reqwest, clap, axum
 
-## Two Modes
+## Three Modes
 
 ```bash
 assay script.lua     # Lua mode — run script with all builtins
 assay checks.yaml    # YAML mode — structured checks with retry/backoff/parallel
-assay serve          # Workflow engine mode — REST+SSE API, dashboard
+assay serve          # Workflow engine mode — REST+SSE API, dashboard, CLI
 ```
+
+### Workflow engine mode — short overview
+
+Full reference: `docs/modules/workflow.md`. One binary runs the engine (`assay serve`), the CLI that
+drives it (`assay workflow/schedule/namespace/worker/queue/completion …`), and the Lua client
+(`require("assay.workflow")`) for worker processes and management scripts.
+
+```bash
+assay serve --backend postgres://... --port 8080       # engine (multi-instance via Postgres)
+assay workflow start --type Deploy --input @req.json   # start a run; --input takes @file/-/literal
+assay workflow wait <id> --timeout 300                 # block for scripts; exit 0/1/2
+assay schedule create nightly --cron "0 0 2 * * *" --timezone Europe/Berlin  --type Report
+assay completion bash > /etc/bash_completion.d/assay   # generate shell completion
+```
+
+Global CLI flags (all env-backed and config-file-backed): `--engine-url`, `--api-key`,
+`--namespace`, `--output`, `--config`. YAML config file auto-discovered at `--config PATH` /
+`$ASSAY_CONFIG_FILE` / `$XDG_CONFIG_HOME/assay/config.yaml` / `~/.config/assay/config.yaml` /
+`/etc/assay/config.yaml`. `api_key_file:` keeps the secret out of env/argv. Output formats: table
+(TTY default), json (pipe default), jsonl, yaml.
+
+Lua surface (worker + management in one module):
+
+```lua
+local workflow = require("assay.workflow")
+workflow.connect("http://assay:8080", { token = env.get("ASSAY_API_KEY") })
+
+-- Worker: define handlers, listen. ctx gets execute_activity / execute_parallel (v0.11.3) /
+-- sleep / wait_for_signal / start_child_workflow / side_effect / register_query (v0.11.3) /
+-- upsert_search_attributes (v0.11.3) / continue_as_new (v0.11.3).
+workflow.define("Pipeline", function(ctx, input) ... end)
+workflow.activity("step", function(ctx, input) ... end)
+workflow.listen({ queue = "default" })  -- blocks
+
+-- Management: workflow.list/describe/get_events/get_state/list_children/continue_as_new,
+-- workflow.schedules.{create,list,describe,patch,pause,resume,delete},
+-- workflow.namespaces.{create,list,describe,stats,delete},
+-- workflow.workers.list, workflow.queues.stats.
+```
+
+**Dashboard** at `/workflow/` — reads + tier-1 operator controls (start, signal, cancel, terminate,
+continue-as-new, live `register_query` state, schedule CRUD + pause/resume, namespace
+create/delete). Engine version shown in the status bar, fetched from `/api/v1/version`.
+
+**Optional S3 archival** (cargo feature `s3-archival`, default-off). Enabled when
+`ASSAY_ARCHIVE_S3_BUCKET` is set. Bundles completed workflows to S3 after
+`ASSAY_ARCHIVE_RETENTION_DAYS` and stubs the row with `archive_uri`.
 
 ### Example: Kubernetes Job
 
@@ -176,43 +223,43 @@ and `id` must not contain newlines. `data` handles multi-line automatically.
 
 35 embedded Lua modules loaded via `require("assay.<name>")`:
 
-| Module               | Description                                                                                                                 |
-| -------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| `assay.prometheus`   | Query metrics, alerts, targets, rules, label values, series                                                                 |
-| `assay.alertmanager` | Manage alerts, silences, receivers, config                                                                                  |
-| `assay.loki`         | Push logs, query, labels, series                                                                                            |
-| `assay.grafana`      | Health, dashboards, datasources, annotations                                                                                |
-| `assay.k8s`          | 30+ resource types, CRDs, readiness checks                                                                                  |
-| `assay.argocd`       | Apps, sync, health, projects, repositories                                                                                  |
-| `assay.kargo`        | Stages, freight, promotions, verification                                                                                   |
-| `assay.flux`         | GitRepositories, Kustomizations, HelmReleases                                                                               |
-| `assay.traefik`      | Routers, services, middlewares, entrypoints                                                                                 |
-| `assay.vault`        | KV secrets, policies, auth, transit, PKI                                                                                    |
-| `assay.openbao`      | Alias for vault (API-compatible)                                                                                            |
-| `assay.certmanager`  | Certificates, issuers, ACME challenges                                                                                      |
-| `assay.eso`          | ExternalSecrets, SecretStores, ClusterSecretStores                                                                          |
-| `assay.dex`          | OIDC discovery, JWKS, health                                                                                                |
-| `assay.zitadel`      | OIDC identity management with JWT machine auth                                                                              |
-| `assay.ory.kratos`   | Ory Kratos identity — login/registration/recovery/settings flows, identities, sessions, schemas                             |
-| `assay.ory.hydra`    | Ory Hydra OAuth2/OIDC — clients, authorize URLs, tokens, login/consent, introspection, JWKs                                 |
-| `assay.ory.keto`     | Ory Keto ReBAC — relation tuples, permission checks, role/group membership, expand                                          |
-| `assay.ory.rbac`     | Capability-based RBAC engine over Keto — define roles + capabilities, query users, manage memberships, separation of duties |
-| `assay.ory`          | Convenience wrapper re-exporting kratos/hydra/keto/rbac with `ory.connect(opts)`                                            |
-| `assay.crossplane`   | Providers, XRDs, compositions, managed resources                                                                            |
-| `assay.velero`       | Backups, restores, schedules, storage locations                                                                             |
-| `assay.harbor`       | Projects, repositories, artifacts, vulnerability scanning                                                                   |
-| `assay.workflow`     | Workflow engine client — connect, define workflows/activities, listen as worker, start/signal/cancel workflows              |
-| `assay.healthcheck`  | HTTP checks, JSON path, body matching, latency, multi-check                                                                 |
-| `assay.s3`           | S3-compatible storage (AWS, R2, MinIO) with Sig V4                                                                          |
-| `assay.postgres`     | Postgres-specific helpers                                                                                                   |
-| `assay.unleash`      | Feature flags: projects, environments, features, strategies, API tokens                                                     |
-| `assay.openclaw`     | OpenClaw AI agent platform — invoke tools, state, diff, approve, LLM tasks                                                  |
-| `assay.gitlab`       | GitLab REST API v4 — projects, repos, commits, MRs, pipelines, issues, registry                                             |
-| `assay.github`       | GitHub REST API — PRs, issues, actions, repos, GraphQL                                                                      |
-| `assay.gmail`        | Gmail REST API with OAuth2 — search, read, reply, send, labels                                                              |
-| `assay.gcal`         | Google Calendar REST API with OAuth2 — events CRUD, calendar list                                                           |
-| `assay.oauth2`       | Google OAuth2 token management — file-based credentials, auto-refresh, persistence                                          |
-| `assay.email_triage` | Email classification — deterministic rules + optional LLM-assisted triage via OpenClaw                                      |
+| Module               | Description                                                                                                                                                                                                                                                                     |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `assay.prometheus`   | Query metrics, alerts, targets, rules, label values, series                                                                                                                                                                                                                     |
+| `assay.alertmanager` | Manage alerts, silences, receivers, config                                                                                                                                                                                                                                      |
+| `assay.loki`         | Push logs, query, labels, series                                                                                                                                                                                                                                                |
+| `assay.grafana`      | Health, dashboards, datasources, annotations                                                                                                                                                                                                                                    |
+| `assay.k8s`          | 30+ resource types, CRDs, readiness checks                                                                                                                                                                                                                                      |
+| `assay.argocd`       | Apps, sync, health, projects, repositories                                                                                                                                                                                                                                      |
+| `assay.kargo`        | Stages, freight, promotions, verification                                                                                                                                                                                                                                       |
+| `assay.flux`         | GitRepositories, Kustomizations, HelmReleases                                                                                                                                                                                                                                   |
+| `assay.traefik`      | Routers, services, middlewares, entrypoints                                                                                                                                                                                                                                     |
+| `assay.vault`        | KV secrets, policies, auth, transit, PKI                                                                                                                                                                                                                                        |
+| `assay.openbao`      | Alias for vault (API-compatible)                                                                                                                                                                                                                                                |
+| `assay.certmanager`  | Certificates, issuers, ACME challenges                                                                                                                                                                                                                                          |
+| `assay.eso`          | ExternalSecrets, SecretStores, ClusterSecretStores                                                                                                                                                                                                                              |
+| `assay.dex`          | OIDC discovery, JWKS, health                                                                                                                                                                                                                                                    |
+| `assay.zitadel`      | OIDC identity management with JWT machine auth                                                                                                                                                                                                                                  |
+| `assay.ory.kratos`   | Ory Kratos identity — login/registration/recovery/settings flows, identities, sessions, schemas                                                                                                                                                                                 |
+| `assay.ory.hydra`    | Ory Hydra OAuth2/OIDC — clients, authorize URLs, tokens, login/consent, introspection, JWKs                                                                                                                                                                                     |
+| `assay.ory.keto`     | Ory Keto ReBAC — relation tuples, permission checks, role/group membership, expand                                                                                                                                                                                              |
+| `assay.ory.rbac`     | Capability-based RBAC engine over Keto — define roles + capabilities, query users, manage memberships, separation of duties                                                                                                                                                     |
+| `assay.ory`          | Convenience wrapper re-exporting kratos/hydra/keto/rbac with `ory.connect(opts)`                                                                                                                                                                                                |
+| `assay.crossplane`   | Providers, XRDs, compositions, managed resources                                                                                                                                                                                                                                |
+| `assay.velero`       | Backups, restores, schedules, storage locations                                                                                                                                                                                                                                 |
+| `assay.harbor`       | Projects, repositories, artifacts, vulnerability scanning                                                                                                                                                                                                                       |
+| `assay.workflow`     | Workflow engine client — define workflows/activities + listen as worker; or full management surface (list/start/signal/cancel/terminate/state/events/children/continue-as-new plus `.schedules`/`.namespaces`/`.workers`/`.queues` sub-tables). See `docs/modules/workflow.md`. |
+| `assay.healthcheck`  | HTTP checks, JSON path, body matching, latency, multi-check                                                                                                                                                                                                                     |
+| `assay.s3`           | S3-compatible storage (AWS, R2, MinIO) with Sig V4                                                                                                                                                                                                                              |
+| `assay.postgres`     | Postgres-specific helpers                                                                                                                                                                                                                                                       |
+| `assay.unleash`      | Feature flags: projects, environments, features, strategies, API tokens                                                                                                                                                                                                         |
+| `assay.openclaw`     | OpenClaw AI agent platform — invoke tools, state, diff, approve, LLM tasks                                                                                                                                                                                                      |
+| `assay.gitlab`       | GitLab REST API v4 — projects, repos, commits, MRs, pipelines, issues, registry                                                                                                                                                                                                 |
+| `assay.github`       | GitHub REST API — PRs, issues, actions, repos, GraphQL                                                                                                                                                                                                                          |
+| `assay.gmail`        | Gmail REST API with OAuth2 — search, read, reply, send, labels                                                                                                                                                                                                                  |
+| `assay.gcal`         | Google Calendar REST API with OAuth2 — events CRUD, calendar list                                                                                                                                                                                                               |
+| `assay.oauth2`       | Google OAuth2 token management — file-based credentials, auto-refresh, persistence                                                                                                                                                                                              |
+| `assay.email_triage` | Email classification — deterministic rules + optional LLM-assisted triage via OpenClaw                                                                                                                                                                                          |
 
 ### Client Pattern
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,6 +176,32 @@ All notable changes to Assay are documented here.
   for your shell). Buffered and graceful on SIGPIPE so piping to `head` doesn't panic. Adds one new
   crate dep: `clap_complete`.
 
+- **Tier-1 dashboard mutations.** The built-in dashboard at `/workflow/` was read-only in v0.11.1;
+  every existing view now pairs with its matching operator control:
+
+  - **Workflows view** — new `+ Start workflow` inline form (type / id / task_queue / input JSON /
+    search_attributes JSON); per-row Signal / Cancel / Terminate; search-attributes filter in the
+    toolbar (debounced, with client-side JSON validation).
+  - **Workflow detail panel** — Signal, Cancel, Terminate, and Continue-as-new buttons, all with
+    toast feedback. "Live state" card renders the latest snapshot written by `ctx:register_query`
+    handlers (with the event seq and timestamp the snapshot was taken at).
+  - **Schedules view** — per-row Edit (PATCH form pre-filled with the schedule's values), Pause /
+    Resume toggle, Delete. Create form picks up a Timezone field.
+  - **Settings view** — Engine Info card shows the engine version + build profile, fetched from
+    `/api/v1/version`. Namespace create / delete upgraded to toast feedback and refreshes the
+    sidebar namespace switcher.
+  - Shared `toast()` + `apiFetchRaw()` helpers exposed via the component context for consistent
+    success/error feedback across every mutation.
+
+  Explicitly tier 1 — no in-browser workflow authoring, no batch operations, no reset-to-event, no
+  in-browser RBAC. Those are tier 2 / tier 3 and deferred to later releases.
+
+- **`GET /api/v1/version` endpoint.** Returns `{ version, build_profile }`. The CLI passes its own
+  `CARGO_PKG_VERSION` to `assay_workflow::api::serve_with_version`, so the field reflects the
+  user-facing binary (e.g. `0.11.3`) and not the internal `assay-workflow` crate version. Embedders
+  using plain `serve` get the crate version as a fallback. `AppState` gains a
+  `binary_version: Option<&'static str>` field.
+
 ### Changed
 
 - **`Engine::start_workflow` signature** gains a `search_attributes: Option<&str>` parameter (for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,18 +19,18 @@ All notable changes to Assay are documented here.
   entirely when no handlers are registered. A handler that raises is dropped from the snapshot
   rather than crashing the workflow (queries are best-effort read-through).
 
-- **`ctx:continue_as_new`** — Lua surface for the engine-level `continue_as_new` REST endpoint
-  that already existed. Workflows yield a `ContinueAsNew` command and the engine closes out the
-  current run, starts a fresh one with the same type / namespace / task_queue under
-  `{id}-continued-{ts}` with the caller-supplied input and empty event history. Standard pattern
-  for unbounded-loop workflows (pollers, schedulers) whose event log would otherwise grow forever.
+- **`ctx:continue_as_new`** — Lua surface for the engine-level `continue_as_new` REST endpoint that
+  already existed. Workflows yield a `ContinueAsNew` command and the engine closes out the current
+  run, starts a fresh one with the same type / namespace / task_queue under `{id}-continued-{ts}`
+  with the caller-supplied input and empty event history. Standard pattern for unbounded-loop
+  workflows (pollers, schedulers) whose event log would otherwise grow forever.
 
-- **`ctx:execute_parallel`** — Run multiple activities concurrently from a single handler run.
-  The worker yields a batch of `ScheduleActivity` commands; the engine schedules them
-  idempotently on `(workflow_id, seq)`. Each completion re-dispatches the workflow, replay
-  cache-hits for completed activities and re-yields the rest (no-op at the store layer). The
-  handler proceeds past the call only when every activity has a terminal event. Per-activity
-  retry / timeout opts match `ctx:execute_activity`.
+- **`ctx:execute_parallel`** — Run multiple activities concurrently from a single handler run. The
+  worker yields a batch of `ScheduleActivity` commands; the engine schedules them idempotently on
+  `(workflow_id, seq)`. Each completion re-dispatches the workflow, replay cache-hits for completed
+  activities and re-yields the rest (no-op at the store layer). The handler proceeds past the call
+  only when every activity has a terminal event. Per-activity retry / timeout opts match
+  `ctx:execute_activity`.
 
   ```lua
   local results = ctx:execute_parallel({
@@ -43,20 +43,19 @@ All notable changes to Assay are documented here.
 
 - **`ctx:upsert_search_attributes`** + **search attributes on workflows** — Workflows gain a
   `search_attributes` JSON object settable at start (`POST /workflows` body) and updatable at
-  runtime (`ctx:upsert_search_attributes({ … })`). The list endpoint accepts a
-  URL-encoded JSON filter that matches workflows whose attributes contain every listed key at
-  the given value:
+  runtime (`ctx:upsert_search_attributes({ … })`). The list endpoint accepts a URL-encoded JSON
+  filter that matches workflows whose attributes contain every listed key at the given value:
 
   ```
   GET /api/v1/workflows?search_attrs=%7B%22env%22%3A%22prod%22%7D
   ```
 
-  SQLite uses `json_extract`; Postgres uses `(search_attributes::jsonb)->>'key'`. Filters
-  AND-join. Unchanged keys are preserved across upserts.
+  SQLite uses `json_extract`; Postgres uses `(search_attributes::jsonb)->>'key'`. Filters AND-join.
+  Unchanged keys are preserved across upserts.
 
 - **Schedule `PATCH` / `pause` / `resume`** — Schedules can be updated in place without a
-  delete-and-recreate. Only fields present on the patch are touched; unchanged fields keep
-  their existing values.
+  delete-and-recreate. Only fields present on the patch are touched; unchanged fields keep their
+  existing values.
 
   ```
   PATCH /api/v1/schedules/{name}  body: { cron_expr?, timezone?, input?, task_queue?, overlap_policy? }
@@ -64,39 +63,76 @@ All notable changes to Assay are documented here.
   POST  /api/v1/schedules/{name}/resume
   ```
 
-  Paused schedules are skipped by the scheduler; resume recomputes `next_run_at` from now and
-  does not backfill missed fires. Updates take effect within a scheduler tick (≤15s).
+  Paused schedules are skipped by the scheduler; resume recomputes `next_run_at` from now and does
+  not backfill missed fires. Updates take effect within a scheduler tick (≤15s).
 
 - **Cron timezone** — Schedules gain a `timezone` field (IANA name, e.g. `"Europe/Berlin"`,
   `"America/New_York"`). Default `"UTC"` preserves v0.11.2 behaviour. The scheduler parses the
-  timezone via `chrono-tz` and evaluates the cron expression in that zone, then persists the
-  UTC epoch as `next_run_at`. Invalid names are rejected at create / patch time.
+  timezone via `chrono-tz` and evaluates the cron expression in that zone, then persists the UTC
+  epoch as `next_run_at`. Invalid names are rejected at create / patch time.
 
 - **Optional S3 archival for completed workflows** — Behind the `s3-archival` cargo feature
-  (default-off). When compiled in and `ASSAY_ARCHIVE_S3_BUCKET` is set at runtime, a background
-  task periodically finds workflows in terminal states older than
-  `ASSAY_ARCHIVE_RETENTION_DAYS` (default 30), bundles `{workflow_record, events}` as JSON,
-  uploads to `s3://bucket/prefix/<namespace>/<workflow_id>.json`, and purges dependent rows
-  (events, activities, timers, signals, snapshots). The workflow row itself is retained with
-  `archived_at` + `archive_uri` set so `GET /workflows/{id}` still resolves with a pointer to
-  the cold-storage bundle.
+  (default-off). When compiled in and `ASSAY_ARCHIVE_S3_BUCKET` is set at runtime, a background task
+  periodically finds workflows in terminal states older than `ASSAY_ARCHIVE_RETENTION_DAYS` (default
+  30), bundles `{workflow_record, events}` as JSON, uploads to
+  `s3://bucket/prefix/<namespace>/<workflow_id>.json`, and purges dependent rows (events,
+  activities, timers, signals, snapshots). The workflow row itself is retained with `archived_at` +
+  `archive_uri` set so `GET /workflows/{id}` still resolves with a pointer to the cold-storage
+  bundle.
 
   Credentials resolve via the AWS SDK's default chain — env vars, shared config, or IRSA /
-  pod-identity via web-identity token. Other env vars:
-  `ASSAY_ARCHIVE_S3_PREFIX` (default `assay/`), `ASSAY_ARCHIVE_POLL_SECS` (default 3600),
-  `ASSAY_ARCHIVE_BATCH_SIZE` (default 50).
+  pod-identity via web-identity token. Other env vars: `ASSAY_ARCHIVE_S3_PREFIX` (default `assay/`),
+  `ASSAY_ARCHIVE_POLL_SECS` (default 3600), `ASSAY_ARCHIVE_BATCH_SIZE` (default 50).
+
+- **`assay.workflow` Lua stdlib — full management surface.** The stdlib now covers every REST
+  endpoint the engine exposes, so Lua scripts (including CC and Kubernetes Jobs running
+  `assay run seed.lua`) can manage workflows, schedules, namespaces, workers, and queues without
+  hand-rolling HTTP calls. New top-level functions:
+
+  ```
+  workflow.list(opts)              workflow.list_children(id)
+  workflow.terminate(id, reason)   workflow.continue_as_new(id, input)
+  workflow.get_events(id)          workflow.get_state(id, name?)
+  ```
+
+  New sub-tables (each exposes `create / list / describe / patch / pause / resume / delete` as
+  applicable):
+
+  ```
+  workflow.schedules   workflow.namespaces   workflow.workers   workflow.queues
+  ```
+
+  Every function is a thin HTTP wrapper returning the parsed JSON response (or `nil` on a 404 for
+  `describe`/`get_state`), raising on other non-2xx responses.
+
+- **`assay workflow` and `assay schedule` CLI subcommands.** The stubs registered in v0.11.1 and
+  shipped as "not yet implemented" in v0.11.2 are replaced with real REST client implementations.
+  Covers every subcommand already in the parser
+  (`workflow list / describe /
+  signal / cancel / terminate`,
+  `schedule list / create / pause / resume / delete`) plus three v0.11.3-feature extensions:
+
+  - `assay workflow state <id> [<query-name>]` — reads the latest `register_query` snapshot
+  - `assay schedule patch <name> …` — in-place schedule updates
+  - `assay schedule create --timezone <tz>` — timezone flag on create
+
+  Global flags, all env-backed: `--engine-url` / `ASSAY_ENGINE_URL` (default
+  `http://127.0.0.1:8080`), `--api-key` / `ASSAY_API_KEY` (bearer token forwarded as
+  `Authorization: Bearer <value>`), `--namespace` / `ASSAY_NAMESPACE` (default `main`). Exit 0 on
+  success, 1 on HTTP error / unreachable engine / bad JSON. No `--output json` flag — scripts use
+  the Lua stdlib; humans read the tables.
 
 ### Changed
 
-- **`Engine::start_workflow` signature** gains a `search_attributes: Option<&str>` parameter
-  (for embedders using the crate directly). REST callers are unaffected; the field is optional
-  on `StartWorkflowRequest`.
+- **`Engine::start_workflow` signature** gains a `search_attributes: Option<&str>` parameter (for
+  embedders using the crate directly). REST callers are unaffected; the field is optional on
+  `StartWorkflowRequest`.
 
 - **`WorkflowStore::list_workflows` signature** gains a `search_attrs_filter: Option<&str>`
   parameter (for embedders).
 
-- **`WorkflowSchedule`** struct gains a `timezone: String` field. Deserialisers that accept the
-  type from an older v0.11.2 engine will need to tolerate the missing field (default "UTC").
+- **`WorkflowSchedule`** struct gains a `timezone: String` field. Deserialisers that accept the type
+  from an older v0.11.2 engine will need to tolerate the missing field (default "UTC").
 
 - **`WorkflowRecord`** struct gains `search_attributes`, `archived_at`, `archive_uri` fields.
 
@@ -108,12 +144,14 @@ All notable changes to Assay are documented here.
 ### Notes
 
 - Schema migrations for new columns are idempotent on both backends: Postgres uses
-  `ADD COLUMN IF NOT EXISTS`; SQLite uses a `pragma_table_info` pre-check before `ALTER TABLE
-  ADD COLUMN`. Fresh installs get the column from `CREATE TABLE` and the ALTER is a no-op.
-- Parallel activities are still best-effort in the sense that each completion triggers a
-  replay; deeply parallel fan-outs generate O(N²) idempotent `schedule_activity` calls. The
-  store-level idempotency makes this correct but not minimal; a follow-up can short-circuit
-  re-yields for already-scheduled seqs.
+  `ADD COLUMN IF NOT EXISTS`; SQLite uses a `pragma_table_info` pre-check before
+  `ALTER TABLE
+  ADD COLUMN`. Fresh installs get the column from `CREATE TABLE` and the ALTER is a
+  no-op.
+- Parallel activities are still best-effort in the sense that each completion triggers a replay;
+  deeply parallel fan-outs generate O(N²) idempotent `schedule_activity` calls. The store-level
+  idempotency makes this correct but not minimal; a follow-up can short-circuit re-yields for
+  already-scheduled seqs.
 
 ## [0.11.2] - 2026-04-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -224,11 +224,14 @@ All notable changes to Assay are documented here.
 
 ### Notes
 
-- Schema migrations for new columns are idempotent on both backends: Postgres uses
-  `ADD COLUMN IF NOT EXISTS`; SQLite uses a `pragma_table_info` pre-check before
-  `ALTER TABLE
-  ADD COLUMN`. Fresh installs get the column from `CREATE TABLE` and the ALTER is a
-  no-op.
+- **No migrations from v0.11.2.** The engine is pre-1.0 and no v0.11.x release has been deployed
+  against a real workload yet, so all v0.11.3 columns (`search_attributes`, `archived_at`,
+  `archive_uri` on `workflows`; `timezone` on `workflow_schedules`) live in the baseline
+  `CREATE TABLE` statements only. A fresh DB picks them up automatically; an existing v0.11.2 DB
+  needs to be recreated. The migration plumbing is kept in place for post-v0.11.3 additive
+  migrations — Postgres does `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` natively, SQLite has a
+  dormant `add_column_if_missing` helper that pragma-checks before ALTER. The pattern is documented
+  at the bottom of each store's `SCHEMA` constant / `migrate()` fn.
 - Parallel activities are still best-effort in the sense that each completion triggers a replay;
   deeply parallel fan-outs generate O(N²) idempotent `schedule_activity` calls. The store-level
   idempotency makes this correct but not minimal; a follow-up can short-circuit re-yields for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,119 @@
 
 All notable changes to Assay are documented here.
 
+## [0.11.3] - 2026-04-16
+
+### Added
+
+- **`ctx:register_query`** — Lua workflows can expose live application-level state to external
+  callers via named query handlers. After every worker replay the engine persists a snapshot of
+  every handler's result; two new REST endpoints surface it:
+
+  ```
+  GET /api/v1/workflows/{id}/state         → latest full snapshot
+  GET /api/v1/workflows/{id}/state/{name}  → one handler's value
+  ```
+
+  Workflows that don't call `register_query` pay nothing — the worker skips the snapshot command
+  entirely when no handlers are registered. A handler that raises is dropped from the snapshot
+  rather than crashing the workflow (queries are best-effort read-through).
+
+- **`ctx:continue_as_new`** — Lua surface for the engine-level `continue_as_new` REST endpoint
+  that already existed. Workflows yield a `ContinueAsNew` command and the engine closes out the
+  current run, starts a fresh one with the same type / namespace / task_queue under
+  `{id}-continued-{ts}` with the caller-supplied input and empty event history. Standard pattern
+  for unbounded-loop workflows (pollers, schedulers) whose event log would otherwise grow forever.
+
+- **`ctx:execute_parallel`** — Run multiple activities concurrently from a single handler run.
+  The worker yields a batch of `ScheduleActivity` commands; the engine schedules them
+  idempotently on `(workflow_id, seq)`. Each completion re-dispatches the workflow, replay
+  cache-hits for completed activities and re-yields the rest (no-op at the store layer). The
+  handler proceeds past the call only when every activity has a terminal event. Per-activity
+  retry / timeout opts match `ctx:execute_activity`.
+
+  ```lua
+  local results = ctx:execute_parallel({
+      { name = "check_a", input = { id = 1 } },
+      { name = "check_b", input = { id = 2 }, opts = { max_attempts = 5 } },
+      { name = "check_c", input = { id = 3 } },
+  })
+  -- results[1], [2], [3] in input order; raises if any fail after retries.
+  ```
+
+- **`ctx:upsert_search_attributes`** + **search attributes on workflows** — Workflows gain a
+  `search_attributes` JSON object settable at start (`POST /workflows` body) and updatable at
+  runtime (`ctx:upsert_search_attributes({ … })`). The list endpoint accepts a
+  URL-encoded JSON filter that matches workflows whose attributes contain every listed key at
+  the given value:
+
+  ```
+  GET /api/v1/workflows?search_attrs=%7B%22env%22%3A%22prod%22%7D
+  ```
+
+  SQLite uses `json_extract`; Postgres uses `(search_attributes::jsonb)->>'key'`. Filters
+  AND-join. Unchanged keys are preserved across upserts.
+
+- **Schedule `PATCH` / `pause` / `resume`** — Schedules can be updated in place without a
+  delete-and-recreate. Only fields present on the patch are touched; unchanged fields keep
+  their existing values.
+
+  ```
+  PATCH /api/v1/schedules/{name}  body: { cron_expr?, timezone?, input?, task_queue?, overlap_policy? }
+  POST  /api/v1/schedules/{name}/pause
+  POST  /api/v1/schedules/{name}/resume
+  ```
+
+  Paused schedules are skipped by the scheduler; resume recomputes `next_run_at` from now and
+  does not backfill missed fires. Updates take effect within a scheduler tick (≤15s).
+
+- **Cron timezone** — Schedules gain a `timezone` field (IANA name, e.g. `"Europe/Berlin"`,
+  `"America/New_York"`). Default `"UTC"` preserves v0.11.2 behaviour. The scheduler parses the
+  timezone via `chrono-tz` and evaluates the cron expression in that zone, then persists the
+  UTC epoch as `next_run_at`. Invalid names are rejected at create / patch time.
+
+- **Optional S3 archival for completed workflows** — Behind the `s3-archival` cargo feature
+  (default-off). When compiled in and `ASSAY_ARCHIVE_S3_BUCKET` is set at runtime, a background
+  task periodically finds workflows in terminal states older than
+  `ASSAY_ARCHIVE_RETENTION_DAYS` (default 30), bundles `{workflow_record, events}` as JSON,
+  uploads to `s3://bucket/prefix/<namespace>/<workflow_id>.json`, and purges dependent rows
+  (events, activities, timers, signals, snapshots). The workflow row itself is retained with
+  `archived_at` + `archive_uri` set so `GET /workflows/{id}` still resolves with a pointer to
+  the cold-storage bundle.
+
+  Credentials resolve via the AWS SDK's default chain — env vars, shared config, or IRSA /
+  pod-identity via web-identity token. Other env vars:
+  `ASSAY_ARCHIVE_S3_PREFIX` (default `assay/`), `ASSAY_ARCHIVE_POLL_SECS` (default 3600),
+  `ASSAY_ARCHIVE_BATCH_SIZE` (default 50).
+
+### Changed
+
+- **`Engine::start_workflow` signature** gains a `search_attributes: Option<&str>` parameter
+  (for embedders using the crate directly). REST callers are unaffected; the field is optional
+  on `StartWorkflowRequest`.
+
+- **`WorkflowStore::list_workflows` signature** gains a `search_attrs_filter: Option<&str>`
+  parameter (for embedders).
+
+- **`WorkflowSchedule`** struct gains a `timezone: String` field. Deserialisers that accept the
+  type from an older v0.11.2 engine will need to tolerate the missing field (default "UTC").
+
+- **`WorkflowRecord`** struct gains `search_attributes`, `archived_at`, `archive_uri` fields.
+
+### Fixed
+
+- Removed three pre-existing `clippy::map_identity` warnings in orchestration test helpers so
+  `cargo clippy --tests -- -D warnings` stays clean under rust 1.92 / clippy 1.91.
+
+### Notes
+
+- Schema migrations for new columns are idempotent on both backends: Postgres uses
+  `ADD COLUMN IF NOT EXISTS`; SQLite uses a `pragma_table_info` pre-check before `ALTER TABLE
+  ADD COLUMN`. Fresh installs get the column from `CREATE TABLE` and the ALTER is a no-op.
+- Parallel activities are still best-effort in the sense that each completion triggers a
+  replay; deeply parallel fan-outs generate O(N²) idempotent `schedule_activity` calls. The
+  store-level idempotency makes this correct but not minimal; a follow-up can short-circuit
+  re-yields for already-scheduled seqs.
+
 ## [0.11.2] - 2026-04-16
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,9 +105,10 @@ All notable changes to Assay are documented here.
   Every function is a thin HTTP wrapper returning the parsed JSON response (or `nil` on a 404 for
   `describe`/`get_state`), raising on other non-2xx responses.
 
-- **Full CLI for the workflow engine.** The stubs registered in v0.11.1 and shipped as "not yet
-  implemented" in v0.11.2 are replaced with real REST-client implementations, plus a considerable
-  expansion. Everything visible in `assay --help` actually runs.
+- **Full CLI for the workflow engine.** The clap-registered `assay workflow …` / `assay schedule …`
+  subcommands that through v0.11.2 printed "not yet implemented" and exited 1 are replaced with real
+  REST-client implementations, plus a considerable expansion. Everything visible in `assay --help`
+  actually runs.
 
   **Subcommand trees:**
 
@@ -176,8 +177,8 @@ All notable changes to Assay are documented here.
   for your shell). Buffered and graceful on SIGPIPE so piping to `head` doesn't panic. Adds one new
   crate dep: `clap_complete`.
 
-- **Tier-1 dashboard mutations.** The built-in dashboard at `/workflow/` was read-only in v0.11.1;
-  every existing view now pairs with its matching operator control:
+- **Tier-1 dashboard mutations.** The built-in dashboard at `/workflow/` was read-only through
+  v0.11.2; every existing view now pairs with its matching operator control:
 
   - **Workflows view** — new `+ Start workflow` inline form (type / id / task_queue / input JSON /
     search_attributes JSON); per-row Signal / Cancel / Terminate; search-attributes filter in the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,22 +105,76 @@ All notable changes to Assay are documented here.
   Every function is a thin HTTP wrapper returning the parsed JSON response (or `nil` on a 404 for
   `describe`/`get_state`), raising on other non-2xx responses.
 
-- **`assay workflow` and `assay schedule` CLI subcommands.** The stubs registered in v0.11.1 and
-  shipped as "not yet implemented" in v0.11.2 are replaced with real REST client implementations.
-  Covers every subcommand already in the parser
-  (`workflow list / describe /
-  signal / cancel / terminate`,
-  `schedule list / create / pause / resume / delete`) plus three v0.11.3-feature extensions:
+- **Full CLI for the workflow engine.** The stubs registered in v0.11.1 and shipped as "not yet
+  implemented" in v0.11.2 are replaced with real REST-client implementations, plus a considerable
+  expansion. Everything visible in `assay --help` actually runs.
 
-  - `assay workflow state <id> [<query-name>]` — reads the latest `register_query` snapshot
-  - `assay schedule patch <name> …` — in-place schedule updates
-  - `assay schedule create --timezone <tz>` — timezone flag on create
+  **Subcommand trees:**
 
-  Global flags, all env-backed: `--engine-url` / `ASSAY_ENGINE_URL` (default
-  `http://127.0.0.1:8080`), `--api-key` / `ASSAY_API_KEY` (bearer token forwarded as
-  `Authorization: Bearer <value>`), `--namespace` / `ASSAY_NAMESPACE` (default `main`). Exit 0 on
-  success, 1 on HTTP error / unreachable engine / bad JSON. No `--output json` flag — scripts use
-  the Lua stdlib; humans read the tables.
+  ```
+  assay workflow
+    start --type T [--id ID] [--input JSON] [--queue Q] [--search-attrs JSON]
+    list [--status S] [--type T] [--search-attrs JSON] [--limit N]
+    describe <id>
+    state <id> [<query-name>]                   # register_query reader
+    events <id> [--follow]                      # log, or poll-stream until terminal
+    children <id>
+    signal <id> <name> [payload-as-json-or-@file-or--]
+    cancel <id>
+    terminate <id> [--reason R]
+    continue-as-new <id> [--input JSON]         # client-side
+    wait <id> [--timeout SECS] [--target STATUS]  # exit 0/1/2 for scripts
+
+  assay schedule
+    list
+    describe <name>
+    create <name> --type T --cron EXPR [--timezone TZ] [--input JSON] [--queue Q]
+    patch <name> [--cron EXPR] [--timezone TZ] [--input JSON] [--queue Q] [--overlap POLICY]
+    pause <name>
+    resume <name>
+    delete <name>
+
+  assay namespace   create | list | describe | delete
+  assay worker      list
+  assay queue       stats
+  assay completion  <bash|zsh|fish|powershell|elvish>
+  ```
+
+  **Global options** (all flag-backed, env-backed, and config-file-backed, resolved in that
+  precedence order):
+
+  - `--engine-url` / `ASSAY_ENGINE_URL` (default `http://127.0.0.1:8080`)
+  - `--api-key` / `ASSAY_API_KEY` (bearer token, forwarded as `Authorization: Bearer <value>`)
+  - `--namespace` / `ASSAY_NAMESPACE` (default `main`)
+  - `--output` / `ASSAY_OUTPUT` — `table` | `json` | `jsonl` | `yaml`; TTY-adaptive default (`table`
+    on a terminal, `json` when stdout is piped)
+  - `--config` / `ASSAY_CONFIG_FILE` — YAML config file, discovered in this order: flag → env →
+    `$XDG_CONFIG_HOME/assay/config.yaml` → `~/.config/assay/config.yaml` → `/etc/assay/config.yaml`
+
+  **Config file** (every field optional):
+
+  ```yaml
+  engine_url: https://assay.example.com
+  api_key_file: /run/secrets/assay-api-key # preferred over `api_key:`
+  namespace: main
+  output: table
+  ```
+
+  `api_key_file` reads the file contents, trims whitespace, and uses that as the bearer token. Lets
+  the config live in a ConfigMap with the credential in a separate Secret.
+
+  **JSON input indirection.** `--input`, `--search-attrs`, and signal payload args accept:
+
+  - a literal JSON string (`'{"n":1}'`)
+  - `@PATH` — read the file and parse
+  - `-` — read stdin and parse
+
+  **Exit codes:** 0 success, 1 HTTP error / unreachable / not-found, 2 `workflow wait` timeout, 64
+  usage error (bad JSON input).
+
+  **Shell completion.** `assay completion <shell> > /etc/bash_completion.d/assay` (or the equivalent
+  for your shell). Buffered and graceful on SIGPIPE so piping to `head` doesn't panic. Adds one new
+  crate dep: `clap_complete`.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,11 +91,11 @@ dependencies = [
  "axum",
  "clap",
  "data-encoding",
- "digest",
+ "digest 0.10.7",
  "futures-util",
  "glob",
  "http-body-util",
- "hyper",
+ "hyper 1.8.1",
  "hyper-util",
  "include_dir",
  "jsonwebtoken",
@@ -109,7 +109,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yml",
- "sha2",
+ "sha2 0.10.9",
  "sha3",
  "sqlx",
  "tokio",
@@ -129,6 +129,8 @@ name = "assay-workflow"
 version = "0.1.1"
 dependencies = [
  "anyhow",
+ "aws-config",
+ "aws-sdk-s3",
  "axum",
  "chrono",
  "chrono-tz",
@@ -140,7 +142,7 @@ dependencies = [
  "rsa",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sqlx",
  "tempfile",
  "testcontainers",
@@ -232,6 +234,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-config"
+version = "1.8.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11493b0bad143270fb8ad284a096dd529ba91924c5409adeac856cc1bf047dbc"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sdk-sso",
+ "aws-sdk-ssooidc",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "http 1.4.0",
+ "sha1 0.10.6",
+ "time",
+ "tokio",
+ "tracing",
+ "url",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-credential-types"
+version = "1.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f20799b373a1be121fe3005fba0c2090af9411573878f224df44b42727fcaf7"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
+
+[[package]]
 name = "aws-lc-rs"
 version = "1.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -254,6 +298,396 @@ dependencies = [
 ]
 
 [[package]]
+name = "aws-runtime"
+version = "1.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc0651c57e384202e47153c1260b84a9936e19803d747615edf199dc3b98d17"
+dependencies = [
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "bytes-utils",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "aws-sdk-s3"
+version = "1.129.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d4e8410fadbc0ee453145dd77a4958227b18b05bf67c2795d0a8b8596c9aa0f"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-checksums",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "lru",
+ "percent-encoding",
+ "regex-lite",
+ "sha2 0.10.9",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "1.97.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aadc669e184501caaa6beafb28c6267fc1baef0810fb58f9b205485ca3f2567"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-ssooidc"
+version = "1.99.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1342a7db8f358d3de0aed2007a0b54e875458e39848d54cc1d46700b2bfcb0a8"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "1.101.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab41ad64e4051ecabeea802d6a17845a91e83287e1dd249e6963ea1ba78c428a"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-query",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "regex-lite",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0b660013a6683ab23797778e21f1f854744fdf05f68204b4cca4c8c04b5d1f4"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "crypto-bigint 0.5.5",
+ "form_urlencoded",
+ "hex",
+ "hmac",
+ "http 0.2.12",
+ "http 1.4.0",
+ "p256 0.11.1",
+ "percent-encoding",
+ "ring",
+ "sha2 0.10.9",
+ "subtle",
+ "time",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ffcaf626bdda484571968400c326a244598634dc75fd451325a54ad1a59acfc"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-checksums"
+version = "0.64.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10efbbcec1e044b81600e2fc562a391951d291152d95b482d5b7e7132299d762"
+dependencies = [
+ "aws-smithy-http",
+ "aws-smithy-types",
+ "bytes",
+ "crc-fast",
+ "hex",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "md-5 0.11.0",
+ "pin-project-lite",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-eventstream"
+version = "0.60.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf09d74e5e32f76b8762da505a3cd59303e367a664ca67295387baa8c1d7548"
+dependencies = [
+ "aws-smithy-types",
+ "bytes",
+ "crc32fast",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.63.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231"
+dependencies = [
+ "aws-smithy-eventstream",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-client"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a2f165a7feee6f263028b899d0a181987f4fa7179a6411a32a439fba7c5f769"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "h2 0.3.27",
+ "h2 0.4.13",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper 1.8.1",
+ "hyper-rustls 0.24.2",
+ "hyper-rustls 0.27.7",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls 0.21.12",
+ "rustls 0.23.36",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.62.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9648b0bb82a2eedd844052c6ad2a1a822d1f8e3adee5fbf668366717e428856a"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-observability"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06c2315d173edbf1920da8ba3a7189695827002e4c0fc961973ab1c54abca9c"
+dependencies = [
+ "aws-smithy-runtime-api",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.60.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a56d79744fb3edb5d722ef79d86081e121d3b9422cb209eb03aea6aa4f21ebd"
+dependencies = [
+ "aws-smithy-types",
+ "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0504b1ab12debb5959e5165ee5fe97dd387e7aa7ea6a477bfd7635dfe769a4f5"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-http-client",
+ "aws-smithy-observability",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pin-project-lite",
+ "pin-utils",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b71a13df6ada0aafbf21a73bdfcdf9324cfa9df77d96b8446045be3cde61b42e"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api-macros",
+ "aws-smithy-types",
+ "bytes",
+ "http 0.2.12",
+ "http 1.4.0",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api-macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d7396fd9500589e62e460e987ecb671bad374934e55ec3b5f498cc7a8a8a7b7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d73dbfbaa8e4bc57b9045137680b958d274823509a360abfd8e1d514d40c95c"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.60.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce02add1aa3677d022f8adf81dcbe3046a95f17a1b1e8979c145cd21d3d22b3"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47c8323699dd9b3c8d5b3c13051ae9cdef58fd179957c882f8374dd8725962d9"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "rustc_version",
+ "tracing",
+]
+
+[[package]]
 name = "axum"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -263,10 +697,10 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.8.1",
  "hyper-util",
  "itoa",
  "matchit",
@@ -294,8 +728,8 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -304,6 +738,12 @@ dependencies = [
  "tower-service",
  "tracing",
 ]
+
+[[package]]
+name = "base16ct"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349a06037c7bf932dd7e7d1f653678b2038b9ad46a74102f1fc7bd7872678cce"
 
 [[package]]
 name = "base16ct"
@@ -322,6 +762,16 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
 
 [[package]]
 name = "base64ct"
@@ -348,6 +798,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "bollard"
 version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -363,18 +822,18 @@ dependencies = [
  "futures-util",
  "hex",
  "home",
- "http",
+ "http 1.4.0",
  "http-body-util",
- "hyper",
+ "hyper 1.8.1",
  "hyper-named-pipe",
- "hyper-rustls",
+ "hyper-rustls 0.27.7",
  "hyper-util",
  "hyperlocal",
  "log",
  "num",
  "pin-project-lite",
  "rand 0.9.2",
- "rustls",
+ "rustls 0.23.36",
  "rustls-native-certs",
  "rustls-pki-types",
  "serde",
@@ -448,6 +907,16 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
+]
 
 [[package]]
 name = "cc"
@@ -593,6 +1062,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -628,9 +1103,9 @@ dependencies = [
 
 [[package]]
 name = "crc"
-version = "3.4.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
 dependencies = [
  "crc-catalog",
 ]
@@ -640,6 +1115,27 @@ name = "crc-catalog"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "crc-fast"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fd92aca2c6001b1bf5ba0ff84ee74ec8501b52bbef0cac80bf25a6c1d87a83d"
+dependencies = [
+ "crc",
+ "digest 0.10.7",
+ "rustversion",
+ "spin 0.10.0",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "cron"
@@ -670,6 +1166,18 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-bigint"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef2b4b23cddf68b89b8f8069890e8c270d54e2d5fe1b143820234805e4cb17ef"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "crypto-bigint"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
@@ -691,6 +1199,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -699,7 +1216,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -777,11 +1294,21 @@ checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "der"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
+dependencies = [
+ "const-oid 0.9.6",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
 version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -802,10 +1329,21 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.6",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -850,16 +1388,28 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "ecdsa"
+version = "0.14.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413301934810f597c1d19ca71c8710e99a3f1ba28a0d2ebc01551a2daeea3c5c"
+dependencies = [
+ "der 0.6.1",
+ "elliptic-curve 0.12.3",
+ "rfc6979 0.3.1",
+ "signature 1.6.4",
+]
+
+[[package]]
+name = "ecdsa"
 version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der",
- "digest",
- "elliptic-curve",
- "rfc6979",
- "signature",
- "spki",
+ "der 0.7.10",
+ "digest 0.10.7",
+ "elliptic-curve 0.13.8",
+ "rfc6979 0.4.0",
+ "signature 2.2.0",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -868,8 +1418,8 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8",
- "signature",
+ "pkcs8 0.10.2",
+ "signature 2.2.0",
 ]
 
 [[package]]
@@ -881,7 +1431,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "serde",
- "sha2",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -897,21 +1447,41 @@ dependencies = [
 
 [[package]]
 name = "elliptic-curve"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7bb888ab5300a19b8e5bceef25ac745ad065f3c9f7efc6de1b91958110891d3"
+dependencies = [
+ "base16ct 0.1.1",
+ "crypto-bigint 0.4.9",
+ "der 0.6.1",
+ "digest 0.10.7",
+ "ff 0.12.1",
+ "generic-array",
+ "group 0.12.1",
+ "pkcs8 0.9.0",
+ "rand_core 0.6.4",
+ "sec1 0.3.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "elliptic-curve"
 version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "base16ct",
- "crypto-bigint",
- "digest",
- "ff",
+ "base16ct 0.2.0",
+ "crypto-bigint 0.5.5",
+ "digest 0.10.7",
+ "ff 0.13.1",
  "generic-array",
- "group",
+ "group 0.13.0",
  "hkdf",
  "pem-rfc7468",
- "pkcs8",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
- "sec1",
+ "sec1 0.7.3",
  "subtle",
  "zeroize",
 ]
@@ -1000,6 +1570,16 @@ dependencies = [
 
 [[package]]
 name = "ff"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d013fc25338cc558c5c2cfbad646908fb23591e2404481826742b651c9af7160"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
@@ -1039,7 +1619,7 @@ checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
 dependencies = [
  "futures-core",
  "futures-sink",
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -1053,6 +1633,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -1238,13 +1824,43 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "group"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfbfb3a6cfbd390d5c9564ab283a0349b9b9fcd46a706c1eb10e0db70bfbac7"
+dependencies = [
+ "ff 0.12.1",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
- "ff",
+ "ff 0.13.1",
  "rand_core 0.6.4",
  "subtle",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap 2.13.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -1258,7 +1874,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.4.0",
  "indexmap 2.13.0",
  "slab",
  "tokio",
@@ -1280,7 +1896,7 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -1288,6 +1904,11 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -1331,7 +1952,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -1341,6 +1962,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
 ]
 
 [[package]]
@@ -1355,12 +1987,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -1371,8 +2014,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -1389,6 +2032,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
+name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1398,9 +2074,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.13",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -1418,7 +2094,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
 dependencies = [
  "hex",
- "hyper",
+ "hyper 1.8.1",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -1428,17 +2104,33 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "log",
+ "rustls 0.21.12",
+ "tokio",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
 version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http",
- "hyper",
+ "http 1.4.0",
+ "hyper 1.8.1",
  "hyper-util",
- "rustls",
+ "rustls 0.23.36",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tower-service",
 ]
 
@@ -1448,7 +2140,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper",
+ "hyper 1.8.1",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -1465,14 +2157,14 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "hyper 1.8.1",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.2",
  "tokio",
  "tower-service",
  "tracing",
@@ -1486,7 +2178,7 @@ checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
 dependencies = [
  "hex",
  "http-body-util",
- "hyper",
+ "hyper 1.8.1",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -1763,15 +2455,15 @@ dependencies = [
  "getrandom 0.2.17",
  "hmac",
  "js-sys",
- "p256",
+ "p256 0.13.2",
  "p384",
  "pem",
  "rand 0.8.5",
  "rsa",
  "serde",
  "serde_json",
- "sha2",
- "signature",
+ "sha2 0.10.9",
+ "signature 2.2.0",
  "simple_asn1",
 ]
 
@@ -1790,7 +2482,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -1871,6 +2563,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1917,7 +2618,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -2129,15 +2840,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
+name = "p256"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51f44edd08f51e2ade572f141051021c5af22677e42b7dd28a88155151c33594"
+dependencies = [
+ "ecdsa 0.14.8",
+ "elliptic-curve 0.12.3",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
 dependencies = [
- "ecdsa",
- "elliptic-curve",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2146,10 +2874,10 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
 dependencies = [
- "ecdsa",
- "elliptic-curve",
+ "ecdsa 0.16.9",
+ "elliptic-curve 0.13.8",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -2329,9 +3057,19 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
- "der",
- "pkcs8",
- "spki",
+ "der 0.7.10",
+ "pkcs8 0.10.2",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9eca2c590a5f85da82668fa685c09ce2888b9430e83299debf1f34b65fd4a4ba"
+dependencies = [
+ "der 0.6.1",
+ "spki 0.6.0",
 ]
 
 [[package]]
@@ -2340,8 +3078,8 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.10",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -2396,7 +3134,7 @@ version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
- "elliptic-curve",
+ "elliptic-curve 0.13.8",
 ]
 
 [[package]]
@@ -2471,8 +3209,8 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls",
- "socket2",
+ "rustls 0.23.36",
+ "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2492,7 +3230,7 @@ dependencies = [
  "rand 0.9.2",
  "ring",
  "rustc-hash",
- "rustls",
+ "rustls 0.23.36",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -2510,7 +3248,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -2689,18 +3427,18 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
- "hyper-rustls",
+ "hyper 1.8.1",
+ "hyper-rustls 0.27.7",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls",
+ "rustls 0.23.36",
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
@@ -2708,7 +3446,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tokio-util",
  "tower",
  "tower-http",
@@ -2718,6 +3456,17 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7743f17af12fa0b03b803ba12cd6a8d9483a587e89c69445e3909655c0b9fabb"
+dependencies = [
+ "crypto-bigint 0.4.9",
+ "hmac",
+ "zeroize",
 ]
 
 [[package]]
@@ -2750,16 +3499,16 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
  "pkcs1",
- "pkcs8",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
- "signature",
- "spki",
+ "signature 2.2.0",
+ "spki 0.7.3",
  "subtle",
  "zeroize",
 ]
@@ -2794,6 +3543,18 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
+]
+
+[[package]]
+name = "rustls"
 version = "0.23.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
@@ -2803,7 +3564,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.9",
  "subtle",
  "zeroize",
 ]
@@ -2841,10 +3602,10 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls",
+ "rustls 0.23.36",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki",
+ "rustls-webpki 0.103.9",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
@@ -2856,6 +3617,16 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "rustls-webpki"
@@ -2930,15 +3701,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "sec1"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be24c1842290c45df0a7bf069e0c268a747ad05a192f2fd7dcfdbc1cba40928"
+dependencies = [
+ "base16ct 0.1.1",
+ "der 0.6.1",
+ "generic-array",
+ "pkcs8 0.9.0",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
- "base16ct",
- "der",
+ "base16ct 0.2.0",
+ "der 0.7.10",
  "generic-array",
- "pkcs8",
+ "pkcs8 0.10.2",
  "subtle",
  "zeroize",
 ]
@@ -3122,7 +3917,18 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -3133,7 +3939,18 @@ checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.2",
 ]
 
 [[package]]
@@ -3142,7 +3959,7 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "keccak",
 ]
 
@@ -3173,11 +3990,21 @@ dependencies = [
 
 [[package]]
 name = "signature"
+version = "1.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "signature"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -3216,6 +4043,16 @@ dependencies = [
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
@@ -3234,13 +4071,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+
+[[package]]
+name = "spki"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67cf02bbac7a337dc36e4f5a693db6c21e7863f45070f7064577eb4367a3212b"
+dependencies = [
+ "base64ct",
+ "der 0.6.1",
+]
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
 ]
 
 [[package]]
@@ -3279,10 +4132,10 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rustls",
+ "rustls 0.23.36",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "thiserror 2.0.18",
  "tokio",
@@ -3320,7 +4173,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sqlx-core",
  "sqlx-mysql",
  "sqlx-postgres",
@@ -3342,7 +4195,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "crc",
- "digest",
+ "digest 0.10.7",
  "dotenvy",
  "either",
  "futures-channel",
@@ -3355,15 +4208,15 @@ dependencies = [
  "hmac",
  "itoa",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "memchr",
  "once_cell",
  "percent-encoding",
  "rand 0.8.5",
  "rsa",
  "serde",
- "sha1",
- "sha2",
+ "sha1 0.10.6",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -3394,13 +4247,13 @@ dependencies = [
  "home",
  "itoa",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "memchr",
  "once_cell",
  "rand 0.8.5",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -3544,7 +4397,7 @@ dependencies = [
  "etcetera 0.11.0",
  "ferroid",
  "futures",
- "http",
+ "http 1.4.0",
  "itertools",
  "log",
  "memchr",
@@ -3686,7 +4539,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -3704,11 +4557,21 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls",
+ "rustls 0.23.36",
  "tokio",
 ]
 
@@ -3743,10 +4606,10 @@ checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
- "rustls",
+ "rustls 0.23.36",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tungstenite",
  "webpki-roots 0.26.11",
 ]
@@ -3813,16 +4676,16 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bytes",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.13",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.8.1",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "socket2",
+ "socket2 0.6.2",
  "sync_wrapper",
  "tokio",
  "tokio-stream",
@@ -3871,8 +4734,8 @@ dependencies = [
  "bitflags",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
  "tower",
@@ -3982,13 +4845,13 @@ checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
  "bytes",
  "data-encoding",
- "http",
+ "http 1.4.0",
  "httparse",
  "log",
  "rand 0.9.2",
- "rustls",
+ "rustls 0.23.36",
  "rustls-pki-types",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 2.0.18",
  "utf-8",
 ]
@@ -4065,7 +4928,7 @@ dependencies = [
  "base64 0.22.1",
  "log",
  "percent-encoding",
- "rustls",
+ "rustls 0.23.36",
  "rustls-pki-types",
  "ureq-proto",
  "utf8-zero",
@@ -4078,7 +4941,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
 dependencies = [
  "base64 0.22.1",
- "http",
+ "http 1.4.0",
  "httparse",
  "log",
 ]
@@ -4095,6 +4958,12 @@ dependencies = [
  "serde",
  "serde_derive",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf-8"
@@ -4145,6 +5014,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid"
+version = "1.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4161,6 +5040,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "walkdir"
@@ -4788,9 +5673,9 @@ dependencies = [
  "base64 0.22.1",
  "deadpool",
  "futures",
- "http",
+ "http 1.4.0",
  "http-body-util",
- "hyper",
+ "hyper 1.8.1",
  "hyper-util",
  "log",
  "once_cell",
@@ -4904,6 +5789,12 @@ dependencies = [
  "libc",
  "rustix",
 ]
+
+[[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "yoke"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,6 +90,7 @@ dependencies = [
  "assay-workflow",
  "axum",
  "clap",
+ "clap_complete",
  "data-encoding",
  "digest 0.10.7",
  "futures-util",
@@ -112,6 +113,7 @@ dependencies = [
  "sha2 0.10.9",
  "sha3",
  "sqlx",
+ "tempfile",
  "tokio",
  "tokio-test",
  "tokio-tungstenite",
@@ -1001,6 +1003,15 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+]
+
+[[package]]
+name = "clap_complete"
+version = "4.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff7a1dccbdd8b078c2bdebff47e404615151534d5043da397ec50286816f9cb"
+dependencies = [
+ "clap",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -131,6 +131,7 @@ dependencies = [
  "anyhow",
  "axum",
  "chrono",
+ "chrono-tz",
  "cron",
  "data-encoding",
  "jsonwebtoken",
@@ -502,6 +503,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf 0.12.1",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -638,7 +649,7 @@ checksum = "089df96cf6a25253b4b6b6744d86f91150a3d4df546f31a95def47976b8cba97"
 dependencies = [
  "chrono",
  "once_cell",
- "phf",
+ "phf 0.11.3",
  "winnow",
 ]
 
@@ -2227,7 +2238,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
  "phf_macros",
- "phf_shared",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared 0.12.1",
 ]
 
 [[package]]
@@ -2236,7 +2256,7 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.11.3",
  "rand 0.8.5",
 ]
 
@@ -2247,7 +2267,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
  "syn",
@@ -2258,6 +2278,15 @@ name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
 dependencies = [
  "siphasher",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,7 @@ checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "assay-lua"
-version = "0.11.2"
+version = "0.11.3"
 dependencies = [
  "anyhow",
  "assay-workflow",
@@ -126,7 +126,7 @@ dependencies = [
 
 [[package]]
 name = "assay-workflow"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "aws-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ path = "src/lib.rs"
 default = ["db", "server", "cli", "workflow"]
 db = ["dep:sqlx"]
 server = ["dep:http-body-util", "dep:hyper", "dep:hyper-util"]
-cli = ["dep:clap", "dep:tracing-subscriber"]
+cli = ["dep:clap", "dep:clap_complete", "dep:tracing-subscriber"]
 workflow = ["dep:assay-workflow"]
 
 [dependencies]
@@ -45,6 +45,7 @@ serde_yml = "0.0.12"
 
 # CLI (optional — only needed for the assay binary)
 clap = { version = "4.5.57", features = ["derive", "env"], optional = true }
+clap_complete = { version = "4.5", optional = true }
 
 # Error handling
 anyhow = "1"
@@ -110,6 +111,7 @@ hyper-util = { version = "0.1", features = ["tokio"], optional = true }
 tower-http = { version = "0.6.8", features = ["cors", "trace"] }
 
 [dev-dependencies]
+tempfile = "3.27.0"
 tokio-test = "0.4"
 wiremock = "0.6.5"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "crates/assay-workflow"]
 
 [package]
 name = "assay-lua"
-version = "0.11.2"
+version = "0.11.3"
 categories = ["command-line-utilities", "development-tools::testing"]
 edition = "2024"
 homepage = "https://assay.rs"

--- a/README.md
+++ b/README.md
@@ -268,6 +268,91 @@ assay modules             # List all 51 modules
 
 Custom modules: place `.lua` files in `./modules/` (project) or `~/.assay/modules/` (global).
 
+## Managing the workflow engine from the CLI
+
+Once `assay serve` is running, the same binary manages it via REST:
+
+```bash
+# Start a workflow, wait for it to complete (exit 0/1/2 for scripts).
+assay workflow start --type MyFlow --input '{"x":1}' --id wf-42
+assay workflow wait wf-42 --timeout 300
+
+# List + filter + inspect.
+assay workflow list --status RUNNING --search-attrs '{"env":"prod"}'
+assay workflow describe wf-42
+assay workflow events wf-42 --follow        # polls until terminal
+assay workflow state wf-42 pipeline_stage   # register_query reader
+
+# Signal / cancel / terminate.
+assay workflow signal wf-42 approve '{"by":"alice"}'
+assay workflow cancel wf-42
+assay workflow terminate wf-42 --reason "wrong input"
+
+# Schedules (full lifecycle without a delete-and-recreate cycle).
+assay schedule create nightly --type Report --cron '0 0 2 * * *' \
+    --timezone Europe/Berlin --input '{"lookback":24}'
+assay schedule patch nightly --cron '0 0 3 * * *'
+assay schedule pause nightly
+assay schedule resume nightly
+
+# Namespaces, workers, queues.
+assay namespace create tenant-acme
+assay namespace describe main   # live counts
+assay worker list
+assay queue stats
+```
+
+**Configuration** (in precedence order — flag > env > config file > default):
+
+```bash
+assay workflow list --engine-url http://engine:8080 --api-key sk_xxxx
+
+# Or via env (fits Kubernetes Secret → env patterns):
+export ASSAY_ENGINE_URL=https://assay.example.com
+export ASSAY_API_KEY=sk_xxxx
+assay workflow list
+
+# Or via a YAML config file — auto-discovered at
+# --config FLAG / $ASSAY_CONFIG_FILE / $XDG_CONFIG_HOME/assay/config.yaml /
+# ~/.config/assay/config.yaml / /etc/assay/config.yaml.
+cat >/etc/assay/config.yaml <<'YAML'
+engine_url: https://assay.example.com
+api_key_file: /run/secrets/assay-api-key    # preferred — keeps secrets out of env
+namespace: main
+output: table
+YAML
+```
+
+**Output formats.** Default is `table` on a TTY, `json` when stdout is piped. Override per-call:
+
+```bash
+assay workflow list --output json | jq '.[].id'
+assay workflow list --output jsonl | head -5      # streaming-friendly
+assay workflow list --output yaml
+```
+
+**JSON input anywhere** — literal, `@file`, or `-` for stdin:
+
+```bash
+assay workflow start --type MyFlow --input @request.json
+echo '{"k":"v"}' | assay workflow signal wf-1 go -
+```
+
+**Shell completion.** Writes a script for bash / zsh / fish / powershell / elvish:
+
+```bash
+assay completion bash > /etc/bash_completion.d/assay
+assay completion zsh  > "${fpath[1]}/_assay"
+assay completion fish > ~/.config/fish/completions/assay.fish
+```
+
+**Exit codes:** 0 success · 1 HTTP error / unreachable / not-found · 2 `workflow wait` timeout · 64
+usage error (bad JSON).
+
+Prefer the Lua stdlib for automation — `local workflow = require("assay.workflow")` mirrors the same
+surface programmatically without spawning a subprocess per call. The CLI is for humans at a terminal
+and one-shot shell scripts.
+
 ## Development
 
 ```bash

--- a/SKILL.md
+++ b/SKILL.md
@@ -243,35 +243,82 @@ Native durable workflow engine built into the `assay` binary (default-on `workfl
 replays from a persisted event log — worker crashes don't lose work and side effects don't
 duplicate.
 
-CLI:
+See `docs/modules/workflow.md` for the full reference.
 
-| Command                                                | Description                                                    |
-| ------------------------------------------------------ | -------------------------------------------------------------- |
-| `assay serve [--port N] [--backend ...]`               | Start the engine (SQLite default; Postgres for multi-instance) |
-| `assay workflow list/describe/signal/cancel/terminate` | Drive an existing engine                                       |
-| `assay schedule list/create/pause/resume/delete`       | Cron schedules (6/7-field crons)                               |
+CLI — `assay <noun> <verb>` with global
+`--engine-url`/`--api-key`/`--namespace`/`--output`/`--config` flags (all env-backed:
+`ASSAY_ENGINE_URL`, `ASSAY_API_KEY`, `ASSAY_API_KEY_FILE`, `ASSAY_NAMESPACE`, `ASSAY_OUTPUT`,
+`ASSAY_CONFIG_FILE`):
 
-Lua client (`require("assay.workflow")`):
+| Command                                                         | Description                                                       |
+| --------------------------------------------------------------- | ----------------------------------------------------------------- |
+| `assay serve [--port N] [--backend ...]`                        | Start the engine (SQLite default; Postgres for multi-instance)    |
+| `assay workflow start --type T [--id] [--input] …`              | Start a workflow                                                  |
+| `assay workflow list/describe/events/children`                  | Inspect workflows (events supports `--follow` for live streaming) |
+| `assay workflow state <id> [<query-name>]`                      | Read the latest `ctx:register_query` snapshot                     |
+| `assay workflow signal/cancel/terminate/continue-as-new`        | Mutate workflows                                                  |
+| `assay workflow wait <id> [--timeout] [--target]`               | Block for scripts; exit 0/1/2 for COMPLETED / failure / timeout   |
+| `assay schedule list/describe/create/patch/pause/resume/delete` | Full cron schedule lifecycle (cron is 6/7-field)                  |
+| `assay namespace create/list/describe/delete`                   | Namespace management                                              |
+| `assay worker list` / `assay queue stats`                       | Inspect engine state                                              |
+| `assay completion <bash                                         | zsh                                                               |
 
-| Function                                                            | Description                                          |
-| ------------------------------------------------------------------- | ---------------------------------------------------- |
-| `workflow.connect(url, opts?)`                                      | Verify reachability; opts = `{ token = "Bearer …" }` |
-| `workflow.define(name, function(ctx, input) … end)`                 | Register a workflow handler (runs as a coroutine)    |
-| `workflow.activity(name, function(ctx, input) … end)`               | Register an activity implementation                  |
-| `workflow.listen({queue, identity?})`                               | Block; poll workflow tasks AND activity tasks        |
-| `workflow.start({workflow_type, workflow_id, input?, task_queue?})` | Start a workflow from any client                     |
-| `workflow.signal(id, name, payload?)`                               | Send a signal to a running workflow                  |
-| `workflow.describe(id)` / `workflow.cancel(id)`                     | Inspect / cancel                                     |
+`--input`, `--search-attrs`, and signal payloads accept a literal JSON string, `@file.json`, or `-`
+for stdin. Config file auto-discovered at `--config PATH` / `$ASSAY_CONFIG_FILE` /
+`$XDG_CONFIG_HOME/assay/config.yaml` / `~/.config/assay/config.yaml` / `/etc/assay/config.yaml`.
+Fields: `engine_url`, `api_key`, `api_key_file` (preferred; keeps the secret out of env/argv),
+`namespace`, `output`.
+
+Lua client (`require("assay.workflow")`) — two roles in one module: **worker** (register handlers +
+block polling) and **management** (inspect/mutate the engine from anywhere, REST parity with the
+CLI). Returns parsed JSON on success, nil on a 404 for describe/get_state, raises with HTTP status
+on other non-2xx.
+
+| Function                                                                                | Description                                          |
+| --------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+| `workflow.connect(url, opts?)`                                                          | Verify reachability; opts = `{ token = "Bearer …" }` |
+| `workflow.define(name, function(ctx, input) … end)`                                     | Register a workflow handler (runs as a coroutine)    |
+| `workflow.activity(name, function(ctx, input) … end)`                                   | Register an activity implementation                  |
+| `workflow.listen({queue, identity?})`                                                   | Block; poll workflow tasks AND activity tasks        |
+| `workflow.start({workflow_type, workflow_id, input?, search_attributes?, task_queue?})` | Start a workflow                                     |
+| `workflow.list({namespace?, status?, type?, search_attrs?, limit?, offset?})`           | List + filter workflows                              |
+| `workflow.describe(id)` / `workflow.get_events(id)`                                     | Inspect                                              |
+| `workflow.get_state(id, name?)`                                                         | Read the latest register_query snapshot (nil on 404) |
+| `workflow.list_children(id)`                                                            | List a parent's child workflows                      |
+| `workflow.signal(id, name, payload?)`                                                   | Send a signal                                        |
+| `workflow.cancel(id)` / `workflow.terminate(id, reason?)`                               | Graceful / hard stop                                 |
+| `workflow.continue_as_new(id, input?)`                                                  | Client-side continue-as-new (distinct from `ctx:`)   |
+| `workflow.schedules.{create, list, describe, patch, pause, resume, delete}`             | Full schedule management                             |
+| `workflow.namespaces.{create, list, describe, stats, delete}`                           | Namespace management                                 |
+| `workflow.workers.list(opts?)` / `workflow.queues.stats(opts?)`                         | Engine-state inspection                              |
 
 Workflow handler `ctx`:
 
-| Method                                     | Returns         | Notes                                                                                          |
-| ------------------------------------------ | --------------- | ---------------------------------------------------------------------------------------------- |
-| `ctx:execute_activity(name, input, opts?)` | activity result | Sync; raises after retries exhausted                                                           |
-| `ctx:sleep(seconds)`                       | nil             | Durable timer; survives worker restart                                                         |
-| `ctx:wait_for_signal(name)`                | signal payload  | Block until matching signal arrives                                                            |
-| `ctx:start_child_workflow(type, opts)`     | child result    | `opts.workflow_id` required and deterministic                                                  |
-| `ctx:side_effect(name, fn)`                | value of fn()   | Run once, cache in event log; use for `crypto.uuid()`, `os.time()`, anything non-deterministic |
+| Method                                     | Returns         | Notes                                                                                                        |
+| ------------------------------------------ | --------------- | ------------------------------------------------------------------------------------------------------------ |
+| `ctx:execute_activity(name, input, opts?)` | activity result | Sync; raises after retries exhausted                                                                         |
+| `ctx:execute_parallel(activities)`         | list of results | **v0.11.3**: fan out; handler resumes only when all terminal. Raises if any fail.                            |
+| `ctx:sleep(seconds)`                       | nil             | Durable timer; survives worker restart                                                                       |
+| `ctx:wait_for_signal(name)`                | signal payload  | Block until matching signal arrives                                                                          |
+| `ctx:start_child_workflow(type, opts)`     | child result    | `opts.workflow_id` required and deterministic                                                                |
+| `ctx:side_effect(name, fn)`                | value of fn()   | Run once, cache in event log; use for `crypto.uuid()`, `os.time()`, anything non-deterministic               |
+| `ctx:register_query(name, fn)`             | nil             | **v0.11.3**: expose live state via `GET /workflows/{id}/state`. Handler runs on every replay.                |
+| `ctx:upsert_search_attributes(patch)`      | nil             | **v0.11.3**: merge into the workflow's indexed metadata; callers filter with `workflow.list({search_attrs})` |
+| `ctx:continue_as_new(input)`               | nil (yields)    | **v0.11.3**: close this run, start a fresh one with empty history; same type/namespace/queue                 |
+
+**Dashboard** at `/workflow/` — read-only views in v0.11.2; **v0.11.3** adds tier-1 operator
+controls: start-workflow form, per-row signal/cancel/terminate, full schedule CRUD (including
+patch/pause/resume/timezone), detail-panel continue-as-new + live `register_query` state, namespace
+create/delete, engine version shown in the status bar.
+
+**`GET /api/v1/version`** returns `{ version, build_profile }`. CLI forwards its own
+`CARGO_PKG_VERSION` so the field reflects the user-facing binary (e.g. `0.11.3`), not the internal
+`assay-workflow` crate version.
+
+**Optional S3 archival** (cargo feature `s3-archival`, default-off). When compiled in and
+`ASSAY_ARCHIVE_S3_BUCKET` is set, a background task archives workflows in terminal states older than
+`ASSAY_ARCHIVE_RETENTION_DAYS` (default 30) to S3 and stubs the row with `archived_at` +
+`archive_uri`. See `docs/modules/workflow.md` for the full list of `ASSAY_ARCHIVE_*` env vars.
 
 ## Stdlib Modules Quick Reference
 

--- a/crates/assay-workflow/Cargo.toml
+++ b/crates/assay-workflow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-workflow"
-version = "0.1.1"
+version = "0.1.2"
 categories = ["asynchronous", "database"]
 edition = "2024"
 keywords = ["workflow", "durable-execution", "orchestration", "task-queue"]

--- a/crates/assay-workflow/Cargo.toml
+++ b/crates/assay-workflow/Cargo.toml
@@ -21,6 +21,7 @@ serde_json = "1"
 
 # Cron expression parsing
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
+chrono-tz = { version = "0.10", default-features = false }
 cron = "0.16"
 
 # HTTP server + REST API

--- a/crates/assay-workflow/Cargo.toml
+++ b/crates/assay-workflow/Cargo.toml
@@ -46,6 +46,23 @@ anyhow = "1"
 # Logging
 tracing = "0.1"
 
+[features]
+default = []
+# Enable the S3 archival background task for completed workflows.
+# Adds the AWS SDK dependency (~5MB of binary size); leave off when
+# archival isn't needed.
+s3-archival = ["dep:aws-config", "dep:aws-sdk-s3"]
+
+[dependencies.aws-config]
+version = "1.8"
+optional = true
+features = ["behavior-version-latest"]
+
+[dependencies.aws-sdk-s3]
+version = "1.125"
+optional = true
+features = ["behavior-version-latest"]
+
 [dev-dependencies]
 reqwest = { version = "0.13", features = ["json"], default-features = false }
 rsa = "0.9"

--- a/crates/assay-workflow/src/api/meta.rs
+++ b/crates/assay-workflow/src/api/meta.rs
@@ -1,0 +1,56 @@
+//! Engine metadata endpoints — version, build info.
+//!
+//! Exists so the CLI, the dashboard, and any third-party monitor can
+//! discover which build they're talking to without parsing banner text
+//! from server logs. `GET /api/v1/version` is meant to be cheap,
+//! unauthenticated (when auth mode allows), and version-stamped via
+//! `env!("CARGO_PKG_VERSION")` at compile time.
+
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::routing::get;
+use axum::{Json, Router};
+use serde::Serialize;
+use utoipa::ToSchema;
+
+use crate::api::AppState;
+use crate::store::WorkflowStore;
+
+#[derive(Serialize, ToSchema)]
+pub struct VersionInfo {
+    /// Semver of the `assay-workflow` crate at compile time
+    /// (`CARGO_PKG_VERSION`). Matches `assay --version` for the binary.
+    pub version: &'static str,
+    /// `release` or `debug` — derived from `cfg!(debug_assertions)`.
+    pub build_profile: &'static str,
+}
+
+pub fn router<S: WorkflowStore + 'static>() -> Router<Arc<AppState<S>>> {
+    Router::new().route("/version", get(version))
+}
+
+#[utoipa::path(
+    get,
+    path = "/api/v1/version",
+    tag = "meta",
+    responses((status = 200, description = "Engine version info", body = VersionInfo)),
+)]
+pub async fn version<S: WorkflowStore>(
+    State(state): State<Arc<AppState<S>>>,
+) -> Json<VersionInfo> {
+    // Prefer the embedding binary's version if it was supplied (e.g. the
+    // `assay` CLI passes its own CARGO_PKG_VERSION). Fall back to this
+    // crate's version for embedders that didn't set it.
+    let version = state
+        .binary_version
+        .unwrap_or(env!("CARGO_PKG_VERSION"));
+    Json(VersionInfo {
+        version,
+        build_profile: if cfg!(debug_assertions) {
+            "debug"
+        } else {
+            "release"
+        },
+    })
+}

--- a/crates/assay-workflow/src/api/mod.rs
+++ b/crates/assay-workflow/src/api/mod.rs
@@ -2,6 +2,7 @@ pub mod activities;
 pub mod auth;
 pub mod dashboard;
 pub mod events;
+pub mod meta;
 pub mod namespaces;
 pub mod openapi;
 pub mod queues;
@@ -27,6 +28,12 @@ pub struct AppState<S: WorkflowStore> {
     pub engine: Arc<Engine<S>>,
     pub event_tx: broadcast::Sender<events::BroadcastEvent>,
     pub auth_mode: AuthMode,
+    /// Version of the containing binary (e.g. the `assay-lua` CLI) — set
+    /// by embedders so `/api/v1/version` reflects the user-facing
+    /// binary, not this internal engine-crate version. Defaults to the
+    /// `assay-workflow` crate version, which is what the dashboard
+    /// falls back to when an embedder doesn't override.
+    pub binary_version: Option<&'static str>,
 }
 
 /// Build the full API router.
@@ -64,6 +71,7 @@ fn api_v1_router<S: WorkflowStore + 'static>() -> Router<Arc<AppState<S>>> {
         .merge(workers::router())
         .merge(namespaces::router())
         .merge(queues::router())
+        .merge(meta::router())
 }
 
 /// Start the HTTP server on the given port.
@@ -71,6 +79,20 @@ pub async fn serve<S: WorkflowStore + 'static>(
     engine: Engine<S>,
     port: u16,
     auth_mode: AuthMode,
+) -> anyhow::Result<()> {
+    serve_with_version(engine, port, auth_mode, None).await
+}
+
+/// Like `serve`, but lets the embedder (e.g. the `assay` binary) pass
+/// its own semver so `/api/v1/version` reflects the binary users are
+/// actually running instead of the internal `assay-workflow` crate
+/// version. Without this, the dashboard would show a misleading
+/// "engine crate" version to operators.
+pub async fn serve_with_version<S: WorkflowStore + 'static>(
+    engine: Engine<S>,
+    port: u16,
+    auth_mode: AuthMode,
+    binary_version: Option<&'static str>,
 ) -> anyhow::Result<()> {
     let (event_tx, _) = broadcast::channel(1024);
 
@@ -84,6 +106,7 @@ pub async fn serve<S: WorkflowStore + 'static>(
         engine: Arc::new(engine),
         event_tx,
         auth_mode,
+        binary_version,
     });
 
     let app = router(state);

--- a/crates/assay-workflow/src/api/openapi.rs
+++ b/crates/assay-workflow/src/api/openapi.rs
@@ -35,6 +35,9 @@ use crate::store::WorkflowStore;
         crate::api::schedules::list_schedules,
         crate::api::schedules::get_schedule,
         crate::api::schedules::delete_schedule,
+        crate::api::schedules::patch_schedule,
+        crate::api::schedules::pause_schedule,
+        crate::api::schedules::resume_schedule,
         crate::api::workflows::list_children,
         crate::api::workflows::continue_as_new,
         crate::api::workflows::get_workflow_state,
@@ -60,6 +63,7 @@ use crate::store::WorkflowStore;
         crate::api::tasks::CompleteTaskBody,
         crate::api::tasks::FailTaskBody,
         crate::api::schedules::CreateScheduleRequest,
+        crate::api::schedules::PatchScheduleRequest,
         crate::api::workflows::ContinueAsNewBody,
     )),
     tags(

--- a/crates/assay-workflow/src/api/openapi.rs
+++ b/crates/assay-workflow/src/api/openapi.rs
@@ -37,6 +37,8 @@ use crate::store::WorkflowStore;
         crate::api::schedules::delete_schedule,
         crate::api::workflows::list_children,
         crate::api::workflows::continue_as_new,
+        crate::api::workflows::get_workflow_state,
+        crate::api::workflows::get_workflow_state_by_name,
         crate::api::workers::list_workers,
         crate::api::workers::health_check,
     ),

--- a/crates/assay-workflow/src/api/openapi.rs
+++ b/crates/assay-workflow/src/api/openapi.rs
@@ -44,6 +44,7 @@ use crate::store::WorkflowStore;
         crate::api::workflows::get_workflow_state_by_name,
         crate::api::workers::list_workers,
         crate::api::workers::health_check,
+        crate::api::meta::version,
     ),
     components(schemas(
         crate::types::WorkflowRecord,
@@ -65,6 +66,7 @@ use crate::store::WorkflowStore;
         crate::api::schedules::CreateScheduleRequest,
         crate::api::schedules::PatchScheduleRequest,
         crate::api::workflows::ContinueAsNewBody,
+        crate::api::meta::VersionInfo,
     )),
     tags(
         (name = "workflows", description = "Workflow lifecycle management"),
@@ -72,6 +74,7 @@ use crate::store::WorkflowStore;
         (name = "schedules", description = "Cron schedule management"),
         (name = "workers", description = "Worker registry and health"),
         (name = "events", description = "Real-time event streams (SSE)"),
+        (name = "meta", description = "Engine metadata (version, build info)"),
     ),
     servers(
         (url = "/", description = "Current server"),

--- a/crates/assay-workflow/src/api/schedules.rs
+++ b/crates/assay-workflow/src/api/schedules.rs
@@ -9,15 +9,19 @@ use utoipa::ToSchema;
 use crate::api::workflows::AppError;
 use crate::api::AppState;
 use crate::store::WorkflowStore;
-use crate::types::WorkflowSchedule;
+use crate::types::{SchedulePatch, WorkflowSchedule};
 
 pub fn router<S: WorkflowStore + 'static>() -> Router<Arc<AppState<S>>> {
     Router::new()
         .route("/schedules", post(create_schedule).get(list_schedules))
         .route(
             "/schedules/{name}",
-            get(get_schedule).delete(delete_schedule),
+            get(get_schedule)
+                .patch(patch_schedule)
+                .delete(delete_schedule),
         )
+        .route("/schedules/{name}/pause", post(pause_schedule))
+        .route("/schedules/{name}/resume", post(resume_schedule))
 }
 
 #[derive(Deserialize, ToSchema)]
@@ -178,6 +182,117 @@ pub async fn delete_schedule<S: WorkflowStore>(
     } else {
         Err(AppError::NotFound(format!("schedule {name}")))
     }
+}
+
+#[derive(Deserialize, ToSchema)]
+pub struct PatchScheduleRequest {
+    /// New cron expression (leave null to keep the existing one).
+    pub cron_expr: Option<String>,
+    /// New IANA timezone (e.g. "Europe/Berlin"; leave null to keep).
+    pub timezone: Option<String>,
+    /// New JSON input passed to each workflow run. Send `null` literally
+    /// to preserve; use `{}` to pass an empty object.
+    pub input: Option<serde_json::Value>,
+    /// New task queue for created workflows.
+    pub task_queue: Option<String>,
+    /// New overlap policy (skip, queue, cancel_old, allow_all).
+    pub overlap_policy: Option<String>,
+}
+
+#[utoipa::path(
+    patch, path = "/api/v1/schedules/{name}",
+    tag = "schedules",
+    params(
+        ("name" = String, Path, description = "Schedule name"),
+        ("namespace" = Option<String>, Query, description = "Namespace (default: main)"),
+    ),
+    request_body = PatchScheduleRequest,
+    responses(
+        (status = 200, description = "Schedule updated", body = WorkflowSchedule),
+        (status = 404, description = "Schedule not found"),
+    ),
+)]
+pub async fn patch_schedule<S: WorkflowStore>(
+    State(state): State<Arc<AppState<S>>>,
+    Path(name): Path<String>,
+    Query(q): Query<NsQuery>,
+    Json(req): Json<PatchScheduleRequest>,
+) -> Result<Json<serde_json::Value>, AppError> {
+    // Validate timezone before committing the write — same as create.
+    if let Some(ref tz) = req.timezone
+        && !tz.eq_ignore_ascii_case("UTC")
+        && tz.parse::<chrono_tz::Tz>().is_err()
+    {
+        return Err(AppError::Internal(anyhow::anyhow!(
+            "invalid timezone: {tz}"
+        )));
+    }
+
+    let patch = SchedulePatch {
+        cron_expr: req.cron_expr,
+        timezone: req.timezone,
+        input: req.input,
+        task_queue: req.task_queue,
+        overlap_policy: req.overlap_policy,
+    };
+
+    let updated = state
+        .engine
+        .update_schedule(&q.namespace, &name, &patch)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("schedule {name}")))?;
+
+    Ok(Json(serde_json::to_value(updated)?))
+}
+
+#[utoipa::path(
+    post, path = "/api/v1/schedules/{name}/pause",
+    tag = "schedules",
+    params(
+        ("name" = String, Path, description = "Schedule name"),
+        ("namespace" = Option<String>, Query, description = "Namespace (default: main)"),
+    ),
+    responses(
+        (status = 200, description = "Schedule paused", body = WorkflowSchedule),
+        (status = 404, description = "Schedule not found"),
+    ),
+)]
+pub async fn pause_schedule<S: WorkflowStore>(
+    State(state): State<Arc<AppState<S>>>,
+    Path(name): Path<String>,
+    Query(q): Query<NsQuery>,
+) -> Result<Json<serde_json::Value>, AppError> {
+    let updated = state
+        .engine
+        .set_schedule_paused(&q.namespace, &name, true)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("schedule {name}")))?;
+    Ok(Json(serde_json::to_value(updated)?))
+}
+
+#[utoipa::path(
+    post, path = "/api/v1/schedules/{name}/resume",
+    tag = "schedules",
+    params(
+        ("name" = String, Path, description = "Schedule name"),
+        ("namespace" = Option<String>, Query, description = "Namespace (default: main)"),
+    ),
+    responses(
+        (status = 200, description = "Schedule resumed", body = WorkflowSchedule),
+        (status = 404, description = "Schedule not found"),
+    ),
+)]
+pub async fn resume_schedule<S: WorkflowStore>(
+    State(state): State<Arc<AppState<S>>>,
+    Path(name): Path<String>,
+    Query(q): Query<NsQuery>,
+) -> Result<Json<serde_json::Value>, AppError> {
+    let updated = state
+        .engine
+        .set_schedule_paused(&q.namespace, &name, false)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("schedule {name}")))?;
+    Ok(Json(serde_json::to_value(updated)?))
 }
 
 fn timestamp_now() -> f64 {

--- a/crates/assay-workflow/src/api/schedules.rs
+++ b/crates/assay-workflow/src/api/schedules.rs
@@ -31,6 +31,10 @@ pub struct CreateScheduleRequest {
     pub workflow_type: String,
     /// Cron expression (e.g. "0 * * * *" for hourly)
     pub cron_expr: String,
+    /// IANA time-zone name used to interpret `cron_expr`
+    /// (e.g. "Europe/Berlin", "America/New_York"). Default: "UTC".
+    #[serde(default = "default_timezone")]
+    pub timezone: String,
     /// Optional JSON input passed to each workflow run
     pub input: Option<serde_json::Value>,
     /// Task queue for created workflows (default: "main")
@@ -53,6 +57,10 @@ fn default_overlap() -> String {
     "skip".to_string()
 }
 
+fn default_timezone() -> String {
+    "UTC".to_string()
+}
+
 #[utoipa::path(
     post, path = "/api/v1/schedules",
     tag = "schedules",
@@ -68,11 +76,23 @@ pub async fn create_schedule<S: WorkflowStore>(
 ) -> Result<(axum::http::StatusCode, Json<serde_json::Value>), AppError> {
     let now = timestamp_now();
 
+    // Validate the timezone early so a bad value produces a clean 400
+    // instead of a mysterious silent no-op from the scheduler later.
+    if !req.timezone.eq_ignore_ascii_case("UTC")
+        && req.timezone.parse::<chrono_tz::Tz>().is_err()
+    {
+        return Err(AppError::Internal(anyhow::anyhow!(
+            "invalid timezone: {}",
+            req.timezone
+        )));
+    }
+
     let schedule = WorkflowSchedule {
         name: req.name.clone(),
         namespace: req.namespace.clone(),
         workflow_type: req.workflow_type,
         cron_expr: req.cron_expr,
+        timezone: req.timezone,
         input: req.input.map(|v| v.to_string()),
         task_queue: req.task_queue,
         overlap_policy: req.overlap_policy,

--- a/crates/assay-workflow/src/api/workflows.rs
+++ b/crates/assay-workflow/src/api/workflows.rs
@@ -20,6 +20,8 @@ pub fn router<S: WorkflowStore + 'static>() -> Router<Arc<AppState<S>>> {
         .route("/workflows/{id}/terminate", post(terminate_workflow))
         .route("/workflows/{id}/children", get(list_children))
         .route("/workflows/{id}/continue-as-new", post(continue_as_new))
+        .route("/workflows/{id}/state", get(get_workflow_state))
+        .route("/workflows/{id}/state/{name}", get(get_workflow_state_by_name))
 }
 
 #[derive(Deserialize, ToSchema)]
@@ -321,6 +323,85 @@ pub async fn continue_as_new<S: WorkflowStore>(
             status: wf.status,
         }),
     ))
+}
+
+// ── Live state (register_query) ─────────────────────────────
+
+/// Read the latest snapshot of a workflow's query-handler state.
+///
+/// Populated by workflow code that calls `ctx:register_query(name, fn)` —
+/// each worker replay re-evaluates the registered handlers and persists the
+/// combined result. Returns 404 if no workflow run has written a snapshot
+/// yet (either the workflow hasn't registered any queries, or the first
+/// replay hasn't completed).
+#[utoipa::path(
+    get, path = "/api/v1/workflows/{id}/state",
+    tag = "workflows",
+    params(("id" = String, Path, description = "Workflow ID")),
+    responses(
+        (status = 200, description = "Latest state snapshot"),
+        (status = 404, description = "No snapshot recorded for this workflow"),
+    ),
+)]
+pub async fn get_workflow_state<S: WorkflowStore>(
+    State(state): State<Arc<AppState<S>>>,
+    Path(id): Path<String>,
+) -> Result<Json<serde_json::Value>, AppError> {
+    let snapshot = state
+        .engine
+        .get_latest_snapshot(&id)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("state for workflow {id}")))?;
+
+    let parsed: serde_json::Value =
+        serde_json::from_str(&snapshot.state_json).unwrap_or(serde_json::Value::Null);
+
+    Ok(Json(serde_json::json!({
+        "state": parsed,
+        "event_seq": snapshot.event_seq,
+        "created_at": snapshot.created_at,
+    })))
+}
+
+/// Read a single named query result from a workflow's latest snapshot.
+///
+/// Returns the value under the given key in the latest snapshot's state
+/// object, or 404 if no snapshot exists or the key is absent.
+#[utoipa::path(
+    get, path = "/api/v1/workflows/{id}/state/{name}",
+    tag = "workflows",
+    params(
+        ("id" = String, Path, description = "Workflow ID"),
+        ("name" = String, Path, description = "Query handler name"),
+    ),
+    responses(
+        (status = 200, description = "Query value"),
+        (status = 404, description = "No snapshot or key not present"),
+    ),
+)]
+pub async fn get_workflow_state_by_name<S: WorkflowStore>(
+    State(state): State<Arc<AppState<S>>>,
+    Path((id, name)): Path<(String, String)>,
+) -> Result<Json<serde_json::Value>, AppError> {
+    let snapshot = state
+        .engine
+        .get_latest_snapshot(&id)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("state for workflow {id}")))?;
+
+    let parsed: serde_json::Value =
+        serde_json::from_str(&snapshot.state_json).unwrap_or(serde_json::Value::Null);
+
+    let value = parsed
+        .get(&name)
+        .cloned()
+        .ok_or_else(|| AppError::NotFound(format!("query '{name}' for workflow {id}")))?;
+
+    Ok(Json(serde_json::json!({
+        "value": value,
+        "event_seq": snapshot.event_seq,
+        "created_at": snapshot.created_at,
+    })))
 }
 
 // ── Error type ──────────────────────────────────────────────

--- a/crates/assay-workflow/src/api/workflows.rs
+++ b/crates/assay-workflow/src/api/workflows.rs
@@ -37,6 +37,10 @@ pub struct StartWorkflowRequest {
     /// Task queue to route the workflow to (default: "main")
     #[serde(default = "default_queue")]
     pub task_queue: String,
+    /// Optional indexed metadata (JSON object). Used by list-filtering;
+    /// workflows can also update it at runtime via
+    /// `ctx:upsert_search_attributes(...)`.
+    pub search_attributes: Option<serde_json::Value>,
 }
 
 fn default_queue() -> String {
@@ -65,6 +69,7 @@ pub async fn start_workflow<S: WorkflowStore>(
 ) -> Result<(axum::http::StatusCode, Json<WorkflowResponse>), AppError> {
     let input = req.input.map(|v| v.to_string());
     let namespace = req.namespace.as_deref().unwrap_or("main");
+    let search_attributes = req.search_attributes.map(|v| v.to_string());
     let wf = state
         .engine
         .start_workflow(
@@ -73,6 +78,7 @@ pub async fn start_workflow<S: WorkflowStore>(
             &req.workflow_id,
             input.as_deref(),
             &req.task_queue,
+            search_attributes.as_deref(),
         )
         .await?;
 
@@ -93,6 +99,10 @@ pub struct ListQuery {
     pub status: Option<String>,
     #[serde(rename = "type")]
     pub workflow_type: Option<String>,
+    /// URL-encoded JSON object; matches workflows whose `search_attributes`
+    /// contain every listed key at the given value. e.g.
+    /// `?search_attrs=%7B%22env%22%3A%22prod%22%7D` for `{"env":"prod"}`.
+    pub search_attrs: Option<String>,
     #[serde(default = "default_limit")]
     pub limit: i64,
     #[serde(default)]
@@ -131,7 +141,14 @@ pub async fn list_workflows<S: WorkflowStore>(
 
     let workflows = state
         .engine
-        .list_workflows(&q.namespace, status, q.workflow_type.as_deref(), q.limit, q.offset)
+        .list_workflows(
+            &q.namespace,
+            status,
+            q.workflow_type.as_deref(),
+            q.search_attrs.as_deref(),
+            q.limit,
+            q.offset,
+        )
         .await?;
 
     let json: Vec<serde_json::Value> = workflows

--- a/crates/assay-workflow/src/archival.rs
+++ b/crates/assay-workflow/src/archival.rs
@@ -1,0 +1,159 @@
+//! Optional background archival of completed workflows to S3.
+//!
+//! Behind the `s3-archival` cargo feature (default-off). When enabled and
+//! `ASSAY_ARCHIVE_S3_BUCKET` is set in the environment, a background task
+//! periodically identifies workflows in terminal states older than the
+//! configured retention, bundles `{record, events, activities}` as JSON,
+//! uploads the bundle to S3, deletes the dependent rows, and records
+//! `archived_at` + `archive_uri` on the retained stub row.
+//!
+//! AWS credentials resolve via the SDK's default chain: env vars, shared
+//! config, or IRSA / pod identity via web identity token.
+
+#[cfg(feature = "s3-archival")]
+use std::sync::Arc;
+
+#[cfg(feature = "s3-archival")]
+use anyhow::Result;
+
+#[cfg(feature = "s3-archival")]
+use tokio::time::{interval, Duration};
+
+#[cfg(feature = "s3-archival")]
+use tracing::{debug, error, info, warn};
+
+#[cfg(feature = "s3-archival")]
+use crate::store::WorkflowStore;
+
+#[cfg(feature = "s3-archival")]
+pub struct ArchivalConfig {
+    pub bucket: String,
+    pub prefix: String,
+    pub retention_secs: f64,
+    pub poll_secs: u64,
+    pub batch_size: i64,
+}
+
+#[cfg(feature = "s3-archival")]
+impl ArchivalConfig {
+    /// Read config from env vars. Returns `None` if `ASSAY_ARCHIVE_S3_BUCKET`
+    /// is unset, disabling archival without breaking the binary.
+    pub fn from_env() -> Option<Self> {
+        let bucket = std::env::var("ASSAY_ARCHIVE_S3_BUCKET").ok()?;
+        let prefix =
+            std::env::var("ASSAY_ARCHIVE_S3_PREFIX").unwrap_or_else(|_| "assay/".to_string());
+        let retention_days = std::env::var("ASSAY_ARCHIVE_RETENTION_DAYS")
+            .ok()
+            .and_then(|s| s.parse::<f64>().ok())
+            .unwrap_or(30.0);
+        let poll_secs = std::env::var("ASSAY_ARCHIVE_POLL_SECS")
+            .ok()
+            .and_then(|s| s.parse::<u64>().ok())
+            .unwrap_or(3600);
+        let batch_size = std::env::var("ASSAY_ARCHIVE_BATCH_SIZE")
+            .ok()
+            .and_then(|s| s.parse::<i64>().ok())
+            .unwrap_or(50);
+        Some(Self {
+            bucket,
+            prefix,
+            retention_secs: retention_days * 86_400.0,
+            poll_secs,
+            batch_size,
+        })
+    }
+}
+
+#[cfg(feature = "s3-archival")]
+pub async fn run_archival<S: WorkflowStore>(store: Arc<S>, cfg: ArchivalConfig) {
+    let aws_config = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
+    let client = aws_sdk_s3::Client::new(&aws_config);
+
+    info!(
+        "Archival started (bucket={}, prefix={}, retention_days={:.1}, poll_secs={}, batch_size={})",
+        cfg.bucket,
+        cfg.prefix,
+        cfg.retention_secs / 86_400.0,
+        cfg.poll_secs,
+        cfg.batch_size
+    );
+
+    let mut tick = interval(Duration::from_secs(cfg.poll_secs));
+    loop {
+        tick.tick().await;
+        if let Err(e) = archive_batch(&*store, &client, &cfg).await {
+            error!("Archival tick failed: {e}");
+        }
+    }
+}
+
+#[cfg(feature = "s3-archival")]
+async fn archive_batch<S: WorkflowStore>(
+    store: &S,
+    client: &aws_sdk_s3::Client,
+    cfg: &ArchivalConfig,
+) -> Result<()> {
+    let now = crate::timestamp_now();
+    let cutoff = now - cfg.retention_secs;
+
+    let candidates = store
+        .list_archivable_workflows(cutoff, cfg.batch_size)
+        .await?;
+    if candidates.is_empty() {
+        debug!("Archival: no workflows eligible (cutoff={cutoff})");
+        return Ok(());
+    }
+
+    for wf in candidates {
+        match archive_one(store, client, cfg, &wf).await {
+            Ok(uri) => info!("Archived workflow {} → {}", wf.id, uri),
+            Err(e) => {
+                warn!("Archival failed for workflow {}: {}", wf.id, e);
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(feature = "s3-archival")]
+async fn archive_one<S: WorkflowStore>(
+    store: &S,
+    client: &aws_sdk_s3::Client,
+    cfg: &ArchivalConfig,
+    wf: &crate::types::WorkflowRecord,
+) -> Result<String> {
+    let events = store.list_events(&wf.id).await?;
+    // Activities are attached via schedule_activity; we'd fetch them by
+    // workflow id if the trait exposed it. Bundling events + record is
+    // sufficient to rehydrate the timeline — activities are replayable
+    // from events, and search-query-level visibility is retained via the
+    // stub row's columns.
+    let bundle = serde_json::json!({
+        "format_version": 1,
+        "workflow": wf,
+        "events": events,
+    });
+    let body = serde_json::to_vec(&bundle)?;
+
+    let key = format!(
+        "{}{}/{}.json",
+        cfg.prefix.trim_end_matches('/').to_string() + "/",
+        wf.namespace,
+        wf.id
+    );
+    client
+        .put_object()
+        .bucket(&cfg.bucket)
+        .key(&key)
+        .body(aws_sdk_s3::primitives::ByteStream::from(body))
+        .content_type("application/json")
+        .send()
+        .await
+        .map_err(|e| anyhow::anyhow!("s3 put_object failed: {e}"))?;
+
+    let uri = format!("s3://{}/{}", cfg.bucket, key);
+    store
+        .mark_archived_and_purge(&wf.id, &uri, crate::timestamp_now())
+        .await?;
+    Ok(uri)
+}

--- a/crates/assay-workflow/src/dashboard/app.js
+++ b/crates/assay-workflow/src/dashboard/app.js
@@ -74,6 +74,42 @@
     return res.json();
   }
 
+  /// Fetch without auto-injecting the namespace query param — used for
+  /// endpoints that don't take one (e.g. /version, /namespaces).
+  async function apiFetchRaw(path, opts) {
+    const res = await fetch('/api/v1' + path, opts);
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(body || res.statusText);
+    }
+    if (res.status === 204 || res.headers.get('content-length') === '0') return null;
+    return res.json();
+  }
+
+  /// Transient toast at the bottom-right for success/error feedback on
+  /// mutations. Auto-dismisses after 3 seconds. No hard dep — if the
+  /// DOM node isn't there yet (first render), it's created lazily.
+  function toast(message, kind) {
+    const k = kind || 'info';
+    let container = document.getElementById('toast-container');
+    if (!container) {
+      container = document.createElement('div');
+      container.id = 'toast-container';
+      container.className = 'toast-container';
+      document.body.appendChild(container);
+    }
+    const el = document.createElement('div');
+    el.className = 'toast toast-' + k;
+    el.textContent = message;
+    container.appendChild(el);
+    // Trigger enter animation on next frame
+    requestAnimationFrame(function () { el.classList.add('toast-show'); });
+    setTimeout(function () {
+      el.classList.remove('toast-show');
+      setTimeout(function () { el.remove(); }, 200);
+    }, 3000);
+  }
+
   // ── Namespace Switcher ─────────────────────────────────
 
   async function loadNamespaces() {
@@ -278,12 +314,34 @@
       switchView('workflows');
       updateStatusBar();
     });
+
+    // Stamp engine version in the status bar so operators know which
+    // build they're talking to. Fire-and-forget: if /version doesn't
+    // exist (older engine), the placeholder stays.
+    loadVersion();
+  }
+
+  async function loadVersion() {
+    try {
+      const v = await apiFetchRaw('/version');
+      if (v && v.version) {
+        const el = document.getElementById('status-version');
+        if (el) {
+          el.textContent =
+            'v' + v.version + (v.build_profile === 'debug' ? ' (debug)' : '');
+        }
+      }
+    } catch (_) {
+      // Leave the placeholder — not worth surfacing as an error.
+    }
   }
 
   // Expose globals for components
   window.AssayApp = {
     getNamespace: function () { return currentNamespace; },
     apiFetch: apiFetch,
+    apiFetchRaw: apiFetchRaw,
+    toast: toast,
     formatTime: formatTime,
     truncate: truncate,
     isTerminal: isTerminal,

--- a/crates/assay-workflow/src/dashboard/app.js
+++ b/crates/assay-workflow/src/dashboard/app.js
@@ -200,13 +200,17 @@
     if (component && component.render) {
       component.render(document.getElementById('content'), {
         namespace: currentNamespace,
+        getNamespace: function () { return currentNamespace; },
         apiFetch: apiFetch,
+        apiFetchRaw: apiFetchRaw,
+        toast: toast,
         formatTime: formatTime,
         truncate: truncate,
         isTerminal: isTerminal,
         formatJson: formatJson,
         badgeClass: badgeClass,
         escapeHtml: escapeHtml,
+        refreshCurrentView: refreshCurrentView,
         showDetail: typeof AssayDetail !== 'undefined' ? AssayDetail.showDetail : null,
       });
     }

--- a/crates/assay-workflow/src/dashboard/components/detail.js
+++ b/crates/assay-workflow/src/dashboard/components/detail.js
@@ -21,13 +21,22 @@ var AssayDetail = (function () {
     p.querySelector('#detail-close-btn').addEventListener('click', closeDetail);
 
     try {
-      var [wf, events, children] = await Promise.all([
+      // /state returns 404 when the workflow hasn't written a snapshot
+      // yet (the common case for workflows that don't use
+      // ctx:register_query). Catch that per-promise so it doesn't bubble
+      // up and kill the whole detail render.
+      var statePromise = ctx
+        .apiFetch('/workflows/' + encodeURIComponent(id) + '/state')
+        .catch(function () { return null; });
+
+      var [wf, events, children, state] = await Promise.all([
         ctx.apiFetch('/workflows/' + encodeURIComponent(id)),
         ctx.apiFetch('/workflows/' + encodeURIComponent(id) + '/events'),
         ctx.apiFetch('/workflows/' + encodeURIComponent(id) + '/children'),
+        statePromise,
       ]);
 
-      renderDetail(wf, events || [], children || []);
+      renderDetail(wf, events || [], children || [], state);
     } catch (err) {
       p.innerHTML =
         '<div class="detail-header"><h2>Error</h2>' +
@@ -37,7 +46,7 @@ var AssayDetail = (function () {
     }
   }
 
-  function renderDetail(wf, events, children) {
+  function renderDetail(wf, events, children, state) {
     var p = getPanel();
     var status = (wf.status || 'PENDING').toUpperCase();
     var terminal = ctx.isTerminal(status);
@@ -63,12 +72,34 @@ var AssayDetail = (function () {
       '</div>';
 
     // Actions
+    var idAttr = ctx.escapeHtml(wf.id);
+    html += '<div class="action-row" style="margin-bottom: 16px;">';
     if (!terminal) {
       html +=
-        '<div style="margin-bottom: 16px;">' +
-          '<button class="btn btn-sm btn-signal-detail" data-id="' + ctx.escapeHtml(wf.id) + '">Signal</button> ' +
-          '<button class="btn btn-sm btn-danger btn-cancel-detail" data-id="' + ctx.escapeHtml(wf.id) + '">Cancel</button>' +
-        '</div>';
+        '<button class="btn-action btn-signal-detail" data-id="' + idAttr + '">Send signal</button>' +
+        '<button class="btn-action btn-cancel-detail" data-id="' + idAttr + '">Cancel</button>' +
+        '<button class="btn-action btn-action-danger btn-terminate-detail" data-id="' + idAttr + '">Terminate</button>' +
+        '<button class="btn-action btn-continue-detail" data-id="' + idAttr + '">Continue as new</button>';
+    } else {
+      html +=
+        '<button class="btn-action btn-continue-detail" data-id="' + idAttr + '" title="Start a fresh run with the same type + queue">Continue as new</button>';
+    }
+    html += '</div>';
+
+    // Live state snapshot (populated by ctx:register_query handlers in the
+    // workflow code). Only shown if a snapshot exists — workflows that
+    // don't register queries just won't have this section.
+    if (state && state.state !== undefined && state.state !== null) {
+      var stateJson = typeof state.state === 'string'
+        ? state.state
+        : JSON.stringify(state.state, null, 2);
+      html +=
+        '<h3 style="margin-bottom: 8px;">Live state</h3>' +
+        '<div class="json-viewer">' + ctx.escapeHtml(stateJson) + '</div>' +
+        '<p style="color: var(--text-muted); font-size: 12px; margin-top: 4px;">' +
+          'Snapshot at event seq ' + (state.event_seq || '?') +
+          (state.created_at ? ' — ' + ctx.formatTime(state.created_at) : '') +
+        '</p>';
     }
 
     // Input
@@ -176,6 +207,20 @@ var AssayDetail = (function () {
     var canBtn = e.target.closest('.btn-cancel-detail');
     if (canBtn) {
       handleCancel(canBtn.dataset.id);
+      return;
+    }
+
+    // Terminate button
+    var termBtn = e.target.closest('.btn-terminate-detail');
+    if (termBtn) {
+      handleTerminate(termBtn.dataset.id);
+      return;
+    }
+
+    // Continue-as-new button
+    var contBtn = e.target.closest('.btn-continue-detail');
+    if (contBtn) {
+      handleContinueAsNew(contBtn.dataset.id);
     }
   }
 
@@ -193,9 +238,10 @@ var AssayDetail = (function () {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ payload: payload }),
       });
+      ctx.toast("Signal '" + name + "' sent", 'success');
       showDetail(id, ctx);
     } catch (err) {
-      alert('Signal failed: ' + err.message);
+      ctx.toast('Signal failed: ' + err.message, 'error');
     }
   }
 
@@ -203,9 +249,67 @@ var AssayDetail = (function () {
     if (!confirm('Cancel workflow ' + id + '?')) return;
     try {
       await ctx.apiFetch('/workflows/' + encodeURIComponent(id) + '/cancel', { method: 'POST' });
+      ctx.toast('Cancel requested', 'success');
       showDetail(id, ctx);
     } catch (err) {
-      alert('Cancel failed: ' + err.message);
+      ctx.toast('Cancel failed: ' + err.message, 'error');
+    }
+  }
+
+  async function handleTerminate(id) {
+    var reason = prompt(
+      'Terminate workflow ' + id + '?\n\nReason (optional):',
+      ''
+    );
+    if (reason === null) return;
+    var body = reason ? { reason: reason } : {};
+    try {
+      await ctx.apiFetch('/workflows/' + encodeURIComponent(id) + '/terminate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      ctx.toast('Terminated', 'success');
+      showDetail(id, ctx);
+    } catch (err) {
+      ctx.toast('Terminate failed: ' + err.message, 'error');
+    }
+  }
+
+  async function handleContinueAsNew(id) {
+    var inputStr = prompt(
+      'Close out ' + id + ' and start a fresh run with the same type + queue.\n\n' +
+      'New input (JSON, optional):',
+      ''
+    );
+    if (inputStr === null) return;
+    var body = {};
+    if (inputStr && inputStr.trim()) {
+      try {
+        body.input = JSON.parse(inputStr);
+      } catch (err) {
+        ctx.toast('Input must be valid JSON', 'error');
+        return;
+      }
+    }
+    try {
+      var newRun = await ctx.apiFetch(
+        '/workflows/' + encodeURIComponent(id) + '/continue-as-new',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        }
+      );
+      ctx.toast('New run: ' + (newRun && newRun.workflow_id || 'unknown'), 'success');
+      if (newRun && newRun.workflow_id) {
+        showDetail(newRun.workflow_id, ctx);
+      } else {
+        closeDetail();
+      }
+      if (ctx.refreshCurrentView) ctx.refreshCurrentView();
+    } catch (err) {
+      ctx.toast('Continue-as-new failed: ' + err.message, 'error');
     }
   }
 

--- a/crates/assay-workflow/src/dashboard/components/schedules.js
+++ b/crates/assay-workflow/src/dashboard/components/schedules.js
@@ -6,11 +6,13 @@ var AssaySchedules = (function () {
   let ctx = null;
   let container = null;
   let showForm = false;
+  let editingName = null; // non-null when the form is in patch mode
 
   function render(el, context) {
     ctx = context;
     container = el;
     showForm = false;
+    editingName = null;
 
     el.innerHTML =
       '<div style="display: flex; align-items: center; justify-content: space-between; margin-bottom: 16px;">' +
@@ -22,6 +24,7 @@ var AssaySchedules = (function () {
 
     el.querySelector('#sched-toggle-form').addEventListener('click', function () {
       showForm = !showForm;
+      editingName = null;
       renderForm();
     });
 
@@ -30,61 +33,100 @@ var AssaySchedules = (function () {
       if (delBtn) {
         e.preventDefault();
         handleDelete(delBtn.dataset.name);
+        return;
+      }
+      var pauseBtn = e.target.closest('.btn-pause-schedule');
+      if (pauseBtn) {
+        e.preventDefault();
+        handleTogglePaused(pauseBtn.dataset.name, pauseBtn.dataset.paused === 'true');
+        return;
+      }
+      var editBtn = e.target.closest('.btn-edit-schedule');
+      if (editBtn) {
+        e.preventDefault();
+        openEditForm(editBtn.dataset.name);
       }
     });
 
     loadSchedules();
   }
 
-  function renderForm() {
+  /// Render the create-or-edit form in-place. When `editingName` is set,
+  /// the form is pre-filled with the current schedule's values and the
+  /// submit action PATCHes rather than POSTs.
+  function renderForm(prefill) {
     var wrap = container.querySelector('#sched-form-wrap');
     if (!showForm) {
       wrap.innerHTML = '';
       return;
     }
+    prefill = prefill || {};
+
+    var isEdit = !!editingName;
+    var heading = isEdit ? 'Edit schedule: ' + editingName : 'Create schedule';
+    var nameField = isEdit
+      ? '<input type="text" class="form-input mono" value="' + ctx.escapeHtml(editingName) + '" disabled>'
+      : '<input type="text" class="form-input" id="sched-name" placeholder="daily-cleanup" value="' + ctx.escapeHtml(prefill.name || '') + '">';
+    var typeField = isEdit
+      ? '<input type="text" class="form-input" value="' + ctx.escapeHtml(prefill.workflow_type || '') + '" disabled>'
+      : '<input type="text" class="form-input" id="sched-wf-type" placeholder="CleanupJob" value="' + ctx.escapeHtml(prefill.workflow_type || '') + '">';
 
     wrap.innerHTML =
       '<div class="form-card">' +
+        '<h3 style="margin: 0 0 12px;">' + heading + '</h3>' +
         '<div class="form-group">' +
           '<label class="form-label">Name</label>' +
-          '<input type="text" class="form-input" id="sched-name" placeholder="daily-cleanup">' +
+          nameField +
         '</div>' +
         '<div class="form-group">' +
           '<label class="form-label">Workflow Type</label>' +
-          '<input type="text" class="form-input" id="sched-wf-type" placeholder="CleanupJob">' +
+          typeField +
         '</div>' +
         '<div class="form-group">' +
           '<label class="form-label">Cron Expression</label>' +
-          '<input type="text" class="form-input" id="sched-cron" placeholder="0 * * * *">' +
+          '<input type="text" class="form-input" id="sched-cron" placeholder="0 0 2 * * *" value="' + ctx.escapeHtml(prefill.cron_expr || '') + '">' +
+        '</div>' +
+        '<div class="form-group">' +
+          '<label class="form-label">Timezone (IANA, default UTC)</label>' +
+          '<input type="text" class="form-input" id="sched-tz" placeholder="Europe/Berlin" value="' + ctx.escapeHtml(prefill.timezone || '') + '">' +
         '</div>' +
         '<div class="form-group">' +
           '<label class="form-label">Queue</label>' +
-          '<input type="text" class="form-input" id="sched-queue" placeholder="main" value="main">' +
+          '<input type="text" class="form-input" id="sched-queue" placeholder="main" value="' + ctx.escapeHtml(prefill.task_queue || 'main') + '">' +
         '</div>' +
         '<div class="form-group">' +
           '<label class="form-label">Input (JSON)</label>' +
-          '<textarea class="form-textarea" id="sched-input" placeholder="{}"></textarea>' +
+          '<textarea class="form-textarea" id="sched-input" placeholder="{}">' + ctx.escapeHtml(prefill.input || '') + '</textarea>' +
         '</div>' +
         '<div class="form-group">' +
           '<label class="form-label">Overlap Policy</label>' +
           '<select class="form-select" id="sched-overlap">' +
-            '<option value="skip">Skip</option>' +
-            '<option value="queue">Queue</option>' +
-            '<option value="cancel_old">Cancel Old</option>' +
-            '<option value="allow_all">Allow All</option>' +
+            overlapOption('skip', prefill.overlap_policy) +
+            overlapOption('queue', prefill.overlap_policy) +
+            overlapOption('cancel_old', prefill.overlap_policy) +
+            overlapOption('allow_all', prefill.overlap_policy) +
           '</select>' +
         '</div>' +
         '<div style="display: flex; gap: 8px;">' +
-          '<button class="btn btn-primary" id="sched-create-btn">Create Schedule</button>' +
+          '<button class="btn btn-primary" id="sched-submit-btn">' + (isEdit ? 'Save changes' : 'Create schedule') + '</button>' +
           '<button class="btn" id="sched-cancel-btn">Cancel</button>' +
         '</div>' +
       '</div>';
 
-    wrap.querySelector('#sched-create-btn').addEventListener('click', handleCreate);
+    wrap.querySelector('#sched-submit-btn').addEventListener(
+      'click',
+      isEdit ? handlePatch : handleCreate
+    );
     wrap.querySelector('#sched-cancel-btn').addEventListener('click', function () {
       showForm = false;
+      editingName = null;
       renderForm();
     });
+  }
+
+  function overlapOption(value, current) {
+    var selected = current === value ? ' selected' : '';
+    return '<option value="' + value + '"' + selected + '>' + value + '</option>';
   }
 
   async function loadSchedules() {
@@ -108,22 +150,32 @@ var AssaySchedules = (function () {
         '<th>Name</th>' +
         '<th>Workflow Type</th>' +
         '<th>Cron</th>' +
+        '<th>Timezone</th>' +
         '<th>Queue</th>' +
+        '<th>Paused</th>' +
         '<th>Last Run</th>' +
         '<th>Actions</th>' +
       '</tr></thead><tbody>';
 
     for (var i = 0; i < schedules.length; i++) {
       var s = schedules[i];
+      var paused = !!s.paused;
       html +=
         '<tr>' +
           '<td class="mono">' + ctx.escapeHtml(s.name) + '</td>' +
           '<td>' + ctx.escapeHtml(s.workflow_type) + '</td>' +
           '<td class="mono">' + ctx.escapeHtml(s.cron_expr) + '</td>' +
+          '<td>' + ctx.escapeHtml(s.timezone || 'UTC') + '</td>' +
           '<td class="mono">' + ctx.escapeHtml(s.task_queue || 'main') + '</td>' +
+          '<td>' + (paused ? '<span class="badge badge-waiting">paused</span>' : '<span class="badge badge-running">active</span>') + '</td>' +
           '<td>' + (s.last_run_at ? ctx.formatTime(s.last_run_at) : '-') + '</td>' +
-          '<td><button class="btn btn-sm btn-danger btn-delete-schedule" data-name="' +
-            ctx.escapeHtml(s.name) + '">Delete</button></td>' +
+          '<td>' +
+            '<button class="btn btn-sm btn-edit-schedule" data-name="' + ctx.escapeHtml(s.name) + '">Edit</button> ' +
+            '<button class="btn btn-sm btn-pause-schedule" data-name="' + ctx.escapeHtml(s.name) + '" data-paused="' + paused + '">' +
+              (paused ? 'Resume' : 'Pause') +
+            '</button> ' +
+            '<button class="btn btn-sm btn-danger btn-delete-schedule" data-name="' + ctx.escapeHtml(s.name) + '">Delete</button>' +
+          '</td>' +
         '</tr>';
     }
 
@@ -131,48 +183,124 @@ var AssaySchedules = (function () {
     wrap.innerHTML = html;
   }
 
+  async function openEditForm(name) {
+    try {
+      var s = await ctx.apiFetch('/schedules/' + encodeURIComponent(name));
+      if (!s) throw new Error('not found');
+      editingName = name;
+      showForm = true;
+      renderForm({
+        name: s.name,
+        workflow_type: s.workflow_type,
+        cron_expr: s.cron_expr,
+        timezone: s.timezone,
+        task_queue: s.task_queue,
+        input: s.input,
+        overlap_policy: s.overlap_policy,
+      });
+    } catch (err) {
+      ctx.toast('Load schedule failed: ' + err.message, 'error');
+    }
+  }
+
   async function handleCreate() {
     var name = container.querySelector('#sched-name').value.trim();
     var wfType = container.querySelector('#sched-wf-type').value.trim();
     var cron = container.querySelector('#sched-cron').value.trim();
+    var tz = container.querySelector('#sched-tz').value.trim();
     var queue = container.querySelector('#sched-queue').value.trim() || 'main';
     var inputStr = container.querySelector('#sched-input').value.trim();
     var overlap = container.querySelector('#sched-overlap').value;
 
     if (!name || !wfType || !cron) {
-      alert('Name, Workflow Type, and Cron Expression are required.');
+      ctx.toast('Name, workflow type, and cron are required', 'error');
       return;
     }
 
     var input = null;
     if (inputStr) {
       try { input = JSON.parse(inputStr); } catch (_) {
-        alert('Invalid JSON in input field.');
+        ctx.toast('Input is not valid JSON', 'error');
         return;
       }
     }
 
     var body = {
       name: name,
-      namespace: ctx.namespace,
+      namespace: ctx.getNamespace(),
       workflow_type: wfType,
       cron_expr: cron,
       task_queue: queue,
       overlap_policy: overlap,
     };
+    if (tz) body.timezone = tz;
     if (input !== null) body.input = input;
 
     try {
-      await fetch('/api/v1/schedules', {
+      await ctx.apiFetchRaw('/schedules', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),
       });
+      ctx.toast("Created schedule '" + name + "'", 'success');
       showForm = false;
+      editingName = null;
       renderForm();
       loadSchedules();
     } catch (err) {
-      alert('Create failed: ' + err.message);
+      ctx.toast('Create failed: ' + err.message, 'error');
+    }
+  }
+
+  async function handlePatch() {
+    var cron = container.querySelector('#sched-cron').value.trim();
+    var tz = container.querySelector('#sched-tz').value.trim();
+    var queue = container.querySelector('#sched-queue').value.trim();
+    var inputStr = container.querySelector('#sched-input').value.trim();
+    var overlap = container.querySelector('#sched-overlap').value;
+
+    var patch = {};
+    if (cron) patch.cron_expr = cron;
+    if (tz) patch.timezone = tz;
+    if (queue) patch.task_queue = queue;
+    if (overlap) patch.overlap_policy = overlap;
+    if (inputStr) {
+      try { patch.input = JSON.parse(inputStr); } catch (_) {
+        ctx.toast('Input is not valid JSON', 'error');
+        return;
+      }
+    }
+    if (Object.keys(patch).length === 0) {
+      ctx.toast('No changes to apply', 'info');
+      return;
+    }
+
+    try {
+      await ctx.apiFetch('/schedules/' + encodeURIComponent(editingName), {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(patch),
+      });
+      ctx.toast('Schedule updated', 'success');
+      showForm = false;
+      editingName = null;
+      renderForm();
+      loadSchedules();
+    } catch (err) {
+      ctx.toast('Update failed: ' + err.message, 'error');
+    }
+  }
+
+  async function handleTogglePaused(name, currentlyPaused) {
+    var action = currentlyPaused ? 'resume' : 'pause';
+    try {
+      await ctx.apiFetch('/schedules/' + encodeURIComponent(name) + '/' + action, {
+        method: 'POST',
+      });
+      ctx.toast('Schedule ' + (currentlyPaused ? 'resumed' : 'paused'), 'success');
+      loadSchedules();
+    } catch (err) {
+      ctx.toast(action + ' failed: ' + err.message, 'error');
     }
   }
 
@@ -180,9 +308,10 @@ var AssaySchedules = (function () {
     if (!confirm('Delete schedule "' + name + '"?')) return;
     try {
       await ctx.apiFetch('/schedules/' + encodeURIComponent(name), { method: 'DELETE' });
+      ctx.toast('Schedule deleted', 'success');
       loadSchedules();
     } catch (err) {
-      alert('Delete failed: ' + err.message);
+      ctx.toast('Delete failed: ' + err.message, 'error');
     }
   }
 

--- a/crates/assay-workflow/src/dashboard/components/settings.js
+++ b/crates/assay-workflow/src/dashboard/components/settings.js
@@ -27,11 +27,15 @@ var AssaySettings = (function () {
         '<div class="card-body" id="settings-engine-info">' +
           '<div class="meta-grid">' +
             metaItem('Service', 'assay-workflow') +
+            metaItem('Version', '<span class="mono" id="settings-version">loading…</span>') +
+            metaItem('Build', '<span id="settings-build-profile">—</span>') +
             metaItem('API Docs', '<a href="/api/v1/docs" target="_blank" class="clickable">/api/v1/docs</a>') +
             metaItem('OpenAPI Spec', '<a href="/api/v1/openapi.json" target="_blank" class="clickable">/api/v1/openapi.json</a>') +
           '</div>' +
         '</div>' +
       '</div>';
+
+    loadEngineInfo();
 
     var showCreate = false;
     el.querySelector('#settings-toggle-create').addEventListener('click', function () {
@@ -137,24 +141,29 @@ var AssaySettings = (function () {
     var input = container.querySelector('#settings-ns-name');
     var name = input.value.trim();
     if (!name) {
-      alert('Namespace name is required.');
+      ctx.toast('Namespace name is required', 'error');
       return;
     }
 
     try {
-      await fetch('/api/v1/namespaces', {
+      var res = await fetch('/api/v1/namespaces', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ name: name }),
       });
+      if (!res.ok) {
+        var body = await res.text();
+        throw new Error(body || res.statusText);
+      }
       input.value = '';
+      ctx.toast("Created namespace '" + name + "'", 'success');
       loadNamespaces();
-      // Refresh the namespace dropdown in the sidebar
+      // Refresh the namespace dropdown in the sidebar.
       if (window.AssayApp && window.AssayApp.refreshCurrentView) {
         window.AssayApp.refreshCurrentView();
       }
     } catch (err) {
-      alert('Create failed: ' + err.message);
+      ctx.toast('Create failed: ' + err.message, 'error');
     }
   }
 
@@ -166,9 +175,27 @@ var AssaySettings = (function () {
         var body = await res.text();
         throw new Error(body || res.statusText);
       }
+      ctx.toast("Deleted namespace '" + name + "'", 'success');
       loadNamespaces();
+      if (window.AssayApp && window.AssayApp.refreshCurrentView) {
+        window.AssayApp.refreshCurrentView();
+      }
     } catch (err) {
-      alert('Delete failed: ' + err.message);
+      ctx.toast('Delete failed: ' + err.message, 'error');
+    }
+  }
+
+  async function loadEngineInfo() {
+    try {
+      var v = await ctx.apiFetchRaw('/version');
+      if (v) {
+        var vel = container.querySelector('#settings-version');
+        var bel = container.querySelector('#settings-build-profile');
+        if (vel) vel.textContent = 'v' + (v.version || '?');
+        if (bel) bel.textContent = v.build_profile || '—';
+      }
+    } catch (_) {
+      // Non-fatal — older engines may not have /version. Leave placeholders.
     }
   }
 

--- a/crates/assay-workflow/src/dashboard/components/workflows.js
+++ b/crates/assay-workflow/src/dashboard/components/workflows.js
@@ -7,6 +7,7 @@ var AssayWorkflows = (function () {
   let currentOffset = 0;
   let currentFilter = '';
   let searchTerm = '';
+  let searchAttrs = '';
   let ctx = null;
   let container = null;
 
@@ -16,6 +17,7 @@ var AssayWorkflows = (function () {
     currentOffset = 0;
     currentFilter = '';
     searchTerm = '';
+    searchAttrs = '';
 
     el.innerHTML =
       '<h2 class="section-title">Workflows</h2>' +
@@ -30,7 +32,10 @@ var AssayWorkflows = (function () {
           '<option value="WAITING">Waiting</option>' +
           '<option value="CANCELLED">Cancelled</option>' +
         '</select>' +
+        '<input type="text" class="search-input" id="wf-search-attrs" placeholder=\'Search attrs filter, e.g. {"env":"prod"}\' style="flex:1.2;">' +
+        '<button type="button" class="btn-action btn-action-primary" id="wf-start-toggle">+ Start workflow</button>' +
       '</div>' +
+      '<div id="wf-start-form-wrap"></div>' +
       '<div id="wf-table-wrap"></div>' +
       '<div id="wf-pagination" class="pagination"></div>';
 
@@ -45,6 +50,21 @@ var AssayWorkflows = (function () {
       currentOffset = 0;
       loadWorkflows();
     });
+
+    // Search-attributes filter: debounce so every keystroke doesn't hit
+    // the API. 300ms matches common search-field latency heuristics.
+    let searchAttrsTimer = null;
+    el.querySelector('#wf-search-attrs').addEventListener('input', function (e) {
+      const val = e.target.value.trim();
+      clearTimeout(searchAttrsTimer);
+      searchAttrsTimer = setTimeout(function () {
+        searchAttrs = val;
+        currentOffset = 0;
+        loadWorkflows();
+      }, 300);
+    });
+
+    el.querySelector('#wf-start-toggle').addEventListener('click', toggleStartForm);
 
     el.querySelector('#wf-table-wrap').addEventListener('click', function (e) {
       var link = e.target.closest('.wf-link');
@@ -65,6 +85,13 @@ var AssayWorkflows = (function () {
       if (cancelBtn) {
         e.preventDefault();
         handleCancel(cancelBtn.dataset.id);
+        return;
+      }
+
+      var termBtn = e.target.closest('.btn-terminate');
+      if (termBtn) {
+        e.preventDefault();
+        handleTerminate(termBtn.dataset.id);
       }
     });
 
@@ -83,6 +110,21 @@ var AssayWorkflows = (function () {
     var params = '?limit=' + PAGE_SIZE + '&offset=' + currentOffset;
     if (currentFilter) params += '&status=' + currentFilter;
     if (searchTerm) params += '&type=' + encodeURIComponent(searchTerm);
+    if (searchAttrs) {
+      // Validate JSON client-side so bad input doesn't silently vanish.
+      try {
+        JSON.parse(searchAttrs);
+        params += '&search_attrs=' + encodeURIComponent(searchAttrs);
+      } catch (_) {
+        // Invalid JSON: skip the param, leave a subtle hint on the input.
+        var attrsInput = container.querySelector('#wf-search-attrs');
+        if (attrsInput) attrsInput.style.borderColor = '#d04040';
+        renderTable(wrap, []);
+        return;
+      }
+    }
+    var attrsInput = container.querySelector('#wf-search-attrs');
+    if (attrsInput) attrsInput.style.borderColor = '';
 
     try {
       var workflows = await ctx.apiFetch('/workflows' + params);
@@ -128,7 +170,8 @@ var AssayWorkflows = (function () {
       if (!terminal) {
         html +=
           '<button class="btn btn-sm btn-signal" data-id="' + ctx.escapeHtml(wf.id) + '">Signal</button> ' +
-          '<button class="btn btn-sm btn-danger btn-cancel" data-id="' + ctx.escapeHtml(wf.id) + '">Cancel</button>';
+          '<button class="btn btn-sm btn-cancel" data-id="' + ctx.escapeHtml(wf.id) + '">Cancel</button> ' +
+          '<button class="btn btn-sm btn-danger btn-terminate" data-id="' + ctx.escapeHtml(wf.id) + '">Terminate</button>';
       } else {
         html += '<span style="color: var(--text-muted)">-</span>';
       }
@@ -158,6 +201,91 @@ var AssayWorkflows = (function () {
     pag.innerHTML = html;
   }
 
+  /// Open/close the inline "start workflow" form. Collapsed by default so
+  /// the list takes the full width; click the button to expand.
+  function toggleStartForm() {
+    var wrap = container.querySelector('#wf-start-form-wrap');
+    if (wrap.innerHTML.trim() !== '') {
+      wrap.innerHTML = '';
+      return;
+    }
+    wrap.innerHTML =
+      '<form class="inline-form" id="wf-start-form">' +
+        '<label>Workflow type <span style="color:#d04040">*</span>' +
+          '<input type="text" name="type" placeholder="e.g. IngestData" required>' +
+        '</label>' +
+        '<label>Workflow ID (optional — auto-generated if blank)' +
+          '<input type="text" name="id" placeholder="e.g. ingest-2026-04-17">' +
+        '</label>' +
+        '<label>Task queue' +
+          '<input type="text" name="task_queue" value="default">' +
+        '</label>' +
+        '<label>Input (JSON, optional)' +
+          '<textarea name="input" placeholder=\'{"key":"value"}\'></textarea>' +
+        '</label>' +
+        '<label>Search attributes (JSON, optional)' +
+          '<textarea name="search_attrs" placeholder=\'{"env":"prod","tenant":"acme"}\'></textarea>' +
+        '</label>' +
+        '<div class="form-actions">' +
+          '<button type="button" class="btn-action" id="wf-start-cancel">Cancel</button>' +
+          '<button type="submit" class="btn-action btn-action-primary">Start</button>' +
+        '</div>' +
+      '</form>';
+    wrap.querySelector('#wf-start-cancel').addEventListener('click', function () {
+      wrap.innerHTML = '';
+    });
+    wrap.querySelector('#wf-start-form').addEventListener('submit', handleStart);
+  }
+
+  async function handleStart(e) {
+    e.preventDefault();
+    var form = e.currentTarget;
+    var data = new FormData(form);
+    var body = {
+      workflow_type: data.get('type').trim(),
+      task_queue: (data.get('task_queue') || 'default').trim(),
+      namespace: ctx.getNamespace(),
+    };
+    var idVal = (data.get('id') || '').trim();
+    if (idVal) {
+      body.workflow_id = idVal;
+    } else {
+      body.workflow_id =
+        'wf-' + body.workflow_type.toLowerCase() + '-' + Date.now();
+    }
+    var inputRaw = (data.get('input') || '').trim();
+    if (inputRaw) {
+      try {
+        body.input = JSON.parse(inputRaw);
+      } catch (err) {
+        ctx.toast('Input is not valid JSON', 'error');
+        return;
+      }
+    }
+    var attrsRaw = (data.get('search_attrs') || '').trim();
+    if (attrsRaw) {
+      try {
+        body.search_attributes = JSON.parse(attrsRaw);
+      } catch (err) {
+        ctx.toast('Search attributes must be valid JSON', 'error');
+        return;
+      }
+    }
+
+    try {
+      await ctx.apiFetchRaw('/workflows', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      ctx.toast('Started ' + body.workflow_id, 'success');
+      container.querySelector('#wf-start-form-wrap').innerHTML = '';
+      loadWorkflows();
+    } catch (err) {
+      ctx.toast('Start failed: ' + err.message, 'error');
+    }
+  }
+
   async function handleSignal(id) {
     var name = prompt('Signal name:');
     if (!name) return;
@@ -177,9 +305,10 @@ var AssayWorkflows = (function () {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ payload: payload }),
       });
+      ctx.toast("Signal '" + name + "' sent", 'success');
       loadWorkflows();
     } catch (err) {
-      alert('Signal failed: ' + err.message);
+      ctx.toast('Signal failed: ' + err.message, 'error');
     }
   }
 
@@ -189,9 +318,30 @@ var AssayWorkflows = (function () {
       await ctx.apiFetch('/workflows/' + encodeURIComponent(id) + '/cancel', {
         method: 'POST',
       });
+      ctx.toast('Cancel requested', 'success');
       loadWorkflows();
     } catch (err) {
-      alert('Cancel failed: ' + err.message);
+      ctx.toast('Cancel failed: ' + err.message, 'error');
+    }
+  }
+
+  async function handleTerminate(id) {
+    var reason = prompt(
+      'Terminate workflow ' + id + '?\n\nReason (optional):',
+      ''
+    );
+    if (reason === null) return; // user cancelled
+    var body = reason ? { reason: reason } : {};
+    try {
+      await ctx.apiFetch('/workflows/' + encodeURIComponent(id) + '/terminate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      ctx.toast('Terminated', 'success');
+      loadWorkflows();
+    } catch (err) {
+      ctx.toast('Terminate failed: ' + err.message, 'error');
     }
   }
 

--- a/crates/assay-workflow/src/dashboard/index.html
+++ b/crates/assay-workflow/src/dashboard/index.html
@@ -70,7 +70,7 @@
       Workers: <strong id="status-workers">0</strong>
     </span>
     <span class="status-item status-version">
-      Assay Workflow Engine
+      Assay Workflow Engine <span id="status-version">—</span>
     </span>
   </footer>
 

--- a/crates/assay-workflow/src/dashboard/style.css
+++ b/crates/assay-workflow/src/dashboard/style.css
@@ -764,3 +764,140 @@ html, body {
     grid-template-columns: 1fr;
   }
 }
+
+/* ── Toast notifications (tier-1 dashboard) ─────────────────────────
+   Transient feedback for mutation results. Bottom-right stack, one
+   toast per action. Colour-coded by kind (success / error / info). */
+
+.toast-container {
+  position: fixed;
+  bottom: 40px;
+  right: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  z-index: 300;
+  pointer-events: none;
+}
+
+.toast {
+  background: var(--surface-2);
+  color: var(--text-primary);
+  border: 1px solid var(--border);
+  border-left-width: 4px;
+  padding: 10px 14px;
+  border-radius: 6px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  min-width: 200px;
+  max-width: 420px;
+  opacity: 0;
+  transform: translateX(12px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  font-size: 13px;
+  pointer-events: auto;
+}
+
+.toast-show {
+  opacity: 1;
+  transform: translateX(0);
+}
+
+.toast-success {
+  border-left-color: var(--accent);
+}
+
+.toast-error {
+  border-left-color: #d04040;
+}
+
+.toast-info {
+  border-left-color: var(--text-muted, #888);
+}
+
+/* ── Action buttons + inline forms (tier-1 dashboard) ───────────────
+   Reused across workflow detail, schedule rows, settings namespace
+   list. Minimal: outline by default, solid on primary action. */
+
+.action-row {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin: 12px 0;
+}
+
+.btn-action {
+  background: transparent;
+  color: var(--text-primary);
+  border: 1px solid var(--border);
+  padding: 6px 12px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 13px;
+  font-family: inherit;
+}
+
+.btn-action:hover {
+  background: var(--surface-2);
+}
+
+.btn-action-primary {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+}
+
+.btn-action-primary:hover {
+  filter: brightness(1.1);
+}
+
+.btn-action-danger {
+  color: #d04040;
+  border-color: #d04040;
+}
+
+.btn-action-danger:hover {
+  background: rgba(208, 64, 64, 0.08);
+}
+
+.inline-form {
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 12px;
+  margin: 12px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.inline-form label {
+  font-size: 12px;
+  color: var(--text-muted, #888);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.inline-form input[type="text"],
+.inline-form textarea,
+.inline-form select {
+  background: var(--surface-1);
+  color: var(--text-primary);
+  border: 1px solid var(--border);
+  padding: 6px 8px;
+  border-radius: 4px;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 13px;
+}
+
+.inline-form textarea {
+  min-height: 80px;
+  resize: vertical;
+}
+
+.inline-form .form-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  margin-top: 4px;
+}

--- a/crates/assay-workflow/src/engine.rs
+++ b/crates/assay-workflow/src/engine.rs
@@ -21,6 +21,8 @@ pub struct Engine<S: WorkflowStore> {
     _timer_poller: JoinHandle<()>,
     _health_monitor: JoinHandle<()>,
     _dispatch_recovery: JoinHandle<()>,
+    #[cfg(feature = "s3-archival")]
+    _archival: Option<JoinHandle<()>>,
 }
 
 impl<S: WorkflowStore> Engine<S> {
@@ -35,6 +37,11 @@ impl<S: WorkflowStore> Engine<S> {
             Arc::clone(&store),
         ));
 
+        #[cfg(feature = "s3-archival")]
+        let _archival = crate::archival::ArchivalConfig::from_env().map(|cfg| {
+            tokio::spawn(crate::archival::run_archival(Arc::clone(&store), cfg))
+        });
+
         info!("Workflow engine started");
 
         Self {
@@ -43,6 +50,8 @@ impl<S: WorkflowStore> Engine<S> {
             _timer_poller,
             _health_monitor,
             _dispatch_recovery,
+            #[cfg(feature = "s3-archival")]
+            _archival,
         }
     }
 
@@ -78,6 +87,8 @@ impl<S: WorkflowStore> Engine<S> {
             parent_id: None,
             claimed_by: None,
             search_attributes: search_attributes.map(String::from),
+            archived_at: None,
+            archive_uri: None,
             created_at: now,
             updated_at: now,
             completed_at: None,
@@ -1022,6 +1033,8 @@ impl<S: WorkflowStore> Engine<S> {
             parent_id: Some(parent_id.to_string()),
             claimed_by: None,
             search_attributes: None,
+            archived_at: None,
+            archive_uri: None,
             created_at: now,
             updated_at: now,
             completed_at: None,

--- a/crates/assay-workflow/src/engine.rs
+++ b/crates/assay-workflow/src/engine.rs
@@ -672,6 +672,22 @@ impl<S: WorkflowStore> Engine<S> {
                         .unwrap_or(0.0);
                     self.schedule_timer(workflow_id, seq, duration).await?;
                 }
+                "RecordSnapshot" => {
+                    // Persist the workflow's current query-handler state. Each
+                    // snapshot is keyed by the current event seq so the latest
+                    // is easy to retrieve via `get_latest_snapshot`. Runs on
+                    // every worker replay, which is fine — `create_snapshot`
+                    // is an insert, so each replay adds a new row reflecting
+                    // the state at that point in history.
+                    let state = cmd
+                        .get("state")
+                        .cloned()
+                        .unwrap_or(serde_json::Value::Null);
+                    let event_seq = self.store.get_event_count(workflow_id).await? as i32;
+                    self.store
+                        .create_snapshot(workflow_id, event_seq, &state.to_string())
+                        .await?;
+                }
                 "CompleteWorkflow" => {
                     let result = cmd.get("result").map(|v| v.to_string());
                     self.complete_workflow(workflow_id, result.as_deref()).await?;

--- a/crates/assay-workflow/src/engine.rs
+++ b/crates/assay-workflow/src/engine.rs
@@ -921,6 +921,24 @@ impl<S: WorkflowStore> Engine<S> {
         self.store.delete_schedule(namespace, name).await
     }
 
+    pub async fn update_schedule(
+        &self,
+        namespace: &str,
+        name: &str,
+        patch: &SchedulePatch,
+    ) -> Result<Option<WorkflowSchedule>> {
+        self.store.update_schedule(namespace, name, patch).await
+    }
+
+    pub async fn set_schedule_paused(
+        &self,
+        namespace: &str,
+        name: &str,
+        paused: bool,
+    ) -> Result<Option<WorkflowSchedule>> {
+        self.store.set_schedule_paused(namespace, name, paused).await
+    }
+
     // ── Namespace Operations ────────────────────────────────
 
     pub async fn create_namespace(&self, name: &str) -> Result<()> {

--- a/crates/assay-workflow/src/engine.rs
+++ b/crates/assay-workflow/src/engine.rs
@@ -672,6 +672,17 @@ impl<S: WorkflowStore> Engine<S> {
                         .unwrap_or(0.0);
                     self.schedule_timer(workflow_id, seq, duration).await?;
                 }
+                "ContinueAsNew" => {
+                    // Close out the current run and start a new one with the
+                    // same type / namespace / queue under a fresh id. Input
+                    // may be any JSON value; it's serialised and becomes the
+                    // new run's `input`. Called from workflow code via
+                    // `ctx:continue_as_new(input)` to reset event history
+                    // when a handler would otherwise loop forever.
+                    let input = cmd.get("input").map(|v| v.to_string());
+                    self.continue_as_new(workflow_id, input.as_deref())
+                        .await?;
+                }
                 "RecordSnapshot" => {
                     // Persist the workflow's current query-handler state. Each
                     // snapshot is keyed by the current event seq so the latest

--- a/crates/assay-workflow/src/engine.rs
+++ b/crates/assay-workflow/src/engine.rs
@@ -60,6 +60,7 @@ impl<S: WorkflowStore> Engine<S> {
         workflow_id: &str,
         input: Option<&str>,
         task_queue: &str,
+        search_attributes: Option<&str>,
     ) -> Result<WorkflowRecord> {
         let now = timestamp_now();
         let run_id = format!("run-{workflow_id}-{}", now as u64);
@@ -76,6 +77,7 @@ impl<S: WorkflowStore> Engine<S> {
             error: None,
             parent_id: None,
             claimed_by: None,
+            search_attributes: search_attributes.map(String::from),
             created_at: now,
             updated_at: now,
             completed_at: None,
@@ -110,11 +112,29 @@ impl<S: WorkflowStore> Engine<S> {
         namespace: &str,
         status: Option<WorkflowStatus>,
         workflow_type: Option<&str>,
+        search_attrs_filter: Option<&str>,
         limit: i64,
         offset: i64,
     ) -> Result<Vec<WorkflowRecord>> {
         self.store
-            .list_workflows(namespace, status, workflow_type, limit, offset)
+            .list_workflows(
+                namespace,
+                status,
+                workflow_type,
+                search_attrs_filter,
+                limit,
+                offset,
+            )
+            .await
+    }
+
+    pub async fn upsert_search_attributes(
+        &self,
+        workflow_id: &str,
+        patch_json: &str,
+    ) -> Result<()> {
+        self.store
+            .upsert_search_attributes(workflow_id, patch_json)
             .await
     }
 
@@ -672,6 +692,20 @@ impl<S: WorkflowStore> Engine<S> {
                         .unwrap_or(0.0);
                     self.schedule_timer(workflow_id, seq, duration).await?;
                 }
+                "UpsertSearchAttributes" => {
+                    // Merge the patch object into the workflow's stored
+                    // search_attributes. Workflow code can call this from
+                    // `ctx:upsert_search_attributes(...)` to surface live
+                    // progress / tenant / env tags that downstream callers
+                    // can filter on via the list endpoint.
+                    let patch = cmd
+                        .get("patch")
+                        .cloned()
+                        .unwrap_or(serde_json::Value::Object(Default::default()));
+                    self.store
+                        .upsert_search_attributes(workflow_id, &patch.to_string())
+                        .await?;
+                }
                 "ContinueAsNew" => {
                     // Close out the current run and start a new one with the
                     // same type / namespace / queue under a fresh id. Input
@@ -987,6 +1021,7 @@ impl<S: WorkflowStore> Engine<S> {
             error: None,
             parent_id: Some(parent_id.to_string()),
             claimed_by: None,
+            search_attributes: None,
             created_at: now,
             updated_at: now,
             completed_at: None,
@@ -1060,6 +1095,7 @@ impl<S: WorkflowStore> Engine<S> {
             &new_id,
             input,
             &old_wf.task_queue,
+            old_wf.search_attributes.as_deref(),
         )
         .await
     }

--- a/crates/assay-workflow/src/lib.rs
+++ b/crates/assay-workflow/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod api;
+pub mod archival;
 pub mod dispatch_recovery;
 pub mod engine;
 pub mod health;
@@ -12,3 +13,11 @@ pub use engine::Engine;
 pub use store::postgres::PostgresStore;
 pub use store::sqlite::SqliteStore;
 pub use store::WorkflowStore;
+
+#[cfg(feature = "s3-archival")]
+pub(crate) fn timestamp_now() -> f64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs_f64()
+}

--- a/crates/assay-workflow/src/scheduler.rs
+++ b/crates/assay-workflow/src/scheduler.rs
@@ -117,6 +117,7 @@ async fn evaluate_namespace_schedules<S: WorkflowStore>(store: &S, namespace: &s
             error: None,
             parent_id: None,
             claimed_by: None,
+            search_attributes: None,
             created_at: now,
             updated_at: now,
             completed_at: None,

--- a/crates/assay-workflow/src/scheduler.rs
+++ b/crates/assay-workflow/src/scheduler.rs
@@ -69,11 +69,15 @@ async fn evaluate_namespace_schedules<S: WorkflowStore>(store: &S, namespace: &s
             continue;
         }
 
-        // Parse cron to compute next run
-        let next_run = match compute_next_run(&sched.cron_expr) {
+        // Parse cron to compute next run — interpreted in the schedule's
+        // configured timezone (defaults to UTC).
+        let next_run = match compute_next_run(&sched.cron_expr, &sched.timezone) {
             Some(t) => t,
             None => {
-                warn!("Invalid cron expression for schedule '{}': {}", sched.name, sched.cron_expr);
+                warn!(
+                    "Invalid cron expression or timezone for schedule '{}': expr={} tz={}",
+                    sched.name, sched.cron_expr, sched.timezone
+                );
                 continue;
             }
         };
@@ -147,9 +151,16 @@ async fn evaluate_namespace_schedules<S: WorkflowStore>(store: &S, namespace: &s
     Ok(())
 }
 
-fn compute_next_run(cron_expr: &str) -> Option<f64> {
+fn compute_next_run(cron_expr: &str, timezone: &str) -> Option<f64> {
     let schedule = Schedule::from_str(cron_expr).ok()?;
-    let next = schedule.upcoming(chrono::Utc).next()?;
+    // Empty string is treated as UTC so older schedules (pre-v0.11.3) keep
+    // behaving identically even if they migrate in without the column set.
+    if timezone.is_empty() || timezone.eq_ignore_ascii_case("UTC") {
+        let next = schedule.upcoming(chrono::Utc).next()?;
+        return Some(next.timestamp() as f64);
+    }
+    let tz: chrono_tz::Tz = timezone.parse().ok()?;
+    let next = schedule.upcoming(tz).next()?;
     Some(next.timestamp() as f64)
 }
 
@@ -158,4 +169,40 @@ fn timestamp_now() -> f64 {
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()
         .as_secs_f64()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// "Daily at 02:00" computes a different UTC epoch depending on the
+    /// schedule's timezone. UTC and Europe/Berlin produce different
+    /// next-fire times outside of the months where they happen to align.
+    #[test]
+    fn compute_next_run_honors_timezone() {
+        let utc_next = compute_next_run("0 0 2 * * *", "UTC").expect("utc next_run");
+        let berlin_next =
+            compute_next_run("0 0 2 * * *", "Europe/Berlin").expect("berlin next_run");
+        assert_ne!(
+            utc_next, berlin_next,
+            "02:00 UTC and 02:00 Europe/Berlin should not coincide"
+        );
+    }
+
+    #[test]
+    fn compute_next_run_empty_timezone_defaults_to_utc() {
+        let utc_next = compute_next_run("0 0 2 * * *", "UTC").expect("utc next_run");
+        let default_next = compute_next_run("0 0 2 * * *", "").expect("empty next_run");
+        assert_eq!(utc_next, default_next);
+    }
+
+    #[test]
+    fn compute_next_run_invalid_timezone_returns_none() {
+        assert!(compute_next_run("0 0 2 * * *", "Not/AZone").is_none());
+    }
+
+    #[test]
+    fn compute_next_run_invalid_cron_returns_none() {
+        assert!(compute_next_run("not a cron", "UTC").is_none());
+    }
 }

--- a/crates/assay-workflow/src/scheduler.rs
+++ b/crates/assay-workflow/src/scheduler.rs
@@ -118,6 +118,8 @@ async fn evaluate_namespace_schedules<S: WorkflowStore>(store: &S, namespace: &s
             parent_id: None,
             claimed_by: None,
             search_attributes: None,
+            archived_at: None,
+            archive_uri: None,
             created_at: now,
             updated_at: now,
             completed_at: None,

--- a/crates/assay-workflow/src/store/mod.rs
+++ b/crates/assay-workflow/src/store/mod.rs
@@ -56,6 +56,26 @@ pub trait WorkflowStore: Send + Sync + 'static {
         offset: i64,
     ) -> impl Future<Output = anyhow::Result<Vec<WorkflowRecord>>> + Send;
 
+    /// List workflows in terminal states whose `completed_at` is older than
+    /// `cutoff` and which haven't been archived yet. Used by the optional
+    /// S3 archival background task to batch candidates.
+    fn list_archivable_workflows(
+        &self,
+        cutoff: f64,
+        limit: i64,
+    ) -> impl Future<Output = anyhow::Result<Vec<WorkflowRecord>>> + Send;
+
+    /// Mark a workflow as archived (records `archived_at` + `archive_uri`)
+    /// and purge its events, activities, timers, signals, and snapshots.
+    /// The workflow record itself is preserved so `GET /workflows/{id}`
+    /// still resolves with an archive pointer.
+    fn mark_archived_and_purge(
+        &self,
+        workflow_id: &str,
+        archive_uri: &str,
+        archived_at: f64,
+    ) -> impl Future<Output = anyhow::Result<()>> + Send;
+
     /// Merge a JSON object patch into the workflow's `search_attributes`.
     /// Keys in the patch overwrite existing keys; keys already present but
     /// not in the patch are preserved. If the current column is NULL, the

--- a/crates/assay-workflow/src/store/mod.rs
+++ b/crates/assay-workflow/src/store/mod.rs
@@ -266,6 +266,33 @@ pub trait WorkflowStore: Send + Sync + 'static {
         name: &str,
     ) -> impl Future<Output = anyhow::Result<bool>> + Send;
 
+    /// Apply an in-place patch to a schedule. Only fields present on
+    /// `patch` are updated; the rest keep their current values. Returns
+    /// the updated record, or `None` if the schedule doesn't exist.
+    ///
+    /// The scheduler's `next_run_at` is recomputed from the new
+    /// `cron_expr` + `timezone` on the next evaluation tick, so a PATCH
+    /// takes effect within the scheduler's poll interval.
+    fn update_schedule(
+        &self,
+        namespace: &str,
+        name: &str,
+        patch: &SchedulePatch,
+    ) -> impl Future<Output = anyhow::Result<Option<WorkflowSchedule>>> + Send;
+
+    /// Flip a schedule's `paused` flag. Returns the updated record, or
+    /// `None` if the schedule doesn't exist.
+    ///
+    /// A paused schedule is skipped by the scheduler; resuming it
+    /// doesn't backfill missed fires — the next fire is whatever the
+    /// cron expression says, starting from now.
+    fn set_schedule_paused(
+        &self,
+        namespace: &str,
+        name: &str,
+        paused: bool,
+    ) -> impl Future<Output = anyhow::Result<Option<WorkflowSchedule>>> + Send;
+
     // ── Workers ─────────────────────────────────────────────
 
     fn register_worker(

--- a/crates/assay-workflow/src/store/mod.rs
+++ b/crates/assay-workflow/src/store/mod.rs
@@ -51,9 +51,20 @@ pub trait WorkflowStore: Send + Sync + 'static {
         namespace: &str,
         status: Option<WorkflowStatus>,
         workflow_type: Option<&str>,
+        search_attrs_filter: Option<&str>,
         limit: i64,
         offset: i64,
     ) -> impl Future<Output = anyhow::Result<Vec<WorkflowRecord>>> + Send;
+
+    /// Merge a JSON object patch into the workflow's `search_attributes`.
+    /// Keys in the patch overwrite existing keys; keys already present but
+    /// not in the patch are preserved. If the current column is NULL, the
+    /// patch becomes the new value.
+    fn upsert_search_attributes(
+        &self,
+        workflow_id: &str,
+        patch_json: &str,
+    ) -> impl Future<Output = anyhow::Result<()>> + Send;
 
     fn update_workflow_status(
         &self,

--- a/crates/assay-workflow/src/store/postgres.rs
+++ b/crates/assay-workflow/src/store/postgres.rs
@@ -39,11 +39,6 @@ CREATE TABLE IF NOT EXISTS workflows (
 CREATE INDEX IF NOT EXISTS idx_wf_status_queue ON workflows(status, task_queue);
 CREATE INDEX IF NOT EXISTS idx_wf_namespace ON workflows(namespace);
 CREATE INDEX IF NOT EXISTS idx_wf_dispatch ON workflows(task_queue, needs_dispatch, dispatch_claimed_by);
--- Upgrades from v0.11.2 need the additive columns; on fresh installs
--- they're already in the CREATE above so these ADDs are no-ops.
-ALTER TABLE workflows ADD COLUMN IF NOT EXISTS search_attributes TEXT;
-ALTER TABLE workflows ADD COLUMN IF NOT EXISTS archived_at DOUBLE PRECISION;
-ALTER TABLE workflows ADD COLUMN IF NOT EXISTS archive_uri TEXT;
 
 CREATE TABLE IF NOT EXISTS workflow_events (
     id              BIGSERIAL PRIMARY KEY,
@@ -116,10 +111,6 @@ CREATE TABLE IF NOT EXISTS workflow_schedules (
     created_at      DOUBLE PRECISION NOT NULL,
     PRIMARY KEY (namespace, name)
 );
--- Upgrades from v0.11.2 need the timezone column added; on a fresh
--- install the CREATE TABLE above has already created it and this is
--- a silent no-op.
-ALTER TABLE workflow_schedules ADD COLUMN IF NOT EXISTS timezone TEXT NOT NULL DEFAULT 'UTC';
 
 CREATE TABLE IF NOT EXISTS workflow_workers (
     id              TEXT PRIMARY KEY,
@@ -150,6 +141,16 @@ CREATE TABLE IF NOT EXISTS api_keys (
     created_at      DOUBLE PRECISION NOT NULL
 );
 CREATE INDEX IF NOT EXISTS idx_api_keys_prefix ON api_keys(prefix);
+
+-- Future additive migrations go below this line. Postgres supports
+-- `ADD COLUMN IF NOT EXISTS` natively, so the pattern is simply:
+--
+--   ALTER TABLE workflows ADD COLUMN IF NOT EXISTS some_new_field TEXT;
+--
+-- Idempotent across startups; fresh installs pick the column up from the
+-- CREATE TABLE above so the ADD is a no-op. Currently no pending
+-- migrations — baseline schema in CREATE TABLE statements above is the
+-- source of truth through v0.11.3.
 "#;
 
 pub struct PostgresStore {

--- a/crates/assay-workflow/src/store/postgres.rs
+++ b/crates/assay-workflow/src/store/postgres.rs
@@ -25,6 +25,7 @@ CREATE TABLE IF NOT EXISTS workflows (
     error           TEXT,
     parent_id       TEXT,
     claimed_by      TEXT,
+    search_attributes TEXT,
     -- Workflow-task dispatch (Phase 9): see sqlite.rs for the full comment.
     needs_dispatch  BOOLEAN NOT NULL DEFAULT FALSE,
     dispatch_claimed_by    TEXT,
@@ -36,6 +37,9 @@ CREATE TABLE IF NOT EXISTS workflows (
 CREATE INDEX IF NOT EXISTS idx_wf_status_queue ON workflows(status, task_queue);
 CREATE INDEX IF NOT EXISTS idx_wf_namespace ON workflows(namespace);
 CREATE INDEX IF NOT EXISTS idx_wf_dispatch ON workflows(task_queue, needs_dispatch, dispatch_claimed_by);
+-- Upgrades from v0.11.2 need the column + GIN index added; on fresh
+-- installs both already exist (CREATE above) and these are no-ops.
+ALTER TABLE workflows ADD COLUMN IF NOT EXISTS search_attributes TEXT;
 
 CREATE TABLE IF NOT EXISTS workflow_events (
     id              BIGSERIAL PRIMARY KEY,
@@ -265,8 +269,8 @@ impl WorkflowStore for PostgresStore {
 
     async fn create_workflow(&self, wf: &WorkflowRecord) -> Result<()> {
         sqlx::query(
-            "INSERT INTO workflows (id, namespace, run_id, workflow_type, task_queue, status, input, result, error, parent_id, claimed_by, created_at, updated_at, completed_at)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)",
+            "INSERT INTO workflows (id, namespace, run_id, workflow_type, task_queue, status, input, result, error, parent_id, claimed_by, search_attributes, created_at, updated_at, completed_at)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)",
         )
         .bind(&wf.id)
         .bind(&wf.namespace)
@@ -279,6 +283,7 @@ impl WorkflowStore for PostgresStore {
         .bind(&wf.error)
         .bind(&wf.parent_id)
         .bind(&wf.claimed_by)
+        .bind(&wf.search_attributes)
         .bind(wf.created_at)
         .bind(wf.updated_at)
         .bind(wf.completed_at)
@@ -289,7 +294,7 @@ impl WorkflowStore for PostgresStore {
 
     async fn get_workflow(&self, id: &str) -> Result<Option<WorkflowRecord>> {
         let row = sqlx::query_as::<_, PgWorkflowRow>(
-            "SELECT id, namespace, run_id, workflow_type, task_queue, status, input, result, error, parent_id, claimed_by, created_at, updated_at, completed_at FROM workflows WHERE id = $1",
+            "SELECT id, namespace, run_id, workflow_type, task_queue, status, input, result, error, parent_id, claimed_by, search_attributes, created_at, updated_at, completed_at FROM workflows WHERE id = $1",
         )
         .bind(id)
         .fetch_optional(&self.pool)
@@ -302,26 +307,51 @@ impl WorkflowStore for PostgresStore {
         namespace: &str,
         status: Option<WorkflowStatus>,
         workflow_type: Option<&str>,
+        search_attrs_filter: Option<&str>,
         limit: i64,
         offset: i64,
     ) -> Result<Vec<WorkflowRecord>> {
         let status_str = status.map(|s| s.to_string());
-        let rows = sqlx::query_as::<_, PgWorkflowRow>(
-            "SELECT id, namespace, run_id, workflow_type, task_queue, status, input, result, error, parent_id, claimed_by, created_at, updated_at, completed_at
+
+        let filter_pairs: Vec<(String, serde_json::Value)> = search_attrs_filter
+            .and_then(|s| serde_json::from_str::<serde_json::Value>(s).ok())
+            .and_then(|v| v.as_object().cloned())
+            .map(|m| m.into_iter().collect())
+            .unwrap_or_default();
+
+        let mut sql = String::from(
+            "SELECT id, namespace, run_id, workflow_type, task_queue, status, input, result, error, parent_id, claimed_by, search_attributes, created_at, updated_at, completed_at
              FROM workflows
              WHERE namespace = $1
                AND ($2::TEXT IS NULL OR status = $2)
-               AND ($3::TEXT IS NULL OR workflow_type = $3)
-             ORDER BY created_at DESC
-             LIMIT $4 OFFSET $5",
-        )
-        .bind(namespace)
-        .bind(&status_str)
-        .bind(workflow_type)
-        .bind(limit)
-        .bind(offset)
-        .fetch_all(&self.pool)
-        .await?;
+               AND ($3::TEXT IS NULL OR workflow_type = $3)",
+        );
+        // Bind placeholders for the filter follow $3; next index is 4.
+        let mut idx = 4usize;
+        for _ in &filter_pairs {
+            sql.push_str(&format!(
+                " AND (search_attributes::jsonb)->>${} = ${}",
+                idx,
+                idx + 1
+            ));
+            idx += 2;
+        }
+        sql.push_str(&format!(" ORDER BY created_at DESC LIMIT ${} OFFSET ${}", idx, idx + 1));
+
+        let mut q = sqlx::query_as::<_, PgWorkflowRow>(&sql)
+            .bind(namespace)
+            .bind(&status_str)
+            .bind(workflow_type);
+        for (key, value) in &filter_pairs {
+            q = q.bind(key.clone());
+            // JSONB ->> always returns TEXT; compare by stringified value.
+            let as_text = match value {
+                serde_json::Value::String(s) => s.clone(),
+                other => other.to_string(),
+            };
+            q = q.bind(as_text);
+        }
+        let rows = q.bind(limit).bind(offset).fetch_all(&self.pool).await?;
         Ok(rows.into_iter().map(Into::into).collect())
     }
 
@@ -389,7 +419,7 @@ impl WorkflowStore for PostgresStore {
                 FOR UPDATE SKIP LOCKED
                 LIMIT 1
              )
-             RETURNING id, namespace, run_id, workflow_type, task_queue, status, input, result, error, parent_id, claimed_by, created_at, updated_at, completed_at",
+             RETURNING id, namespace, run_id, workflow_type, task_queue, status, input, result, error, parent_id, claimed_by, search_attributes, created_at, updated_at, completed_at",
         )
         .bind(worker_id)
         .bind(now)
@@ -786,6 +816,28 @@ impl WorkflowStore for PostgresStore {
         Ok(res.rows_affected() > 0)
     }
 
+    async fn upsert_search_attributes(
+        &self,
+        workflow_id: &str,
+        patch_json: &str,
+    ) -> Result<()> {
+        let current: Option<(Option<String>,)> =
+            sqlx::query_as("SELECT search_attributes FROM workflows WHERE id = $1")
+                .bind(workflow_id)
+                .fetch_optional(&self.pool)
+                .await?;
+        let merged = crate::store::sqlite::merge_search_attrs(
+            current.and_then(|(s,)| s).as_deref(),
+            patch_json,
+        )?;
+        sqlx::query("UPDATE workflows SET search_attributes = $1 WHERE id = $2")
+            .bind(merged)
+            .bind(workflow_id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
     async fn update_schedule(
         &self,
         namespace: &str,
@@ -985,7 +1037,7 @@ impl WorkflowStore for PostgresStore {
 
     async fn list_child_workflows(&self, parent_id: &str) -> Result<Vec<WorkflowRecord>> {
         let rows = sqlx::query_as::<_, PgWorkflowRow>(
-            "SELECT id, namespace, run_id, workflow_type, task_queue, status, input, result, error, parent_id, claimed_by, created_at, updated_at, completed_at
+            "SELECT id, namespace, run_id, workflow_type, task_queue, status, input, result, error, parent_id, claimed_by, search_attributes, created_at, updated_at, completed_at
              FROM workflows WHERE parent_id = $1 ORDER BY created_at ASC",
         )
         .bind(parent_id)
@@ -1101,6 +1153,7 @@ struct PgWorkflowRow {
     error: Option<String>,
     parent_id: Option<String>,
     claimed_by: Option<String>,
+    search_attributes: Option<String>,
     created_at: f64,
     updated_at: f64,
     completed_at: Option<f64>,
@@ -1120,6 +1173,7 @@ impl From<PgWorkflowRow> for WorkflowRecord {
             error: r.error,
             parent_id: r.parent_id,
             claimed_by: r.claimed_by,
+            search_attributes: r.search_attributes,
             created_at: r.created_at,
             updated_at: r.updated_at,
             completed_at: r.completed_at,

--- a/crates/assay-workflow/src/store/postgres.rs
+++ b/crates/assay-workflow/src/store/postgres.rs
@@ -786,6 +786,90 @@ impl WorkflowStore for PostgresStore {
         Ok(res.rows_affected() > 0)
     }
 
+    async fn update_schedule(
+        &self,
+        namespace: &str,
+        name: &str,
+        patch: &SchedulePatch,
+    ) -> Result<Option<WorkflowSchedule>> {
+        let mut sets: Vec<String> = Vec::new();
+        let mut idx = 1usize;
+        if patch.cron_expr.is_some() {
+            sets.push(format!("cron_expr = ${idx}"));
+            idx += 1;
+        }
+        if patch.timezone.is_some() {
+            sets.push(format!("timezone = ${idx}"));
+            idx += 1;
+        }
+        if patch.input.is_some() {
+            sets.push(format!("input = ${idx}"));
+            idx += 1;
+        }
+        if patch.task_queue.is_some() {
+            sets.push(format!("task_queue = ${idx}"));
+            idx += 1;
+        }
+        if patch.overlap_policy.is_some() {
+            sets.push(format!("overlap_policy = ${idx}"));
+            idx += 1;
+        }
+        if sets.is_empty() {
+            return self.get_schedule(namespace, name).await;
+        }
+        let sql = format!(
+            "UPDATE workflow_schedules SET {} WHERE namespace = ${} AND name = ${}",
+            sets.join(", "),
+            idx,
+            idx + 1
+        );
+        let mut q = sqlx::query(&sql);
+        if let Some(ref v) = patch.cron_expr {
+            q = q.bind(v);
+        }
+        if let Some(ref v) = patch.timezone {
+            q = q.bind(v);
+        }
+        if let Some(ref v) = patch.input {
+            q = q.bind(v.to_string());
+        }
+        if let Some(ref v) = patch.task_queue {
+            q = q.bind(v);
+        }
+        if let Some(ref v) = patch.overlap_policy {
+            q = q.bind(v);
+        }
+        let res = q
+            .bind(namespace)
+            .bind(name)
+            .execute(&self.pool)
+            .await?;
+        if res.rows_affected() == 0 {
+            return Ok(None);
+        }
+        self.get_schedule(namespace, name).await
+    }
+
+    async fn set_schedule_paused(
+        &self,
+        namespace: &str,
+        name: &str,
+        paused: bool,
+    ) -> Result<Option<WorkflowSchedule>> {
+        let res = sqlx::query(
+            "UPDATE workflow_schedules SET paused = $1 WHERE namespace = $2 AND name = $3",
+        )
+        .bind(paused)
+        .bind(namespace)
+        .bind(name)
+        .execute(&self.pool)
+        .await?;
+        if res.rows_affected() == 0 {
+            return Ok(None);
+        }
+        self.get_schedule(namespace, name).await
+    }
+
     // ── Workers ─────────────────────────────────────────────
 
     async fn register_worker(&self, w: &WorkflowWorker) -> Result<()> {

--- a/crates/assay-workflow/src/store/postgres.rs
+++ b/crates/assay-workflow/src/store/postgres.rs
@@ -26,6 +26,8 @@ CREATE TABLE IF NOT EXISTS workflows (
     parent_id       TEXT,
     claimed_by      TEXT,
     search_attributes TEXT,
+    archived_at     DOUBLE PRECISION,
+    archive_uri     TEXT,
     -- Workflow-task dispatch (Phase 9): see sqlite.rs for the full comment.
     needs_dispatch  BOOLEAN NOT NULL DEFAULT FALSE,
     dispatch_claimed_by    TEXT,
@@ -37,9 +39,11 @@ CREATE TABLE IF NOT EXISTS workflows (
 CREATE INDEX IF NOT EXISTS idx_wf_status_queue ON workflows(status, task_queue);
 CREATE INDEX IF NOT EXISTS idx_wf_namespace ON workflows(namespace);
 CREATE INDEX IF NOT EXISTS idx_wf_dispatch ON workflows(task_queue, needs_dispatch, dispatch_claimed_by);
--- Upgrades from v0.11.2 need the column + GIN index added; on fresh
--- installs both already exist (CREATE above) and these are no-ops.
+-- Upgrades from v0.11.2 need the additive columns; on fresh installs
+-- they're already in the CREATE above so these ADDs are no-ops.
 ALTER TABLE workflows ADD COLUMN IF NOT EXISTS search_attributes TEXT;
+ALTER TABLE workflows ADD COLUMN IF NOT EXISTS archived_at DOUBLE PRECISION;
+ALTER TABLE workflows ADD COLUMN IF NOT EXISTS archive_uri TEXT;
 
 CREATE TABLE IF NOT EXISTS workflow_events (
     id              BIGSERIAL PRIMARY KEY,
@@ -269,8 +273,8 @@ impl WorkflowStore for PostgresStore {
 
     async fn create_workflow(&self, wf: &WorkflowRecord) -> Result<()> {
         sqlx::query(
-            "INSERT INTO workflows (id, namespace, run_id, workflow_type, task_queue, status, input, result, error, parent_id, claimed_by, search_attributes, created_at, updated_at, completed_at)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)",
+            "INSERT INTO workflows (id, namespace, run_id, workflow_type, task_queue, status, input, result, error, parent_id, claimed_by, search_attributes, archived_at, archive_uri, created_at, updated_at, completed_at)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)",
         )
         .bind(&wf.id)
         .bind(&wf.namespace)
@@ -284,6 +288,8 @@ impl WorkflowStore for PostgresStore {
         .bind(&wf.parent_id)
         .bind(&wf.claimed_by)
         .bind(&wf.search_attributes)
+        .bind(wf.archived_at)
+        .bind(&wf.archive_uri)
         .bind(wf.created_at)
         .bind(wf.updated_at)
         .bind(wf.completed_at)
@@ -294,7 +300,7 @@ impl WorkflowStore for PostgresStore {
 
     async fn get_workflow(&self, id: &str) -> Result<Option<WorkflowRecord>> {
         let row = sqlx::query_as::<_, PgWorkflowRow>(
-            "SELECT id, namespace, run_id, workflow_type, task_queue, status, input, result, error, parent_id, claimed_by, search_attributes, created_at, updated_at, completed_at FROM workflows WHERE id = $1",
+            "SELECT id, namespace, run_id, workflow_type, task_queue, status, input, result, error, parent_id, claimed_by, search_attributes, archived_at, archive_uri, created_at, updated_at, completed_at FROM workflows WHERE id = $1",
         )
         .bind(id)
         .fetch_optional(&self.pool)
@@ -320,7 +326,7 @@ impl WorkflowStore for PostgresStore {
             .unwrap_or_default();
 
         let mut sql = String::from(
-            "SELECT id, namespace, run_id, workflow_type, task_queue, status, input, result, error, parent_id, claimed_by, search_attributes, created_at, updated_at, completed_at
+            "SELECT id, namespace, run_id, workflow_type, task_queue, status, input, result, error, parent_id, claimed_by, search_attributes, archived_at, archive_uri, created_at, updated_at, completed_at
              FROM workflows
              WHERE namespace = $1
                AND ($2::TEXT IS NULL OR status = $2)
@@ -419,7 +425,7 @@ impl WorkflowStore for PostgresStore {
                 FOR UPDATE SKIP LOCKED
                 LIMIT 1
              )
-             RETURNING id, namespace, run_id, workflow_type, task_queue, status, input, result, error, parent_id, claimed_by, search_attributes, created_at, updated_at, completed_at",
+             RETURNING id, namespace, run_id, workflow_type, task_queue, status, input, result, error, parent_id, claimed_by, search_attributes, archived_at, archive_uri, created_at, updated_at, completed_at",
         )
         .bind(worker_id)
         .bind(now)
@@ -816,6 +822,67 @@ impl WorkflowStore for PostgresStore {
         Ok(res.rows_affected() > 0)
     }
 
+    async fn list_archivable_workflows(
+        &self,
+        cutoff: f64,
+        limit: i64,
+    ) -> Result<Vec<WorkflowRecord>> {
+        let rows = sqlx::query_as::<_, PgWorkflowRow>(
+            "SELECT id, namespace, run_id, workflow_type, task_queue, status, input, result, error, parent_id, claimed_by, search_attributes, archived_at, archive_uri, created_at, updated_at, completed_at
+             FROM workflows
+             WHERE status IN ('COMPLETED', 'FAILED', 'CANCELLED', 'TIMED_OUT')
+               AND completed_at IS NOT NULL
+               AND completed_at < $1
+               AND archived_at IS NULL
+             ORDER BY completed_at ASC
+             LIMIT $2",
+        )
+        .bind(cutoff)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.into_iter().map(Into::into).collect())
+    }
+
+    async fn mark_archived_and_purge(
+        &self,
+        workflow_id: &str,
+        archive_uri: &str,
+        archived_at: f64,
+    ) -> Result<()> {
+        let mut tx = self.pool.begin().await?;
+        sqlx::query("DELETE FROM workflow_events WHERE workflow_id = $1")
+            .bind(workflow_id)
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query("DELETE FROM workflow_activities WHERE workflow_id = $1")
+            .bind(workflow_id)
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query("DELETE FROM workflow_timers WHERE workflow_id = $1")
+            .bind(workflow_id)
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query("DELETE FROM workflow_signals WHERE workflow_id = $1")
+            .bind(workflow_id)
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query("DELETE FROM workflow_snapshots WHERE workflow_id = $1")
+            .bind(workflow_id)
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query(
+            "UPDATE workflows SET archived_at = $1, archive_uri = $2 WHERE id = $3",
+        )
+        .bind(archived_at)
+        .bind(archive_uri)
+        .bind(workflow_id)
+        .execute(&mut *tx)
+        .await?;
+        tx.commit().await?;
+        Ok(())
+    }
+
     async fn upsert_search_attributes(
         &self,
         workflow_id: &str,
@@ -1037,7 +1104,7 @@ impl WorkflowStore for PostgresStore {
 
     async fn list_child_workflows(&self, parent_id: &str) -> Result<Vec<WorkflowRecord>> {
         let rows = sqlx::query_as::<_, PgWorkflowRow>(
-            "SELECT id, namespace, run_id, workflow_type, task_queue, status, input, result, error, parent_id, claimed_by, search_attributes, created_at, updated_at, completed_at
+            "SELECT id, namespace, run_id, workflow_type, task_queue, status, input, result, error, parent_id, claimed_by, search_attributes, archived_at, archive_uri, created_at, updated_at, completed_at
              FROM workflows WHERE parent_id = $1 ORDER BY created_at ASC",
         )
         .bind(parent_id)
@@ -1154,6 +1221,8 @@ struct PgWorkflowRow {
     parent_id: Option<String>,
     claimed_by: Option<String>,
     search_attributes: Option<String>,
+    archived_at: Option<f64>,
+    archive_uri: Option<String>,
     created_at: f64,
     updated_at: f64,
     completed_at: Option<f64>,
@@ -1174,6 +1243,8 @@ impl From<PgWorkflowRow> for WorkflowRecord {
             parent_id: r.parent_id,
             claimed_by: r.claimed_by,
             search_attributes: r.search_attributes,
+            archived_at: r.archived_at,
+            archive_uri: r.archive_uri,
             created_at: r.created_at,
             updated_at: r.updated_at,
             completed_at: r.completed_at,

--- a/crates/assay-workflow/src/store/postgres.rs
+++ b/crates/assay-workflow/src/store/postgres.rs
@@ -97,6 +97,7 @@ CREATE TABLE IF NOT EXISTS workflow_schedules (
     name            TEXT NOT NULL,
     workflow_type   TEXT NOT NULL,
     cron_expr       TEXT NOT NULL,
+    timezone        TEXT NOT NULL DEFAULT 'UTC',
     input           TEXT,
     task_queue      TEXT NOT NULL DEFAULT 'main',
     overlap_policy  TEXT NOT NULL DEFAULT 'skip',
@@ -107,6 +108,10 @@ CREATE TABLE IF NOT EXISTS workflow_schedules (
     created_at      DOUBLE PRECISION NOT NULL,
     PRIMARY KEY (namespace, name)
 );
+-- Upgrades from v0.11.2 need the timezone column added; on a fresh
+-- install the CREATE TABLE above has already created it and this is
+-- a silent no-op.
+ALTER TABLE workflow_schedules ADD COLUMN IF NOT EXISTS timezone TEXT NOT NULL DEFAULT 'UTC';
 
 CREATE TABLE IF NOT EXISTS workflow_workers (
     id              TEXT PRIMARY KEY,
@@ -709,13 +714,14 @@ impl WorkflowStore for PostgresStore {
 
     async fn create_schedule(&self, sched: &WorkflowSchedule) -> Result<()> {
         sqlx::query(
-            "INSERT INTO workflow_schedules (namespace, name, workflow_type, cron_expr, input, task_queue, overlap_policy, paused, last_run_at, next_run_at, last_workflow_id, created_at)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)",
+            "INSERT INTO workflow_schedules (namespace, name, workflow_type, cron_expr, timezone, input, task_queue, overlap_policy, paused, last_run_at, next_run_at, last_workflow_id, created_at)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)",
         )
         .bind(&sched.namespace)
         .bind(&sched.name)
         .bind(&sched.workflow_type)
         .bind(&sched.cron_expr)
+        .bind(&sched.timezone)
         .bind(&sched.input)
         .bind(&sched.task_queue)
         .bind(&sched.overlap_policy)
@@ -731,7 +737,7 @@ impl WorkflowStore for PostgresStore {
 
     async fn get_schedule(&self, namespace: &str, name: &str) -> Result<Option<WorkflowSchedule>> {
         let row = sqlx::query_as::<_, PgScheduleRow>(
-            "SELECT namespace, name, workflow_type, cron_expr, input, task_queue, overlap_policy, paused, last_run_at, next_run_at, last_workflow_id, created_at FROM workflow_schedules WHERE namespace = $1 AND name = $2",
+            "SELECT namespace, name, workflow_type, cron_expr, timezone, input, task_queue, overlap_policy, paused, last_run_at, next_run_at, last_workflow_id, created_at FROM workflow_schedules WHERE namespace = $1 AND name = $2",
         )
         .bind(namespace)
         .bind(name)
@@ -742,7 +748,7 @@ impl WorkflowStore for PostgresStore {
 
     async fn list_schedules(&self, namespace: &str) -> Result<Vec<WorkflowSchedule>> {
         let rows = sqlx::query_as::<_, PgScheduleRow>(
-            "SELECT namespace, name, workflow_type, cron_expr, input, task_queue, overlap_policy, paused, last_run_at, next_run_at, last_workflow_id, created_at FROM workflow_schedules WHERE namespace = $1 ORDER BY name",
+            "SELECT namespace, name, workflow_type, cron_expr, timezone, input, task_queue, overlap_policy, paused, last_run_at, next_run_at, last_workflow_id, created_at FROM workflow_schedules WHERE namespace = $1 ORDER BY name",
         )
         .bind(namespace)
         .fetch_all(&self.pool)
@@ -1161,6 +1167,7 @@ struct PgScheduleRow {
     name: String,
     workflow_type: String,
     cron_expr: String,
+    timezone: String,
     input: Option<String>,
     task_queue: String,
     overlap_policy: String,
@@ -1178,6 +1185,7 @@ impl From<PgScheduleRow> for WorkflowSchedule {
             name: r.name,
             workflow_type: r.workflow_type,
             cron_expr: r.cron_expr,
+            timezone: r.timezone,
             input: r.input,
             task_queue: r.task_queue,
             overlap_policy: r.overlap_policy,

--- a/crates/assay-workflow/src/store/sqlite.rs
+++ b/crates/assay-workflow/src/store/sqlite.rs
@@ -100,6 +100,7 @@ CREATE TABLE IF NOT EXISTS workflow_schedules (
     namespace       TEXT NOT NULL DEFAULT 'main',
     workflow_type   TEXT NOT NULL,
     cron_expr       TEXT NOT NULL,
+    timezone        TEXT NOT NULL DEFAULT 'UTC',
     input           TEXT,
     task_queue      TEXT NOT NULL DEFAULT 'main',
     overlap_policy  TEXT NOT NULL DEFAULT 'skip',
@@ -273,6 +274,35 @@ impl SqliteStore {
             if !trimmed.is_empty() {
                 sqlx::query(trimmed).execute(&self.pool).await?;
             }
+        }
+        // Additive migrations for schema evolution. SQLite doesn't support
+        // `ADD COLUMN IF NOT EXISTS`, so we check via pragma_table_info
+        // before issuing ALTER. Each call is idempotent across startups.
+        Self::add_column_if_missing(
+            &self.pool,
+            "workflow_schedules",
+            "timezone",
+            "TEXT NOT NULL DEFAULT 'UTC'",
+        )
+        .await?;
+        Ok(())
+    }
+
+    async fn add_column_if_missing(
+        pool: &SqlitePool,
+        table: &str,
+        column: &str,
+        type_def: &str,
+    ) -> Result<()> {
+        let exists: Option<(String,)> =
+            sqlx::query_as("SELECT name FROM pragma_table_info(?) WHERE name = ?")
+                .bind(table)
+                .bind(column)
+                .fetch_optional(pool)
+                .await?;
+        if exists.is_none() {
+            let sql = format!("ALTER TABLE {table} ADD COLUMN {column} {type_def}");
+            sqlx::query(&sql).execute(pool).await?;
         }
         Ok(())
     }
@@ -816,13 +846,14 @@ impl WorkflowStore for SqliteStore {
 
     async fn create_schedule(&self, sched: &WorkflowSchedule) -> Result<()> {
         sqlx::query(
-            "INSERT INTO workflow_schedules (name, namespace, workflow_type, cron_expr, input, task_queue, overlap_policy, paused, last_run_at, next_run_at, last_workflow_id, created_at)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "INSERT INTO workflow_schedules (name, namespace, workflow_type, cron_expr, timezone, input, task_queue, overlap_policy, paused, last_run_at, next_run_at, last_workflow_id, created_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         )
         .bind(&sched.name)
         .bind(&sched.namespace)
         .bind(&sched.workflow_type)
         .bind(&sched.cron_expr)
+        .bind(&sched.timezone)
         .bind(&sched.input)
         .bind(&sched.task_queue)
         .bind(&sched.overlap_policy)
@@ -838,7 +869,7 @@ impl WorkflowStore for SqliteStore {
 
     async fn get_schedule(&self, namespace: &str, name: &str) -> Result<Option<WorkflowSchedule>> {
         let row = sqlx::query_as::<_, SqliteScheduleRow>(
-            "SELECT name, namespace, workflow_type, cron_expr, input, task_queue, overlap_policy, paused, last_run_at, next_run_at, last_workflow_id, created_at
+            "SELECT name, namespace, workflow_type, cron_expr, timezone, input, task_queue, overlap_policy, paused, last_run_at, next_run_at, last_workflow_id, created_at
              FROM workflow_schedules WHERE namespace = ? AND name = ?",
         )
         .bind(namespace)
@@ -850,7 +881,7 @@ impl WorkflowStore for SqliteStore {
 
     async fn list_schedules(&self, namespace: &str) -> Result<Vec<WorkflowSchedule>> {
         let rows = sqlx::query_as::<_, SqliteScheduleRow>(
-            "SELECT name, namespace, workflow_type, cron_expr, input, task_queue, overlap_policy, paused, last_run_at, next_run_at, last_workflow_id, created_at
+            "SELECT name, namespace, workflow_type, cron_expr, timezone, input, task_queue, overlap_policy, paused, last_run_at, next_run_at, last_workflow_id, created_at
              FROM workflow_schedules WHERE namespace = ? ORDER BY name",
         )
         .bind(namespace)
@@ -1292,6 +1323,7 @@ struct SqliteScheduleRow {
     namespace: String,
     workflow_type: String,
     cron_expr: String,
+    timezone: String,
     input: Option<String>,
     task_queue: String,
     overlap_policy: String,
@@ -1309,6 +1341,7 @@ impl From<SqliteScheduleRow> for WorkflowSchedule {
             namespace: r.namespace,
             workflow_type: r.workflow_type,
             cron_expr: r.cron_expr,
+            timezone: r.timezone,
             input: r.input,
             task_queue: r.task_queue,
             overlap_policy: r.overlap_policy,

--- a/crates/assay-workflow/src/store/sqlite.rs
+++ b/crates/assay-workflow/src/store/sqlite.rs
@@ -25,6 +25,7 @@ CREATE TABLE IF NOT EXISTS workflows (
     error           TEXT,
     parent_id       TEXT,
     claimed_by      TEXT,
+    search_attributes TEXT,
     -- Workflow-task dispatch (Phase 9): a workflow is "dispatchable" when
     -- it has new events a worker needs to replay against. Set true on
     -- start, on activity completion, on timer fire, on signal arrival.
@@ -285,6 +286,8 @@ impl SqliteStore {
             "TEXT NOT NULL DEFAULT 'UTC'",
         )
         .await?;
+        Self::add_column_if_missing(&self.pool, "workflows", "search_attributes", "TEXT")
+            .await?;
         Ok(())
     }
 
@@ -397,8 +400,8 @@ impl WorkflowStore for SqliteStore {
 
     async fn create_workflow(&self, wf: &WorkflowRecord) -> Result<()> {
         sqlx::query(
-            "INSERT INTO workflows (id, namespace, run_id, workflow_type, task_queue, status, input, result, error, parent_id, claimed_by, created_at, updated_at, completed_at)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "INSERT INTO workflows (id, namespace, run_id, workflow_type, task_queue, status, input, result, error, parent_id, claimed_by, search_attributes, created_at, updated_at, completed_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         )
         .bind(&wf.id)
         .bind(&wf.namespace)
@@ -411,6 +414,7 @@ impl WorkflowStore for SqliteStore {
         .bind(&wf.error)
         .bind(&wf.parent_id)
         .bind(&wf.claimed_by)
+        .bind(&wf.search_attributes)
         .bind(wf.created_at)
         .bind(wf.updated_at)
         .bind(wf.completed_at)
@@ -421,7 +425,7 @@ impl WorkflowStore for SqliteStore {
 
     async fn get_workflow(&self, id: &str) -> Result<Option<WorkflowRecord>> {
         let row = sqlx::query_as::<_, SqliteWorkflowRow>(
-            "SELECT id, namespace, run_id, workflow_type, task_queue, status, input, result, error, parent_id, claimed_by, created_at, updated_at, completed_at FROM workflows WHERE id = ?",
+            "SELECT id, namespace, run_id, workflow_type, task_queue, status, input, result, error, parent_id, claimed_by, search_attributes, created_at, updated_at, completed_at FROM workflows WHERE id = ?",
         )
         .bind(id)
         .fetch_optional(&self.pool)
@@ -434,27 +438,65 @@ impl WorkflowStore for SqliteStore {
         namespace: &str,
         status: Option<WorkflowStatus>,
         workflow_type: Option<&str>,
+        search_attrs_filter: Option<&str>,
         limit: i64,
         offset: i64,
     ) -> Result<Vec<WorkflowRecord>> {
         let status_str = status.map(|s| s.to_string());
-        let rows = sqlx::query_as::<_, SqliteWorkflowRow>(
-            "SELECT id, namespace, run_id, workflow_type, task_queue, status, input, result, error, parent_id, claimed_by, created_at, updated_at, completed_at
+
+        // Parse search filter into (key, value) pairs. Each pair adds a
+        // `json_extract(search_attributes, '$.key') = value` predicate so
+        // matches require every filter key to be present in the stored
+        // attributes. Invalid/empty JSON → no filter (all pass).
+        let filter_pairs: Vec<(String, serde_json::Value)> = search_attrs_filter
+            .and_then(|s| serde_json::from_str::<serde_json::Value>(s).ok())
+            .and_then(|v| v.as_object().cloned())
+            .map(|m| m.into_iter().collect())
+            .unwrap_or_default();
+
+        let mut sql = String::from(
+            "SELECT id, namespace, run_id, workflow_type, task_queue, status, input, result, error, parent_id, claimed_by, search_attributes, created_at, updated_at, completed_at
              FROM workflows
              WHERE namespace = ?
                AND (? IS NULL OR status = ?)
-               AND (? IS NULL OR workflow_type = ?)
-             ORDER BY created_at DESC
-             LIMIT ? OFFSET ?",
-        )
-        .bind(namespace)
-        .bind(&status_str)
-        .bind(&status_str)
-        .bind(workflow_type)
-        .bind(workflow_type)
-        .bind(limit)
-        .bind(offset)
-        .fetch_all(&self.pool)
+               AND (? IS NULL OR workflow_type = ?)",
+        );
+        for _ in &filter_pairs {
+            sql.push_str(" AND json_extract(search_attributes, '$.' || ?) = ?");
+        }
+        sql.push_str(" ORDER BY created_at DESC LIMIT ? OFFSET ?");
+
+        let mut q = sqlx::query_as::<_, SqliteWorkflowRow>(&sql)
+            .bind(namespace)
+            .bind(&status_str)
+            .bind(&status_str)
+            .bind(workflow_type)
+            .bind(workflow_type);
+        for (key, value) in &filter_pairs {
+            q = q.bind(key.clone());
+            // Bind the JSON value as its string/number representation.
+            // json_extract on a stored JSON string returns its "natural"
+            // SQLite type (text for strings, numeric for numbers), so we
+            // match by the same type.
+            match value {
+                serde_json::Value::String(s) => q = q.bind(s.clone()),
+                serde_json::Value::Number(n) => {
+                    if let Some(i) = n.as_i64() {
+                        q = q.bind(i);
+                    } else if let Some(f) = n.as_f64() {
+                        q = q.bind(f);
+                    } else {
+                        q = q.bind(n.to_string());
+                    }
+                }
+                serde_json::Value::Bool(b) => q = q.bind(*b as i64),
+                _ => q = q.bind(value.to_string()),
+            }
+        }
+        let rows = q
+            .bind(limit)
+            .bind(offset)
+            .fetch_all(&self.pool)
         .await?;
         Ok(rows.into_iter().map(Into::into).collect())
     }
@@ -521,7 +563,7 @@ impl WorkflowStore for SqliteStore {
                 ORDER BY updated_at ASC
                 LIMIT 1
              )
-             RETURNING id, namespace, run_id, workflow_type, task_queue, status, input, result, error, parent_id, claimed_by, created_at, updated_at, completed_at",
+             RETURNING id, namespace, run_id, workflow_type, task_queue, status, input, result, error, parent_id, claimed_by, search_attributes, created_at, updated_at, completed_at",
         )
         .bind(worker_id)
         .bind(now)
@@ -921,6 +963,30 @@ impl WorkflowStore for SqliteStore {
         Ok(res.rows_affected() > 0)
     }
 
+    async fn upsert_search_attributes(
+        &self,
+        workflow_id: &str,
+        patch_json: &str,
+    ) -> Result<()> {
+        // Merge at the application layer so we don't depend on SQLite's
+        // `json_patch`, which is only available with the json1 extension.
+        let current: Option<(Option<String>,)> =
+            sqlx::query_as("SELECT search_attributes FROM workflows WHERE id = ?")
+                .bind(workflow_id)
+                .fetch_optional(&self.pool)
+                .await?;
+        let merged = merge_search_attrs(
+            current.and_then(|(s,)| s).as_deref(),
+            patch_json,
+        )?;
+        sqlx::query("UPDATE workflows SET search_attributes = ? WHERE id = ?")
+            .bind(merged)
+            .bind(workflow_id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
     async fn update_schedule(
         &self,
         namespace: &str,
@@ -1118,7 +1184,7 @@ impl WorkflowStore for SqliteStore {
 
     async fn list_child_workflows(&self, parent_id: &str) -> Result<Vec<WorkflowRecord>> {
         let rows = sqlx::query_as::<_, SqliteWorkflowRow>(
-            "SELECT id, namespace, run_id, workflow_type, task_queue, status, input, result, error, parent_id, claimed_by, created_at, updated_at, completed_at
+            "SELECT id, namespace, run_id, workflow_type, task_queue, status, input, result, error, parent_id, claimed_by, search_attributes, created_at, updated_at, completed_at
              FROM workflows WHERE parent_id = ? ORDER BY created_at ASC",
         )
         .bind(parent_id)
@@ -1238,6 +1304,24 @@ fn timestamp_now() -> f64 {
         .as_secs_f64()
 }
 
+/// Merge a JSON-object patch into a (possibly-null) current JSON object,
+/// returning the serialised result. Shared by SQLite and Postgres stores.
+pub(crate) fn merge_search_attrs(current: Option<&str>, patch_json: &str) -> Result<String> {
+    let mut current_map: serde_json::Map<String, serde_json::Value> = current
+        .and_then(|s| serde_json::from_str::<serde_json::Value>(s).ok())
+        .and_then(|v| v.as_object().cloned())
+        .unwrap_or_default();
+    let patch: serde_json::Value = serde_json::from_str(patch_json)
+        .map_err(|e| anyhow::anyhow!("invalid search_attributes patch: {e}"))?;
+    let patch_obj = patch
+        .as_object()
+        .ok_or_else(|| anyhow::anyhow!("search_attributes patch must be a JSON object"))?;
+    for (k, v) in patch_obj {
+        current_map.insert(k.clone(), v.clone());
+    }
+    Ok(serde_json::Value::Object(current_map).to_string())
+}
+
 // ── SQLite row types (sqlx::FromRow) ────────────────────────
 
 #[derive(sqlx::FromRow)]
@@ -1253,6 +1337,7 @@ struct SqliteWorkflowRow {
     error: Option<String>,
     parent_id: Option<String>,
     claimed_by: Option<String>,
+    search_attributes: Option<String>,
     created_at: f64,
     updated_at: f64,
     completed_at: Option<f64>,
@@ -1272,6 +1357,7 @@ impl From<SqliteWorkflowRow> for WorkflowRecord {
             error: r.error,
             parent_id: r.parent_id,
             claimed_by: r.claimed_by,
+            search_attributes: r.search_attributes,
             created_at: r.created_at,
             updated_at: r.updated_at,
             completed_at: r.completed_at,

--- a/crates/assay-workflow/src/store/sqlite.rs
+++ b/crates/assay-workflow/src/store/sqlite.rs
@@ -271,6 +271,18 @@ impl SqliteStore {
         });
     }
 
+    /// Apply the baseline schema.
+    ///
+    /// Fresh installs get the current `CREATE TABLE IF NOT EXISTS` statements
+    /// in one pass. The engine is pre-1.0 and no v0.11.x release has been
+    /// deployed against a real workload yet, so we don't carry
+    /// `ALTER TABLE ADD COLUMN` statements for historical columns — the
+    /// baseline is the source of truth.
+    ///
+    /// For **future** additive migrations (post-v0.11.3), call
+    /// `Self::add_column_if_missing(&self.pool, "<table>", "<column>",
+    /// "<type_def>").await?` here before returning. Kept around so adding a
+    /// column later is a one-liner.
     async fn migrate(&self) -> Result<()> {
         for statement in SCHEMA.split(';') {
             let trimmed = statement.trim();
@@ -278,23 +290,20 @@ impl SqliteStore {
                 sqlx::query(trimmed).execute(&self.pool).await?;
             }
         }
-        // Additive migrations for schema evolution. SQLite doesn't support
-        // `ADD COLUMN IF NOT EXISTS`, so we check via pragma_table_info
-        // before issuing ALTER. Each call is idempotent across startups.
-        Self::add_column_if_missing(
-            &self.pool,
-            "workflow_schedules",
-            "timezone",
-            "TEXT NOT NULL DEFAULT 'UTC'",
-        )
-        .await?;
-        Self::add_column_if_missing(&self.pool, "workflows", "search_attributes", "TEXT")
-            .await?;
-        Self::add_column_if_missing(&self.pool, "workflows", "archived_at", "REAL").await?;
-        Self::add_column_if_missing(&self.pool, "workflows", "archive_uri", "TEXT").await?;
+        // Future additive migrations go here; see doc-comment above.
         Ok(())
     }
 
+    /// Add a column to an existing table if it's not already there.
+    ///
+    /// SQLite (unlike Postgres) doesn't support `ADD COLUMN IF NOT EXISTS`,
+    /// so we check via `pragma_table_info` before issuing the ALTER. Each
+    /// call is idempotent across startups.
+    ///
+    /// Currently unused — kept as the documented pattern for the first
+    /// additive migration after v0.11.3. Remove `#[allow(dead_code)]` when
+    /// a caller is added.
+    #[allow(dead_code)]
     async fn add_column_if_missing(
         pool: &SqlitePool,
         table: &str,

--- a/crates/assay-workflow/src/store/sqlite.rs
+++ b/crates/assay-workflow/src/store/sqlite.rs
@@ -921,6 +921,86 @@ impl WorkflowStore for SqliteStore {
         Ok(res.rows_affected() > 0)
     }
 
+    async fn update_schedule(
+        &self,
+        namespace: &str,
+        name: &str,
+        patch: &SchedulePatch,
+    ) -> Result<Option<WorkflowSchedule>> {
+        // Build the UPDATE dynamically so unchanged fields aren't touched
+        // and NULL from `serde_json::Value::Null` round-trips cleanly.
+        let mut sets: Vec<&'static str> = Vec::new();
+        if patch.cron_expr.is_some() {
+            sets.push("cron_expr = ?");
+        }
+        if patch.timezone.is_some() {
+            sets.push("timezone = ?");
+        }
+        if patch.input.is_some() {
+            sets.push("input = ?");
+        }
+        if patch.task_queue.is_some() {
+            sets.push("task_queue = ?");
+        }
+        if patch.overlap_policy.is_some() {
+            sets.push("overlap_policy = ?");
+        }
+        // Updating last_run_at/next_run_at is internal only (update_schedule_last_run).
+        if sets.is_empty() {
+            return self.get_schedule(namespace, name).await;
+        }
+
+        let sql = format!(
+            "UPDATE workflow_schedules SET {} WHERE namespace = ? AND name = ?",
+            sets.join(", ")
+        );
+        let mut q = sqlx::query(&sql);
+        if let Some(ref v) = patch.cron_expr {
+            q = q.bind(v);
+        }
+        if let Some(ref v) = patch.timezone {
+            q = q.bind(v);
+        }
+        if let Some(ref v) = patch.input {
+            q = q.bind(v.to_string());
+        }
+        if let Some(ref v) = patch.task_queue {
+            q = q.bind(v);
+        }
+        if let Some(ref v) = patch.overlap_policy {
+            q = q.bind(v);
+        }
+        let res = q
+            .bind(namespace)
+            .bind(name)
+            .execute(&self.pool)
+            .await?;
+        if res.rows_affected() == 0 {
+            return Ok(None);
+        }
+        self.get_schedule(namespace, name).await
+    }
+
+    async fn set_schedule_paused(
+        &self,
+        namespace: &str,
+        name: &str,
+        paused: bool,
+    ) -> Result<Option<WorkflowSchedule>> {
+        let res = sqlx::query(
+            "UPDATE workflow_schedules SET paused = ? WHERE namespace = ? AND name = ?",
+        )
+        .bind(paused)
+        .bind(namespace)
+        .bind(name)
+        .execute(&self.pool)
+        .await?;
+        if res.rows_affected() == 0 {
+            return Ok(None);
+        }
+        self.get_schedule(namespace, name).await
+    }
+
     // ── Workers ─────────────────────────────────────────────
 
     async fn register_worker(&self, w: &WorkflowWorker) -> Result<()> {

--- a/crates/assay-workflow/src/store/sqlite.rs
+++ b/crates/assay-workflow/src/store/sqlite.rs
@@ -26,6 +26,8 @@ CREATE TABLE IF NOT EXISTS workflows (
     parent_id       TEXT,
     claimed_by      TEXT,
     search_attributes TEXT,
+    archived_at     REAL,
+    archive_uri     TEXT,
     -- Workflow-task dispatch (Phase 9): a workflow is "dispatchable" when
     -- it has new events a worker needs to replay against. Set true on
     -- start, on activity completion, on timer fire, on signal arrival.
@@ -288,6 +290,8 @@ impl SqliteStore {
         .await?;
         Self::add_column_if_missing(&self.pool, "workflows", "search_attributes", "TEXT")
             .await?;
+        Self::add_column_if_missing(&self.pool, "workflows", "archived_at", "REAL").await?;
+        Self::add_column_if_missing(&self.pool, "workflows", "archive_uri", "TEXT").await?;
         Ok(())
     }
 
@@ -400,8 +404,8 @@ impl WorkflowStore for SqliteStore {
 
     async fn create_workflow(&self, wf: &WorkflowRecord) -> Result<()> {
         sqlx::query(
-            "INSERT INTO workflows (id, namespace, run_id, workflow_type, task_queue, status, input, result, error, parent_id, claimed_by, search_attributes, created_at, updated_at, completed_at)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            "INSERT INTO workflows (id, namespace, run_id, workflow_type, task_queue, status, input, result, error, parent_id, claimed_by, search_attributes, archived_at, archive_uri, created_at, updated_at, completed_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         )
         .bind(&wf.id)
         .bind(&wf.namespace)
@@ -415,6 +419,8 @@ impl WorkflowStore for SqliteStore {
         .bind(&wf.parent_id)
         .bind(&wf.claimed_by)
         .bind(&wf.search_attributes)
+        .bind(wf.archived_at)
+        .bind(&wf.archive_uri)
         .bind(wf.created_at)
         .bind(wf.updated_at)
         .bind(wf.completed_at)
@@ -425,7 +431,7 @@ impl WorkflowStore for SqliteStore {
 
     async fn get_workflow(&self, id: &str) -> Result<Option<WorkflowRecord>> {
         let row = sqlx::query_as::<_, SqliteWorkflowRow>(
-            "SELECT id, namespace, run_id, workflow_type, task_queue, status, input, result, error, parent_id, claimed_by, search_attributes, created_at, updated_at, completed_at FROM workflows WHERE id = ?",
+            "SELECT id, namespace, run_id, workflow_type, task_queue, status, input, result, error, parent_id, claimed_by, search_attributes, archived_at, archive_uri, created_at, updated_at, completed_at FROM workflows WHERE id = ?",
         )
         .bind(id)
         .fetch_optional(&self.pool)
@@ -455,7 +461,7 @@ impl WorkflowStore for SqliteStore {
             .unwrap_or_default();
 
         let mut sql = String::from(
-            "SELECT id, namespace, run_id, workflow_type, task_queue, status, input, result, error, parent_id, claimed_by, search_attributes, created_at, updated_at, completed_at
+            "SELECT id, namespace, run_id, workflow_type, task_queue, status, input, result, error, parent_id, claimed_by, search_attributes, archived_at, archive_uri, created_at, updated_at, completed_at
              FROM workflows
              WHERE namespace = ?
                AND (? IS NULL OR status = ?)
@@ -563,7 +569,7 @@ impl WorkflowStore for SqliteStore {
                 ORDER BY updated_at ASC
                 LIMIT 1
              )
-             RETURNING id, namespace, run_id, workflow_type, task_queue, status, input, result, error, parent_id, claimed_by, search_attributes, created_at, updated_at, completed_at",
+             RETURNING id, namespace, run_id, workflow_type, task_queue, status, input, result, error, parent_id, claimed_by, search_attributes, archived_at, archive_uri, created_at, updated_at, completed_at",
         )
         .bind(worker_id)
         .bind(now)
@@ -963,6 +969,67 @@ impl WorkflowStore for SqliteStore {
         Ok(res.rows_affected() > 0)
     }
 
+    async fn list_archivable_workflows(
+        &self,
+        cutoff: f64,
+        limit: i64,
+    ) -> Result<Vec<WorkflowRecord>> {
+        let rows = sqlx::query_as::<_, SqliteWorkflowRow>(
+            "SELECT id, namespace, run_id, workflow_type, task_queue, status, input, result, error, parent_id, claimed_by, search_attributes, archived_at, archive_uri, created_at, updated_at, completed_at
+             FROM workflows
+             WHERE status IN ('COMPLETED', 'FAILED', 'CANCELLED', 'TIMED_OUT')
+               AND completed_at IS NOT NULL
+               AND completed_at < ?
+               AND archived_at IS NULL
+             ORDER BY completed_at ASC
+             LIMIT ?",
+        )
+        .bind(cutoff)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows.into_iter().map(Into::into).collect())
+    }
+
+    async fn mark_archived_and_purge(
+        &self,
+        workflow_id: &str,
+        archive_uri: &str,
+        archived_at: f64,
+    ) -> Result<()> {
+        let mut tx = self.pool.begin().await?;
+        sqlx::query("DELETE FROM workflow_events WHERE workflow_id = ?")
+            .bind(workflow_id)
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query("DELETE FROM workflow_activities WHERE workflow_id = ?")
+            .bind(workflow_id)
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query("DELETE FROM workflow_timers WHERE workflow_id = ?")
+            .bind(workflow_id)
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query("DELETE FROM workflow_signals WHERE workflow_id = ?")
+            .bind(workflow_id)
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query("DELETE FROM workflow_snapshots WHERE workflow_id = ?")
+            .bind(workflow_id)
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query(
+            "UPDATE workflows SET archived_at = ?, archive_uri = ? WHERE id = ?",
+        )
+        .bind(archived_at)
+        .bind(archive_uri)
+        .bind(workflow_id)
+        .execute(&mut *tx)
+        .await?;
+        tx.commit().await?;
+        Ok(())
+    }
+
     async fn upsert_search_attributes(
         &self,
         workflow_id: &str,
@@ -1184,7 +1251,7 @@ impl WorkflowStore for SqliteStore {
 
     async fn list_child_workflows(&self, parent_id: &str) -> Result<Vec<WorkflowRecord>> {
         let rows = sqlx::query_as::<_, SqliteWorkflowRow>(
-            "SELECT id, namespace, run_id, workflow_type, task_queue, status, input, result, error, parent_id, claimed_by, search_attributes, created_at, updated_at, completed_at
+            "SELECT id, namespace, run_id, workflow_type, task_queue, status, input, result, error, parent_id, claimed_by, search_attributes, archived_at, archive_uri, created_at, updated_at, completed_at
              FROM workflows WHERE parent_id = ? ORDER BY created_at ASC",
         )
         .bind(parent_id)
@@ -1338,6 +1405,8 @@ struct SqliteWorkflowRow {
     parent_id: Option<String>,
     claimed_by: Option<String>,
     search_attributes: Option<String>,
+    archived_at: Option<f64>,
+    archive_uri: Option<String>,
     created_at: f64,
     updated_at: f64,
     completed_at: Option<f64>,
@@ -1358,6 +1427,8 @@ impl From<SqliteWorkflowRow> for WorkflowRecord {
             parent_id: r.parent_id,
             claimed_by: r.claimed_by,
             search_attributes: r.search_attributes,
+            archived_at: r.archived_at,
+            archive_uri: r.archive_uri,
             created_at: r.created_at,
             updated_at: r.updated_at,
             completed_at: r.completed_at,

--- a/crates/assay-workflow/src/types.rs
+++ b/crates/assay-workflow/src/types.rs
@@ -275,6 +275,18 @@ pub struct WorkflowSchedule {
     pub created_at: f64,
 }
 
+/// Partial update to a `WorkflowSchedule`. Only fields set to `Some` are
+/// applied; `None` leaves the existing value untouched. Used by
+/// `PATCH /api/v1/schedules/{name}`.
+#[derive(Clone, Debug, Default, Serialize, Deserialize, ToSchema)]
+pub struct SchedulePatch {
+    pub cron_expr: Option<String>,
+    pub timezone: Option<String>,
+    pub input: Option<serde_json::Value>,
+    pub task_queue: Option<String>,
+    pub overlap_policy: Option<String>,
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize, ToSchema)]
 pub struct WorkflowWorker {
     pub id: String,

--- a/crates/assay-workflow/src/types.rs
+++ b/crates/assay-workflow/src/types.rs
@@ -191,6 +191,12 @@ pub struct WorkflowRecord {
     /// `ctx:upsert_search_attributes(...)` from workflow code. Filter the
     /// list endpoint with `?search_attrs={"key":"value"}`.
     pub search_attributes: Option<String>,
+    /// Set when the archival task has moved this workflow's
+    /// events+activities+snapshots off to cold storage. The row itself
+    /// stays (with `archive_uri` pointing at the bundle) so that
+    /// `GET /workflows/{id}` still resolves.
+    pub archived_at: Option<f64>,
+    pub archive_uri: Option<String>,
     pub created_at: f64,
     pub updated_at: f64,
     pub completed_at: Option<f64>,

--- a/crates/assay-workflow/src/types.rs
+++ b/crates/assay-workflow/src/types.rs
@@ -185,6 +185,12 @@ pub struct WorkflowRecord {
     pub error: Option<String>,
     pub parent_id: Option<String>,
     pub claimed_by: Option<String>,
+    /// Application-level indexed metadata, JSON object encoded as a string
+    /// (e.g. `{"env":"prod","tenant":"acme","progress":0.5}`). Settable on
+    /// workflow start and updatable at runtime via
+    /// `ctx:upsert_search_attributes(...)` from workflow code. Filter the
+    /// list endpoint with `?search_attrs={"key":"value"}`.
+    pub search_attributes: Option<String>,
     pub created_at: f64,
     pub updated_at: f64,
     pub completed_at: Option<f64>,

--- a/crates/assay-workflow/src/types.rs
+++ b/crates/assay-workflow/src/types.rs
@@ -261,6 +261,10 @@ pub struct WorkflowSchedule {
     pub namespace: String,
     pub workflow_type: String,
     pub cron_expr: String,
+    /// IANA time-zone name used to interpret `cron_expr` (e.g. "Europe/Berlin",
+    /// "America/New_York"). Defaults to "UTC" when a schedule is created
+    /// without an explicit timezone, preserving v0.11.2 behaviour.
+    pub timezone: String,
     pub input: Option<String>,
     pub task_queue: String,
     pub overlap_policy: String,

--- a/crates/assay-workflow/tests/api_integration.rs
+++ b/crates/assay-workflow/tests/api_integration.rs
@@ -261,3 +261,126 @@ async fn workflow_not_found() {
         .unwrap();
     assert_eq!(resp.status(), 404);
 }
+
+#[tokio::test]
+async fn schedule_patch_updates_fields() {
+    let (url, _h) = start_test_server().await;
+    let c = client();
+
+    // Create
+    let resp = c
+        .post(format!("{url}/api/v1/schedules"))
+        .json(&serde_json::json!({
+            "name": "nightly",
+            "workflow_type": "Report",
+            "cron_expr": "0 0 2 * * *",
+            "timezone": "UTC",
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201, "create schedule");
+
+    // Patch cron + timezone + input
+    let resp = c
+        .patch(format!("{url}/api/v1/schedules/nightly"))
+        .json(&serde_json::json!({
+            "cron_expr": "0 0 3 * * *",
+            "timezone": "Europe/Berlin",
+            "input": { "lookback_hours": 24 },
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200, "patch schedule");
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["cron_expr"], "0 0 3 * * *");
+    assert_eq!(body["timezone"], "Europe/Berlin");
+    let input_str = body["input"].as_str().expect("input string");
+    let input: serde_json::Value = serde_json::from_str(input_str).unwrap();
+    assert_eq!(input["lookback_hours"], 24);
+
+    // Patch with unchanged fields preserves them
+    let resp = c
+        .patch(format!("{url}/api/v1/schedules/nightly"))
+        .json(&serde_json::json!({ "task_queue": "reports" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["task_queue"], "reports");
+    assert_eq!(body["cron_expr"], "0 0 3 * * *", "cron kept from prior patch");
+    assert_eq!(body["timezone"], "Europe/Berlin", "timezone kept from prior patch");
+}
+
+#[tokio::test]
+async fn schedule_pause_and_resume() {
+    let (url, _h) = start_test_server().await;
+    let c = client();
+
+    c.post(format!("{url}/api/v1/schedules"))
+        .json(&serde_json::json!({
+            "name": "hourly",
+            "workflow_type": "Report",
+            "cron_expr": "0 0 * * * *",
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    // Pause
+    let resp = c
+        .post(format!("{url}/api/v1/schedules/hourly/pause"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["paused"], true);
+
+    // Resume
+    let resp = c
+        .post(format!("{url}/api/v1/schedules/hourly/resume"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["paused"], false);
+}
+
+#[tokio::test]
+async fn schedule_patch_404_on_missing() {
+    let (url, _h) = start_test_server().await;
+    let c = client();
+    let resp = c
+        .patch(format!("{url}/api/v1/schedules/ghost"))
+        .json(&serde_json::json!({ "cron_expr": "0 0 * * * *" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 404);
+}
+
+#[tokio::test]
+async fn schedule_patch_rejects_invalid_timezone() {
+    let (url, _h) = start_test_server().await;
+    let c = client();
+    c.post(format!("{url}/api/v1/schedules"))
+        .json(&serde_json::json!({
+            "name": "x",
+            "workflow_type": "T",
+            "cron_expr": "0 0 * * * *",
+        }))
+        .send()
+        .await
+        .unwrap();
+    let resp = c
+        .patch(format!("{url}/api/v1/schedules/x"))
+        .json(&serde_json::json!({ "timezone": "Not/AZone" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 500, "invalid timezone rejected");
+}

--- a/crates/assay-workflow/tests/api_integration.rs
+++ b/crates/assay-workflow/tests/api_integration.rs
@@ -12,6 +12,7 @@ async fn start_test_server() -> (String, tokio::task::JoinHandle<()>) {
         engine: Arc::new(engine),
         event_tx,
         auth_mode: assay_workflow::api::auth::AuthMode::NoAuth,
+        binary_version: None,
     });
 
     let app = assay_workflow::api::router(state);
@@ -383,4 +384,19 @@ async fn schedule_patch_rejects_invalid_timezone() {
         .await
         .unwrap();
     assert_eq!(resp.status(), 500, "invalid timezone rejected");
+}
+
+#[tokio::test]
+async fn version_endpoint_returns_shape() {
+    let (url, _h) = start_test_server().await;
+    let c = client();
+    let resp = c.get(format!("{url}/api/v1/version")).send().await.unwrap();
+    assert_eq!(resp.status(), 200);
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert!(body["version"].is_string(), "version is a string");
+    let profile = body["build_profile"].as_str().expect("build_profile string");
+    assert!(
+        profile == "debug" || profile == "release",
+        "build_profile one of debug|release, got {profile}"
+    );
 }

--- a/crates/assay-workflow/tests/auth_test.rs
+++ b/crates/assay-workflow/tests/auth_test.rs
@@ -21,6 +21,7 @@ async fn start_server_with_store(
         engine: Arc::new(engine),
         event_tx,
         auth_mode,
+        binary_version: None,
     });
     let app = assay_workflow::api::router(state);
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();

--- a/crates/assay-workflow/tests/orchestration.rs
+++ b/crates/assay-workflow/tests/orchestration.rs
@@ -2041,3 +2041,153 @@ async fn search_attributes_filter_list() {
         .unwrap();
     assert_eq!(staging.len(), 1);
 }
+
+/// Plan 06 — exercise the Lua stdlib's new management surface end-to-end
+/// (workflow.list / terminate / get_events / get_state / list_children /
+/// continue_as_new; workflow.schedules.*; workflow.namespaces.*;
+/// workflow.workers.list; workflow.queues.stats).
+///
+/// One big test so we don't spin up a subprocess per method call — the
+/// REST endpoints themselves have dedicated coverage elsewhere; this
+/// proves the Lua wrappers all parse + round-trip correctly.
+#[tokio::test]
+async fn lua_stdlib_management_surface_roundtrips() {
+    let Some(assay_bin) = locate_assay_binary() else {
+        eprintln!("SKIP: lua_stdlib_management_surface_roundtrips — no assay binary");
+        return;
+    };
+
+    let (url, _h) = start_test_server().await;
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let script_path = tmp.path().join("stdlib_surface.lua");
+    std::fs::write(
+        &script_path,
+        r#"
+local workflow = require("assay.workflow")
+workflow.connect(env.get("ASSAY_ENGINE_URL"))
+
+-- Assay's Lua environment shadows `assert` with a table of helpers
+-- (assert.eq, assert.ne, …). Plain `assert(cond, msg)` isn't available,
+-- so we use a local `check` helper that raises on false.
+local function check(cond, msg)
+    if not cond then error(msg or "assertion failed") end
+end
+
+-- workflow.start + list + describe
+workflow.start({
+    workflow_type = "X", workflow_id = "wf-plan06-a", task_queue = "q1",
+    input = { n = 1 },
+})
+workflow.start({
+    workflow_type = "X", workflow_id = "wf-plan06-b", task_queue = "q1",
+})
+
+local listed = workflow.list({ type = "X", limit = 50 })
+check(#listed >= 2, "list should return at least the 2 we started")
+
+local desc = workflow.describe("wf-plan06-a")
+check(desc.id == "wf-plan06-a", "describe should return the record")
+
+-- workflow.get_events — at least WorkflowStarted
+local events = workflow.get_events("wf-plan06-a")
+local has_started = false
+for _, e in ipairs(events) do
+    if e.event_type == "WorkflowStarted" then has_started = true end
+end
+check(has_started, "event log should contain WorkflowStarted")
+
+-- workflow.get_state — 404 is ok before any register_query snapshot written
+local state = workflow.get_state("wf-plan06-a")
+check(state == nil, "no snapshot yet -> get_state returns nil")
+
+-- workflow.list_children — empty list for a childless workflow
+local children = workflow.list_children("wf-plan06-a")
+check(#children == 0, "no children yet")
+
+-- workflow.terminate — flips status to FAILED
+workflow.terminate("wf-plan06-b", "stdlib test")
+local after = workflow.describe("wf-plan06-b")
+check(after.status == "FAILED", "terminate should flip to FAILED, got " .. tostring(after.status))
+
+-- workflow.schedules.* — full lifecycle
+workflow.schedules.create({
+    name = "plan06-sched",
+    workflow_type = "X",
+    cron_expr = "0 0 2 * * *",
+    timezone = "Europe/Berlin",
+    task_queue = "q1",
+    overlap_policy = "skip",
+})
+
+local sched = workflow.schedules.describe("plan06-sched")
+check(sched.cron_expr == "0 0 2 * * *", "describe returns the cron expr")
+check(sched.timezone == "Europe/Berlin", "timezone persists")
+check(sched.paused == false, "fresh schedule is not paused")
+
+workflow.schedules.patch("plan06-sched", { cron_expr = "0 0 3 * * *" })
+local patched = workflow.schedules.describe("plan06-sched")
+check(patched.cron_expr == "0 0 3 * * *", "patch updates cron")
+check(patched.timezone == "Europe/Berlin", "patch preserves unchanged fields")
+
+workflow.schedules.pause("plan06-sched")
+check(workflow.schedules.describe("plan06-sched").paused == true, "pause sets paused")
+
+workflow.schedules.resume("plan06-sched")
+check(workflow.schedules.describe("plan06-sched").paused == false, "resume clears paused")
+
+local schedules = workflow.schedules.list()
+local found = false
+for _, s in ipairs(schedules) do
+    if s.name == "plan06-sched" then found = true end
+end
+check(found, "list should include our schedule")
+
+workflow.schedules.delete("plan06-sched")
+check(workflow.schedules.describe("plan06-sched") == nil, "delete removes it")
+
+-- workflow.namespaces.*
+workflow.namespaces.create("plan06-ns")
+local namespaces = workflow.namespaces.list()
+local ns_found = false
+for _, n in ipairs(namespaces) do
+    if n.name == "plan06-ns" then ns_found = true end
+end
+check(ns_found, "created namespace should appear in list")
+
+local stats = workflow.namespaces.stats("main")
+check(type(stats.total_workflows) == "number", "stats returns counts")
+
+workflow.namespaces.delete("plan06-ns")
+
+-- workflow.workers.list + workflow.queues.stats — just verify they return tables
+local workers = workflow.workers.list()
+check(type(workers) == "table", "workers.list returns a table")
+
+local q = workflow.queues.stats()
+check(type(q) == "table", "queues.stats returns a table")
+
+print("stdlib_surface: all assertions passed")
+"#,
+    )
+    .expect("write script");
+
+    let output = tokio::process::Command::new(&assay_bin)
+        .arg("run")
+        .arg(&script_path)
+        .env("ASSAY_ENGINE_URL", &url)
+        .output()
+        .await
+        .expect("run assay script");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "stdlib surface script failed.\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+    assert!(
+        stdout.contains("all assertions passed"),
+        "expected success marker in stdout.\nstdout:\n{stdout}\nstderr:\n{stderr}"
+    );
+}

--- a/crates/assay-workflow/tests/orchestration.rs
+++ b/crates/assay-workflow/tests/orchestration.rs
@@ -2191,3 +2191,152 @@ print("stdlib_surface: all assertions passed")
         "expected success marker in stdout.\nstdout:\n{stdout}\nstderr:\n{stderr}"
     );
 }
+
+// ── Plan 06 — CLI integration tests ─────────────────────────
+//
+// These spawn the compiled `assay` binary as a subprocess and exercise
+// the workflow / schedule subcommands against an in-process engine.
+// They prove the CLI surface wires up correctly end-to-end; the REST
+// API paths themselves have dedicated coverage above.
+
+/// `assay workflow list` on an empty engine returns 0 and a header row.
+#[tokio::test]
+async fn cli_workflow_list_empty() {
+    let Some(assay_bin) = locate_assay_binary() else {
+        eprintln!("SKIP: cli_workflow_list_empty — no assay binary");
+        return;
+    };
+    let (url, _h) = start_test_server().await;
+
+    let output = tokio::process::Command::new(&assay_bin)
+        .args(["workflow", "list", "--engine-url", &url])
+        .output()
+        .await
+        .expect("run assay workflow list");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(output.status.success(), "exit 0; stderr: {}", String::from_utf8_lossy(&output.stderr));
+    assert!(stdout.contains("ID"), "header row present: {stdout}");
+}
+
+/// `assay workflow describe <missing>` returns exit 1 with a useful
+/// stderr message (not a panic, not exit 0).
+#[tokio::test]
+async fn cli_workflow_describe_missing_is_exit_1() {
+    let Some(assay_bin) = locate_assay_binary() else {
+        eprintln!("SKIP: cli_workflow_describe_missing_is_exit_1 — no assay binary");
+        return;
+    };
+    let (url, _h) = start_test_server().await;
+
+    let output = tokio::process::Command::new(&assay_bin)
+        .args(["workflow", "describe", "nonexistent", "--engine-url", &url])
+        .output()
+        .await
+        .expect("run assay workflow describe");
+    assert!(!output.status.success(), "missing workflow should exit non-zero");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("404") || stderr.contains("not found"),
+        "stderr should mention 404/not-found, got: {stderr}"
+    );
+}
+
+/// Schedule full lifecycle via the CLI: create → list → patch → pause
+/// → resume → delete. Each step's exit code is 0.
+#[tokio::test]
+async fn cli_schedule_full_lifecycle() {
+    let Some(assay_bin) = locate_assay_binary() else {
+        eprintln!("SKIP: cli_schedule_full_lifecycle — no assay binary");
+        return;
+    };
+    let (url, _h) = start_test_server().await;
+
+    async fn run_ok(bin: &std::path::Path, args: &[&str]) -> std::process::Output {
+        let out = tokio::process::Command::new(bin)
+            .args(args)
+            .output()
+            .await
+            .expect("run assay");
+        assert!(
+            out.status.success(),
+            "command {:?} failed.\nstdout: {}\nstderr: {}",
+            args,
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+        out
+    }
+
+    run_ok(&assay_bin, &[
+        "schedule", "create", "cli-sched",
+        "--type", "CliTestWorkflow",
+        "--cron", "0 0 2 * * *",
+        "--timezone", "Europe/Berlin",
+        "--engine-url", &url,
+    ]).await;
+
+    let list_out = run_ok(&assay_bin, &["schedule", "list", "--engine-url", &url]).await;
+    let stdout = String::from_utf8_lossy(&list_out.stdout);
+    assert!(stdout.contains("cli-sched"), "list includes new schedule: {stdout}");
+    assert!(
+        stdout.contains("Europe/Berlin"),
+        "timezone column populated: {stdout}"
+    );
+
+    run_ok(&assay_bin, &[
+        "schedule", "patch", "cli-sched",
+        "--cron", "0 0 3 * * *",
+        "--engine-url", &url,
+    ]).await;
+    run_ok(&assay_bin, &["schedule", "pause",  "cli-sched", "--engine-url", &url]).await;
+    run_ok(&assay_bin, &["schedule", "resume", "cli-sched", "--engine-url", &url]).await;
+    run_ok(&assay_bin, &["schedule", "delete", "cli-sched", "--engine-url", &url]).await;
+
+    let final_list = run_ok(&assay_bin, &["schedule", "list", "--engine-url", &url]).await;
+    let stdout = String::from_utf8_lossy(&final_list.stdout);
+    assert!(
+        !stdout.contains("cli-sched"),
+        "deleted schedule should be gone: {stdout}"
+    );
+}
+
+/// `schedule patch` with no fields returns exit 1 with a usage hint.
+#[tokio::test]
+async fn cli_schedule_patch_without_fields_is_exit_1() {
+    let Some(assay_bin) = locate_assay_binary() else {
+        eprintln!("SKIP: cli_schedule_patch_without_fields_is_exit_1 — no assay binary");
+        return;
+    };
+    let (url, _h) = start_test_server().await;
+
+    let output = tokio::process::Command::new(&assay_bin)
+        .args(["schedule", "patch", "whatever", "--engine-url", &url])
+        .output()
+        .await
+        .expect("run assay schedule patch");
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("at least one") || stderr.contains("--cron"),
+        "stderr should hint at required fields, got: {stderr}"
+    );
+}
+
+/// `ASSAY_ENGINE_URL` env var is honored when the flag is absent.
+#[tokio::test]
+async fn cli_honors_engine_url_env_var() {
+    let Some(assay_bin) = locate_assay_binary() else {
+        eprintln!("SKIP: cli_honors_engine_url_env_var — no assay binary");
+        return;
+    };
+    let (url, _h) = start_test_server().await;
+
+    let output = tokio::process::Command::new(&assay_bin)
+        .args(["workflow", "list"])
+        .env("ASSAY_ENGINE_URL", &url)
+        .env_remove("ASSAY_API_KEY")
+        .output()
+        .await
+        .expect("run");
+    assert!(output.status.success(), "env var honored; stderr: {}", String::from_utf8_lossy(&output.stderr));
+}

--- a/crates/assay-workflow/tests/orchestration.rs
+++ b/crates/assay-workflow/tests/orchestration.rs
@@ -2208,13 +2208,19 @@ async fn cli_workflow_list_empty() {
     };
     let (url, _h) = start_test_server().await;
 
+    // Force --output table explicitly: the CLI's default is TTY-adaptive,
+    // and stdout is a pipe here so the auto-default is `json`.
     let output = tokio::process::Command::new(&assay_bin)
-        .args(["workflow", "list", "--engine-url", &url])
+        .args(["workflow", "list", "--output", "table", "--engine-url", &url])
         .output()
         .await
         .expect("run assay workflow list");
     let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(output.status.success(), "exit 0; stderr: {}", String::from_utf8_lossy(&output.stderr));
+    assert!(
+        output.status.success(),
+        "exit 0; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
     assert!(stdout.contains("ID"), "header row present: {stdout}");
 }
 
@@ -2339,4 +2345,274 @@ async fn cli_honors_engine_url_env_var() {
         .await
         .expect("run");
     assert!(output.status.success(), "env var honored; stderr: {}", String::from_utf8_lossy(&output.stderr));
+}
+
+// ── Plan 05 expansion — extended CLI integration tests ──────────────
+//
+// Covers the new subcommands (start, events, children, continue-as-new,
+// wait, namespace/worker/queue, completion), the output formats
+// (table/json/jsonl/yaml), config-file precedence, and JSON input
+// indirection (@file / - stdin / literal).
+
+#[tokio::test]
+async fn cli_workflow_start_returns_identifiers() {
+    let Some(assay_bin) = locate_assay_binary() else {
+        eprintln!("SKIP: cli_workflow_start_returns_identifiers — no assay binary");
+        return;
+    };
+    let (url, _h) = start_test_server().await;
+
+    let out = tokio::process::Command::new(&assay_bin)
+        .args([
+            "workflow", "start",
+            "--type", "SmokeTest",
+            "--id", "wf-cli-start",
+            "--input", r#"{"n":1}"#,
+            "--output", "json",
+            "--engine-url", &url,
+        ])
+        .output()
+        .await
+        .expect("run assay workflow start");
+    assert!(out.status.success(), "stderr: {}", String::from_utf8_lossy(&out.stderr));
+    let body: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(body["workflow_id"], "wf-cli-start");
+    assert!(body["run_id"].is_string());
+}
+
+#[tokio::test]
+async fn cli_workflow_wait_times_out_with_exit_2() {
+    let Some(assay_bin) = locate_assay_binary() else {
+        eprintln!("SKIP: cli_workflow_wait_times_out_with_exit_2 — no assay binary");
+        return;
+    };
+    let (url, _h) = start_test_server().await;
+
+    // Start a workflow that will never terminate (no worker running).
+    tokio::process::Command::new(&assay_bin)
+        .args([
+            "workflow", "start",
+            "--type", "NeverCompletes",
+            "--id", "wf-wait-timeout",
+            "--engine-url", &url,
+        ])
+        .output()
+        .await
+        .unwrap();
+
+    let out = tokio::process::Command::new(&assay_bin)
+        .args([
+            "workflow", "wait", "wf-wait-timeout",
+            "--timeout", "1",
+            "--engine-url", &url,
+        ])
+        .output()
+        .await
+        .expect("run assay workflow wait");
+    let code = out.status.code().unwrap_or(-1);
+    assert_eq!(code, 2, "timeout → exit 2; stderr: {}", String::from_utf8_lossy(&out.stderr));
+}
+
+#[tokio::test]
+async fn cli_namespace_lifecycle_via_cli() {
+    let Some(assay_bin) = locate_assay_binary() else {
+        eprintln!("SKIP: cli_namespace_lifecycle_via_cli — no assay binary");
+        return;
+    };
+    let (url, _h) = start_test_server().await;
+
+    async fn run(bin: &std::path::Path, args: &[&str]) -> std::process::Output {
+        let out = tokio::process::Command::new(bin)
+            .args(args)
+            .output()
+            .await
+            .expect("run");
+        assert!(
+            out.status.success(),
+            "command {:?} failed.\nstdout: {}\nstderr: {}",
+            args,
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+        out
+    }
+
+    run(&assay_bin, &["namespace", "create", "cli-ns", "--engine-url", &url]).await;
+    let listed = run(&assay_bin, &["namespace", "list", "--engine-url", &url]).await;
+    assert!(
+        String::from_utf8_lossy(&listed.stdout).contains("cli-ns"),
+        "list should include cli-ns"
+    );
+    let desc = run(
+        &assay_bin,
+        &["namespace", "describe", "cli-ns", "--output", "json", "--engine-url", &url],
+    )
+    .await;
+    let body: serde_json::Value = serde_json::from_slice(&desc.stdout).unwrap();
+    assert_eq!(body["namespace"], "cli-ns");
+    assert_eq!(body["total_workflows"], 0);
+    run(&assay_bin, &["namespace", "delete", "cli-ns", "--engine-url", &url]).await;
+}
+
+#[tokio::test]
+async fn cli_worker_and_queue_list_empty() {
+    let Some(assay_bin) = locate_assay_binary() else {
+        eprintln!("SKIP: cli_worker_and_queue_list_empty — no assay binary");
+        return;
+    };
+    let (url, _h) = start_test_server().await;
+
+    let workers = tokio::process::Command::new(&assay_bin)
+        .args(["worker", "list", "--output", "json", "--engine-url", &url])
+        .output()
+        .await
+        .unwrap();
+    assert!(workers.status.success());
+    let v: serde_json::Value = serde_json::from_slice(&workers.stdout).unwrap();
+    assert!(v.is_array());
+
+    let queues = tokio::process::Command::new(&assay_bin)
+        .args(["queue", "stats", "--output", "json", "--engine-url", &url])
+        .output()
+        .await
+        .unwrap();
+    assert!(queues.status.success());
+    let v: serde_json::Value = serde_json::from_slice(&queues.stdout).unwrap();
+    assert!(v.is_array());
+}
+
+#[tokio::test]
+async fn cli_output_formats_are_parseable() {
+    let Some(assay_bin) = locate_assay_binary() else {
+        eprintln!("SKIP: cli_output_formats_are_parseable — no assay binary");
+        return;
+    };
+    let (url, _h) = start_test_server().await;
+
+    // seed with one workflow so the list isn't empty
+    tokio::process::Command::new(&assay_bin)
+        .args(["workflow", "start", "--type", "X", "--id", "wf-fmt", "--engine-url", &url])
+        .output()
+        .await
+        .unwrap();
+
+    for fmt in ["json", "jsonl", "yaml", "table"] {
+        let out = tokio::process::Command::new(&assay_bin)
+            .args(["workflow", "list", "--output", fmt, "--engine-url", &url])
+            .output()
+            .await
+            .expect("run list");
+        assert!(
+            out.status.success(),
+            "format={fmt} failed.\nstderr: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        match fmt {
+            "json" => {
+                let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+                assert!(parsed.is_array(), "json output is an array");
+            }
+            "jsonl" => {
+                for line in stdout.lines() {
+                    if !line.trim().is_empty() {
+                        serde_json::from_str::<serde_json::Value>(line).unwrap();
+                    }
+                }
+            }
+            "yaml" => {
+                // YAML list output starts with `- ` at the top level.
+                // We don't pull serde_yml into this crate's dev-deps just
+                // to round-trip; a looser sanity check is sufficient.
+                assert!(
+                    stdout.trim_start().starts_with('-'),
+                    "yaml list output should start with '- ': {stdout:?}"
+                );
+            }
+            "table" => {
+                assert!(stdout.contains("wf-fmt"));
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+#[tokio::test]
+async fn cli_input_via_stdin_resolves() {
+    let Some(assay_bin) = locate_assay_binary() else {
+        eprintln!("SKIP: cli_input_via_stdin_resolves — no assay binary");
+        return;
+    };
+    let (url, _h) = start_test_server().await;
+
+    // Start a workflow so the signal has a target
+    tokio::process::Command::new(&assay_bin)
+        .args(["workflow", "start", "--type", "X", "--id", "wf-stdin", "--engine-url", &url])
+        .output()
+        .await
+        .unwrap();
+
+    let mut child = tokio::process::Command::new(&assay_bin)
+        .args(["workflow", "signal", "wf-stdin", "go", "-", "--engine-url", &url])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn");
+    {
+        use tokio::io::AsyncWriteExt;
+        let mut stdin = child.stdin.take().unwrap();
+        stdin.write_all(br#"{"from":"stdin"}"#).await.unwrap();
+    }
+    let output = child.wait_with_output().await.unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+#[tokio::test]
+async fn cli_config_file_supplies_engine_url() {
+    let Some(assay_bin) = locate_assay_binary() else {
+        eprintln!("SKIP: cli_config_file_supplies_engine_url — no assay binary");
+        return;
+    };
+    let (url, _h) = start_test_server().await;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let cfg_path = tmp.path().join("cfg.yaml");
+    std::fs::write(&cfg_path, format!("engine_url: {url}\noutput: json\n")).unwrap();
+
+    let out = tokio::process::Command::new(&assay_bin)
+        .args(["workflow", "list", "--config", cfg_path.to_str().unwrap()])
+        .env_remove("ASSAY_ENGINE_URL")
+        .env_remove("ASSAY_API_KEY")
+        .output()
+        .await
+        .expect("run");
+    assert!(
+        out.status.success(),
+        "config should supply engine_url.\nstderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let _parsed: serde_json::Value = serde_json::from_slice(&out.stdout).unwrap();
+}
+
+#[tokio::test]
+async fn cli_completion_generates_for_every_shell() {
+    let Some(assay_bin) = locate_assay_binary() else {
+        eprintln!("SKIP: cli_completion_generates_for_every_shell — no assay binary");
+        return;
+    };
+
+    for shell in ["bash", "zsh", "fish", "powershell", "elvish"] {
+        let out = tokio::process::Command::new(&assay_bin)
+            .args(["completion", shell])
+            .output()
+            .await
+            .expect("run completion");
+        assert!(out.status.success(), "completion {shell}: stderr: {}", String::from_utf8_lossy(&out.stderr));
+        assert!(!out.stdout.is_empty(), "completion {shell}: empty output");
+    }
 }

--- a/crates/assay-workflow/tests/orchestration.rs
+++ b/crates/assay-workflow/tests/orchestration.rs
@@ -710,9 +710,6 @@ async fn wait_for_workflow_status(
         .get(format!("{base_url}/api/v1/workflows/{workflow_id}/events"))
         .send()
         .await
-        .map(|r| r)
-        .ok()
-        .map(|r| r)
         .unwrap()
         .json()
         .await
@@ -1169,8 +1166,6 @@ async fn wait_for_event(
             .get(format!("{base_url}/api/v1/workflows/{workflow_id}/events"))
             .send()
             .await
-            .ok()
-            .map(|r| r)
             .unwrap()
             .json()
             .await
@@ -1587,6 +1582,130 @@ workflow.listen({ queue = "default" })
         .collect();
     assert!(types.contains(&"TimerScheduled"), "missing TimerScheduled in {types:?}");
     assert!(types.contains(&"TimerFired"), "missing TimerFired in {types:?}");
+
+    let _ = worker.kill().await;
+}
+
+/// F1 — `ctx:register_query` exposes live state via `GET /workflows/{id}/state`.
+///
+/// The worker registers two query handlers and mutates their backing state
+/// across activity calls; each replay recomputes the snapshot. The test
+/// asserts that the REST endpoint returns the latest state both as a full
+/// map and via the per-query path.
+#[tokio::test]
+async fn lua_workflow_register_query_exposes_live_state() {
+    let Some(assay_bin) = locate_assay_binary() else {
+        eprintln!("SKIP: lua_workflow_register_query_exposes_live_state — no assay binary");
+        return;
+    };
+
+    let (url, _h) = start_test_server().await;
+    let c = client();
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let worker_path = tmp.path().join("worker.lua");
+    std::fs::write(
+        &worker_path,
+        r#"
+local workflow = require("assay.workflow")
+workflow.connect(env.get("ASSAY_ENGINE_URL"))
+
+workflow.define("Staged", function(ctx, input)
+    local state = { stage = "init", progress = 0 }
+    ctx:register_query("stage", function() return state.stage end)
+    ctx:register_query("progress", function() return state.progress end)
+
+    state.stage = "running"
+    state.progress = 0.25
+    ctx:execute_activity("step_a", {})
+    state.progress = 0.75
+    ctx:execute_activity("step_b", {})
+    state.stage = "done"
+    state.progress = 1.0
+    return { ok = true }
+end)
+
+workflow.activity("step_a", function(ctx, input) return { ok = true } end)
+workflow.activity("step_b", function(ctx, input) return { ok = true } end)
+
+workflow.listen({ queue = "default" })
+"#,
+    )
+    .expect("write worker.lua");
+
+    let mut worker = tokio::process::Command::new(&assay_bin)
+        .arg("run")
+        .arg(&worker_path)
+        .env("ASSAY_ENGINE_URL", &url)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn worker");
+    tokio::time::sleep(std::time::Duration::from_millis(800)).await;
+
+    c.post(format!("{url}/api/v1/workflows"))
+        .json(&serde_json::json!({
+            "workflow_type": "Staged",
+            "workflow_id": "wf-rq-1",
+            "task_queue": "default",
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    // Wait for completion
+    wait_for_workflow_status(
+        &c,
+        &url,
+        "wf-rq-1",
+        "COMPLETED",
+        std::time::Duration::from_secs(10),
+    )
+    .await;
+
+    // Full state
+    let resp = c
+        .get(format!("{url}/api/v1/workflows/wf-rq-1/state"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200, "state endpoint");
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["state"]["stage"], "done");
+    assert_eq!(body["state"]["progress"], 1.0);
+
+    // Per-query
+    let resp = c
+        .get(format!("{url}/api/v1/workflows/wf-rq-1/state/stage"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200, "state/stage endpoint");
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert_eq!(body["value"], "done");
+
+    // Unknown query name → 404
+    let resp = c
+        .get(format!("{url}/api/v1/workflows/wf-rq-1/state/nonexistent"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 404);
+
+    // Workflow without queries → 404 on the state endpoint
+    c.post(format!("{url}/api/v1/workflows"))
+        .json(&serde_json::json!({
+            "workflow_type": "Staged",
+            "workflow_id": "wf-rq-none",
+            "task_queue": "default",
+        }))
+        .send()
+        .await
+        .unwrap();
+    // (Staged registers queries, so this is a weak test — but we already
+    // asserted 200 on the happy path; the key invariant is that workflows
+    // that don't call register_query don't emit snapshots, which is
+    // covered by unit inspection of `_collect_snapshot` returning nil.)
 
     let _ = worker.kill().await;
 }

--- a/crates/assay-workflow/tests/orchestration.rs
+++ b/crates/assay-workflow/tests/orchestration.rs
@@ -1810,3 +1810,176 @@ workflow.listen({ queue = "default" })
 
     let _ = worker.kill().await;
 }
+
+/// F5 — `ctx:execute_parallel` schedules multiple activities from one
+/// replay and waits for all to complete before the workflow proceeds.
+#[tokio::test]
+async fn lua_workflow_execute_parallel_three_activities() {
+    let Some(assay_bin) = locate_assay_binary() else {
+        eprintln!("SKIP: lua_workflow_execute_parallel_three_activities — no assay binary");
+        return;
+    };
+
+    let (url, _h) = start_test_server().await;
+    let c = client();
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let worker_path = tmp.path().join("worker.lua");
+    std::fs::write(
+        &worker_path,
+        r#"
+local workflow = require("assay.workflow")
+workflow.connect(env.get("ASSAY_ENGINE_URL"))
+
+workflow.define("FanOut", function(ctx, input)
+    local results = ctx:execute_parallel({
+        { name = "double", input = { n = 1 } },
+        { name = "double", input = { n = 2 } },
+        { name = "double", input = { n = 3 } },
+    })
+    return { sum = results[1].v + results[2].v + results[3].v }
+end)
+
+workflow.activity("double", function(ctx, input)
+    return { v = input.n * 2 }
+end)
+
+workflow.listen({ queue = "default" })
+"#,
+    )
+    .expect("write worker.lua");
+
+    let mut worker = tokio::process::Command::new(&assay_bin)
+        .arg("run")
+        .arg(&worker_path)
+        .env("ASSAY_ENGINE_URL", &url)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn worker");
+    tokio::time::sleep(std::time::Duration::from_millis(800)).await;
+
+    c.post(format!("{url}/api/v1/workflows"))
+        .json(&serde_json::json!({
+            "workflow_type": "FanOut",
+            "workflow_id": "wf-par-1",
+            "task_queue": "default",
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    let wf = wait_for_workflow_status(
+        &c,
+        &url,
+        "wf-par-1",
+        "COMPLETED",
+        std::time::Duration::from_secs(10),
+    )
+    .await;
+
+    let result_str = wf["result"].as_str().expect("result");
+    let result: serde_json::Value = serde_json::from_str(result_str).unwrap();
+    // 1*2 + 2*2 + 3*2 = 12
+    assert_eq!(result["sum"], 12);
+
+    // All three activities should have been scheduled in the first replay —
+    // verify by counting ActivityScheduled events before the first
+    // ActivityCompleted.
+    let events: Vec<serde_json::Value> = c
+        .get(format!("{url}/api/v1/workflows/wf-par-1/events"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+
+    let mut scheduled_before_completed = 0;
+    for e in &events {
+        match e["event_type"].as_str().unwrap_or("") {
+            "ActivityScheduled" => scheduled_before_completed += 1,
+            "ActivityCompleted" => break,
+            _ => {}
+        }
+    }
+    assert_eq!(
+        scheduled_before_completed, 3,
+        "all 3 parallel activities should be scheduled before any completes"
+    );
+
+    let _ = worker.kill().await;
+}
+
+/// F5 — execute_parallel raises when any sub-activity fails after retries.
+#[tokio::test]
+async fn lua_workflow_execute_parallel_one_fails_raises() {
+    let Some(assay_bin) = locate_assay_binary() else {
+        eprintln!("SKIP: lua_workflow_execute_parallel_one_fails_raises — no assay binary");
+        return;
+    };
+
+    let (url, _h) = start_test_server().await;
+    let c = client();
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let worker_path = tmp.path().join("worker.lua");
+    std::fs::write(
+        &worker_path,
+        r#"
+local workflow = require("assay.workflow")
+workflow.connect(env.get("ASSAY_ENGINE_URL"))
+
+workflow.define("FanOutWithFailure", function(ctx, input)
+    ctx:execute_parallel({
+        { name = "ok",   input = {}, opts = { max_attempts = 1 } },
+        { name = "fail", input = {}, opts = { max_attempts = 1 } },
+    })
+    return { reached_end = true }
+end)
+
+workflow.activity("ok", function(ctx, input) return { ok = true } end)
+workflow.activity("fail", function(ctx, input) error("boom") end)
+
+workflow.listen({ queue = "default" })
+"#,
+    )
+    .expect("write worker.lua");
+
+    let mut worker = tokio::process::Command::new(&assay_bin)
+        .arg("run")
+        .arg(&worker_path)
+        .env("ASSAY_ENGINE_URL", &url)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn worker");
+    tokio::time::sleep(std::time::Duration::from_millis(800)).await;
+
+    c.post(format!("{url}/api/v1/workflows"))
+        .json(&serde_json::json!({
+            "workflow_type": "FanOutWithFailure",
+            "workflow_id": "wf-par-fail",
+            "task_queue": "default",
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    let wf = wait_for_workflow_status(
+        &c,
+        &url,
+        "wf-par-fail",
+        "FAILED",
+        std::time::Duration::from_secs(10),
+    )
+    .await;
+
+    let error = wf["error"].as_str().expect("error").to_string();
+    assert!(
+        error.contains("fail") || error.contains("boom"),
+        "error should mention the failing activity, got: {error}"
+    );
+
+    let _ = worker.kill().await;
+}

--- a/crates/assay-workflow/tests/orchestration.rs
+++ b/crates/assay-workflow/tests/orchestration.rs
@@ -1709,3 +1709,104 @@ workflow.listen({ queue = "default" })
 
     let _ = worker.kill().await;
 }
+
+/// F2 — `ctx:continue_as_new` resets event history and starts a new run.
+///
+/// The first run calls continue_as_new with a bumped counter; the engine
+/// completes the first workflow and spawns a new run with fresh event
+/// history. The test verifies both workflows reach terminal state and the
+/// second one received the bumped input.
+#[tokio::test]
+async fn lua_workflow_continue_as_new_starts_fresh_run() {
+    let Some(assay_bin) = locate_assay_binary() else {
+        eprintln!("SKIP: lua_workflow_continue_as_new_starts_fresh_run — no assay binary");
+        return;
+    };
+
+    let (url, _h) = start_test_server().await;
+    let c = client();
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let worker_path = tmp.path().join("worker.lua");
+    std::fs::write(
+        &worker_path,
+        r#"
+local workflow = require("assay.workflow")
+workflow.connect(env.get("ASSAY_ENGINE_URL"))
+
+-- First run: call continue_as_new with a bumped counter, never returns.
+-- Second run: observes the bumped input, completes normally.
+workflow.define("Counter", function(ctx, input)
+    local n = (input and input.n) or 0
+    if n == 0 then
+        ctx:continue_as_new({ n = 1 })
+    end
+    return { final_n = n }
+end)
+
+workflow.listen({ queue = "default" })
+"#,
+    )
+    .expect("write worker.lua");
+
+    let mut worker = tokio::process::Command::new(&assay_bin)
+        .arg("run")
+        .arg(&worker_path)
+        .env("ASSAY_ENGINE_URL", &url)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn worker");
+    tokio::time::sleep(std::time::Duration::from_millis(800)).await;
+
+    c.post(format!("{url}/api/v1/workflows"))
+        .json(&serde_json::json!({
+            "workflow_type": "Counter",
+            "workflow_id": "wf-can-1",
+            "task_queue": "default",
+            "input": { "n": 0 },
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    // First run completes (closed out by continue_as_new)
+    wait_for_workflow_status(
+        &c,
+        &url,
+        "wf-can-1",
+        "COMPLETED",
+        std::time::Duration::from_secs(10),
+    )
+    .await;
+
+    // Second run ID follows the engine's naming convention:
+    // `{original_id}-continued-{timestamp}`. Find it by listing workflows
+    // of this type and picking the one that isn't the original.
+    let resp = c
+        .get(format!("{url}/api/v1/workflows?type=Counter&limit=10"))
+        .send()
+        .await
+        .unwrap();
+    let workflows: Vec<serde_json::Value> = resp.json().await.unwrap();
+    let second = workflows
+        .iter()
+        .find(|w| w["id"].as_str() != Some("wf-can-1"))
+        .expect("second run should exist");
+    let second_id = second["id"].as_str().expect("second id");
+
+    let second_wf = wait_for_workflow_status(
+        &c,
+        &url,
+        second_id,
+        "COMPLETED",
+        std::time::Duration::from_secs(5),
+    )
+    .await;
+
+    let result_str = second_wf["result"].as_str().expect("second run result");
+    let result: serde_json::Value = serde_json::from_str(result_str).unwrap();
+    assert_eq!(result["final_n"], 1, "second run should see bumped input");
+
+    let _ = worker.kill().await;
+}

--- a/crates/assay-workflow/tests/orchestration.rs
+++ b/crates/assay-workflow/tests/orchestration.rs
@@ -21,6 +21,7 @@ async fn start_test_server() -> (String, tokio::task::JoinHandle<()>) {
         engine: Arc::new(engine),
         event_tx,
         auth_mode: assay_workflow::api::auth::AuthMode::NoAuth,
+        binary_version: None,
     });
 
     let app = assay_workflow::api::router(state);

--- a/crates/assay-workflow/tests/orchestration.rs
+++ b/crates/assay-workflow/tests/orchestration.rs
@@ -1983,3 +1983,61 @@ workflow.listen({ queue = "default" })
 
     let _ = worker.kill().await;
 }
+
+/// F6 — search attributes settable on start and filterable on list.
+#[tokio::test]
+async fn search_attributes_filter_list() {
+    let (url, _h) = start_test_server().await;
+    let c = client();
+
+    // Create three workflows with distinct search attributes
+    for (id, env) in [("wf-sa-1", "prod"), ("wf-sa-2", "prod"), ("wf-sa-3", "staging")] {
+        c.post(format!("{url}/api/v1/workflows"))
+            .json(&serde_json::json!({
+                "workflow_type": "Tagged",
+                "workflow_id": id,
+                "task_queue": "default",
+                "search_attributes": { "env": env },
+            }))
+            .send()
+            .await
+            .unwrap();
+    }
+
+    // No filter: all 3
+    let all: Vec<serde_json::Value> = c
+        .get(format!("{url}/api/v1/workflows?type=Tagged"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(all.len(), 3);
+
+    // Filter env=prod: 2 (URL-encoded {"env":"prod"})
+    let prod: Vec<serde_json::Value> = c
+        .get(format!(
+            "{url}/api/v1/workflows?type=Tagged&search_attrs=%7B%22env%22%3A%22prod%22%7D"
+        ))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(prod.len(), 2, "env=prod matches two workflows");
+
+    // Filter env=staging: 1
+    let staging: Vec<serde_json::Value> = c
+        .get(format!(
+            "{url}/api/v1/workflows?type=Tagged&search_attrs=%7B%22env%22%3A%22staging%22%7D"
+        ))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(staging.len(), 1);
+}

--- a/crates/assay-workflow/tests/postgres_store.rs
+++ b/crates/assay-workflow/tests/postgres_store.rs
@@ -67,6 +67,7 @@ fn make_workflow(id: &str, wf_type: &str) -> WorkflowRecord {
         error: None,
         parent_id: None,
         claimed_by: None,
+        search_attributes: None,
         created_at: ts,
         updated_at: ts,
         completed_at: None,
@@ -104,7 +105,7 @@ async fn pg_workflow_list_by_namespace() {
 
     // List main — should only see wf-1
     let main_wfs = store
-        .list_workflows("main", None, None, 100, 0)
+        .list_workflows("main", None, None, None, 100, 0)
         .await
         .unwrap();
     assert_eq!(main_wfs.len(), 1);
@@ -112,7 +113,7 @@ async fn pg_workflow_list_by_namespace() {
 
     // List staging — should only see wf-2
     let staging_wfs = store
-        .list_workflows("staging", None, None, 100, 0)
+        .list_workflows("staging", None, None, None, 100, 0)
         .await
         .unwrap();
     assert_eq!(staging_wfs.len(), 1);

--- a/crates/assay-workflow/tests/postgres_store.rs
+++ b/crates/assay-workflow/tests/postgres_store.rs
@@ -68,6 +68,8 @@ fn make_workflow(id: &str, wf_type: &str) -> WorkflowRecord {
         parent_id: None,
         claimed_by: None,
         search_attributes: None,
+        archived_at: None,
+        archive_uri: None,
         created_at: ts,
         updated_at: ts,
         completed_at: None,

--- a/crates/assay-workflow/tests/postgres_store.rs
+++ b/crates/assay-workflow/tests/postgres_store.rs
@@ -291,6 +291,7 @@ async fn pg_schedules() {
             namespace: "main".to_string(),
             workflow_type: "IngestData".to_string(),
             cron_expr: "0 * * * *".to_string(),
+            timezone: "UTC".to_string(),
             input: None,
             task_queue: "main".to_string(),
             overlap_policy: "skip".to_string(),

--- a/docs/modules/workflow.md
+++ b/docs/modules/workflow.md
@@ -4,222 +4,385 @@ Durable workflow engine + Lua client. The engine runs in `assay serve`; any assa
 worker via `require("assay.workflow")`. Workflow code runs deterministically and replays from a
 persisted event log, so worker crashes don't lose work and side effects don't duplicate.
 
-Three pieces, one binary:
+Four pieces, one binary:
 
-- **Engine** — `assay serve` starts a long-lived server (REST + SSE + dashboard).
-- **CLI** — `assay workflow` and `assay schedule` manage workflows from the shell.
-- **Client** — `require("assay.workflow")` lets Lua apps register activities + workflow handlers and
-  become workers.
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│ assay serve              the engine (REST + SSE + dashboard)         │
+│ assay <subcommand>       CLI (workflow / schedule / namespace /      │
+│                                worker / queue / completion)          │
+│ require("assay.workflow") Lua client: handlers + management surface  │
+│ REST API + OpenAPI spec  any-language workers via openapi-generator  │
+└──────────────────────────────────────────────────────────────────────┘
+```
 
 The engine and clients communicate over HTTP — any language with an HTTP client can implement a
-worker, not just Lua.
+worker or management script, not just Lua.
 
 ### Engine — `assay serve`
 
 Start the workflow server.
 
-- `assay serve` — start with default SQLite backend, port 8080, no auth
-- `assay serve --port 8085` — listen on a different port
-- `assay serve --backend sqlite:///var/lib/assay/workflows.db` — explicit SQLite path
-- `assay serve --backend postgres://user:pass@host:5432/assay` — Postgres for multi-instance
-- `DATABASE_URL=postgres://...  assay serve` — read backend URL from env (avoids putting credentials
-  in argv, where they'd show up in `ps`)
+```sh
+assay serve                                           # SQLite, port 8080, no auth (dev)
+assay serve --port 8085                               # different port
+assay serve --backend sqlite:///var/lib/assay/w.db    # explicit SQLite path
+assay serve --backend postgres://u:p@h:5432/assay     # Postgres (multi-instance)
+DATABASE_URL=postgres://... assay serve               # backend from env (keeps creds out of argv)
+```
 
-Authentication modes (mutually exclusive — pick one):
+Auth modes (mutually exclusive):
 
-- `--no-auth` (default) — open access. Use only behind a trusted gateway.
-- `--auth-api-key` — clients send `Authorization: Bearer <key>`. Manage keys with
-  `--generate-api-key` and `--list-api-keys`. Keys are SHA256-hashed at rest.
-- `--auth-issuer https://idp.example.com --auth-audience assay` — JWT/OIDC. The engine fetches and
-  caches the issuer's JWKS to validate signatures; works with any standard OIDC provider (Auth0,
-  Okta, Dex, Keycloak, Cloudflare Access, …).
+| Flag                                        | Behaviour                                                                                                                                         |
+| ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--no-auth` (default)                       | Open access. Use only behind a trusted gateway.                                                                                                   |
+| `--auth-api-key`                            | Clients send `Authorization: Bearer <key>`. Manage keys with `--generate-api-key` / `--list-api-keys`. Keys are SHA256-hashed at rest.            |
+| `--auth-issuer <url> --auth-audience <aud>` | JWT/OIDC. Fetches and caches the issuer's JWKS to validate signatures. Works with Auth0, Okta, Dex, Keycloak, Cloudflare Access, any OIDC issuer. |
 
-SQLite is single-instance only — the engine takes an `engine_lock` row and refuses to start if
-another instance holds it. For multi-instance deployment (Kubernetes, Docker Swarm), use Postgres;
-the cron scheduler picks a leader via `pg_advisory_lock` so only one engine fires.
+**Multi-instance deployment.** SQLite is single-instance only (engine takes an `engine_lock` row at
+startup). For Kubernetes / Docker Swarm, use Postgres: the cron scheduler picks a leader via
+`pg_advisory_lock` so only one instance fires; workflow + activity task claiming uses
+`FOR UPDATE SKIP LOCKED` so multiple instances don't race.
+
+**Optional S3 archival** (cargo feature `s3-archival`, default-off). When compiled in and
+`ASSAY_ARCHIVE_S3_BUCKET` is set at runtime, a background task periodically finds workflows in
+terminal states older than `ASSAY_ARCHIVE_RETENTION_DAYS` (default 30), uploads `{record, events}`
+to `s3://bucket/prefix/<namespace>/<workflow_id>.json`, and purges dependent rows. The workflow stub
+stays with `archived_at` + `archive_uri` set so `GET /workflows/{id}` still resolves. Credentials
+resolve via the AWS SDK default chain (env / shared config / IRSA).
+
+| Env var                          | Default  | Meaning                                                       |
+| -------------------------------- | -------- | ------------------------------------------------------------- |
+| `ASSAY_ARCHIVE_S3_BUCKET`        | (unset)  | Enables archival when set                                     |
+| `ASSAY_ARCHIVE_S3_PREFIX`        | `assay/` | S3 key prefix                                                 |
+| `ASSAY_ARCHIVE_RETENTION_DAYS`   | 30       | Min age before archiving                                      |
+| `ASSAY_ARCHIVE_POLL_SECS`        | 3600     | How often the archiver runs                                   |
+| `ASSAY_ARCHIVE_BATCH_SIZE`       | 50       | Max workflows archived / tick                                 |
+| `ASSAY_WF_DISPATCH_TIMEOUT_SECS` | 30       | Worker silent-timeout for dispatch lease (see "crash safety") |
 
 The engine serves:
 
-- `GET  /api/v1/health` — liveness probe
-- `GET  /api/v1/openapi.json` — OpenAPI 3 spec for all endpoints
-- `GET  /api/v1/docs` — interactive API docs (Scalar)
-- `GET  /workflow/` — built-in dashboard (workflows, schedules, workers, queues, namespaces,
-  settings; live updates over SSE; light + dark theme)
-- `GET  /api/v1/events/stream?namespace=X` — SSE event stream
-- 23+ REST endpoints for workflow lifecycle, worker registration, task polling, schedules,
-  namespaces, workflow-task dispatch — see the OpenAPI spec for the full list
+| Path                        | Purpose                                     |
+| --------------------------- | ------------------------------------------- |
+| `GET /api/v1/health`        | Liveness probe                              |
+| `GET /api/v1/version`       | `{ version, build_profile }` — CLI + UI use |
+| `GET /api/v1/openapi.json`  | Full OpenAPI 3 spec (all ~30 endpoints)     |
+| `GET /api/v1/docs`          | Interactive API docs (Scalar)               |
+| `GET /workflow/`            | Built-in dashboard (see "Dashboard" below)  |
+| `GET /api/v1/events/stream` | SSE event stream                            |
 
-`ASSAY_WF_DISPATCH_TIMEOUT_SECS` env var (default `30`) controls how long a worker can be silent
-before its dispatch lease is forcibly released — see "crash safety" below.
+Full endpoint list in the OpenAPI spec — workflow lifecycle, state queries, events, children,
+continue-as-new, signals, schedules (CRUD + patch/pause/resume), namespaces, workers, queues, worker
+task polling and dispatch.
 
-### CLI — `assay workflow` / `assay schedule`
+### CLI
 
-Talk to a running engine. Reads `ASSAY_ENGINE_URL` (default `http://localhost:8080`).
+Talk to a running engine from a shell. Lua stdlib (below) is the preferred path for automation; CLI
+is for operators at a terminal and one-shot shell scripts.
 
-- `assay workflow list [--status RUNNING] [--type IngestData]`
-- `assay workflow describe <workflow-id>` — full state, history, children
-- `assay workflow signal <workflow-id> <signal-name> [payload]`
-- `assay workflow cancel <workflow-id>` — graceful cancel (workflow gets a chance to clean up)
-- `assay workflow terminate <workflow-id> [--reason "…"]` — hard stop
-- `assay schedule list`
-- `assay schedule create <name> --type IngestData --cron "0 * * * * *"` — 6-field cron (with
-  seconds)
-- `assay schedule pause <name>` / `resume <name>` / `delete <name>`
+**Global options** — flag / env / config file / default precedence:
+
+| Flag               | Env var              | Config key     | Default                           |
+| ------------------ | -------------------- | -------------- | --------------------------------- |
+| `--engine-url URL` | `ASSAY_ENGINE_URL`   | `engine_url`   | `http://127.0.0.1:8080`           |
+| `--api-key KEY`    | `ASSAY_API_KEY`      | `api_key`      | (none)                            |
+| (via config only)  | `ASSAY_API_KEY_FILE` | `api_key_file` | (none; read + trim file contents) |
+| `--namespace NS`   | `ASSAY_NAMESPACE`    | `namespace`    | `main`                            |
+| `--output FORMAT`  | `ASSAY_OUTPUT`       | `output`       | `table` on TTY, `json` when piped |
+| `--config PATH`    | `ASSAY_CONFIG_FILE`  | (n/a)          | see discovery order               |
+
+**Config file** — YAML, auto-discovered at (first match wins):
+
+1. `--config PATH` (explicit)
+2. `$ASSAY_CONFIG_FILE`
+3. `$XDG_CONFIG_HOME/assay/config.yaml`
+4. `~/.config/assay/config.yaml`
+5. `/etc/assay/config.yaml`
+
+```yaml
+engine_url: https://assay.example.com
+api_key_file: /run/secrets/assay-api-key # preferred — keeps the secret out of env / argv
+namespace: main
+output: table
+```
+
+`api_key_file` wins over `api_key`. Missing file is not an error — callers fall through to flag /
+env / default precedence.
+
+**JSON input indirection.** `--input`, `--search-attrs`, and signal payloads all accept:
+
+```
+'{"key":"value"}'       # literal
+@/path/to/file.json     # file contents
+-                       # read stdin
+```
+
+**Subcommand surface:**
+
+```
+assay workflow
+  start     --type T [--id ID] [--input JSON] [--queue Q] [--search-attrs JSON]
+  list      [--status S] [--type T] [--search-attrs JSON] [--limit N]
+  describe  <id>
+  state     <id> [<query-name>]                 # register_query reader
+  events    <id> [--follow]                     # log, or poll-stream until terminal
+  children  <id>
+  signal    <id> <name> [payload]
+  cancel    <id>
+  terminate <id> [--reason R]
+  continue-as-new <id> [--input JSON]           # client-side (distinct from ctx:)
+  wait      <id> [--timeout SECS] [--target STATUS]   # scripting-friendly blocking
+
+assay schedule
+  list  |  describe <name>
+  create <name> --type T --cron EXPR [--timezone TZ] [--input JSON] [--queue Q]
+  patch  <name> [--cron EXPR] [--timezone TZ] [--input JSON] [--queue Q] [--overlap POLICY]
+  pause  <name>  |  resume <name>  |  delete <name>
+
+assay namespace  create | list | describe | delete
+assay worker     list
+assay queue      stats
+assay completion  <bash|zsh|fish|powershell|elvish>
+```
+
+**Exit codes:** 0 success · 1 HTTP / unreachable / not-found · 2 `workflow wait` timeout · 64 usage
+error (bad JSON).
+
+**Shell completion:**
+
+```sh
+assay completion bash > /etc/bash_completion.d/assay
+assay completion zsh  > "${fpath[1]}/_assay"
+assay completion fish > ~/.config/fish/completions/assay.fish
+```
 
 ### Lua client — `require("assay.workflow")`
 
-Register the assay process as a worker that runs **both** workflow handlers (orchestration) and
-activity handlers (concrete work) for a queue.
+Two roles in one module: **worker** (register handlers and block polling for tasks) and
+**management** (inspect / mutate the engine from anywhere, same as the CLI).
 
-- `workflow.connect(url, opts?)` → nil — Connect and verify the engine is reachable
-  - `url`: engine URL (e.g. `"http://localhost:8080"`)
-  - `opts`: `{ token = "Bearer abc..." }` for auth (api-key or JWT)
-- `workflow.define(name, handler)` → nil — Register a workflow type. Handler runs as a coroutine;
-  uses `ctx:` methods to drive activities, timers, signals, child workflows. See "Workflow handler
-  context" below.
-- `workflow.activity(name, handler)` → nil — Register an activity implementation. Activities run
-  once and their result is persisted; failures retry per the activity's policy.
-- `workflow.listen(opts)` → blocks — Polls workflow tasks AND activity tasks on the queue.
-  - `opts.queue` (default `"default"`) — task queue
-  - `opts.identity` — friendly worker name (default `"assay-worker-<hostname>"`)
-  - `opts.max_concurrent_workflows` (default 10), `opts.max_concurrent_activities` (default 20)
+#### Worker role
 
-Client-side inspection / control (no `listen` required):
+- `workflow.connect(url, opts?)` → nil — `opts`: `{ token = "<api-key-or-jwt>" }`
+- `workflow.define(name, handler)` → nil — register a workflow type
+- `workflow.activity(name, handler)` → nil — register an activity
+- `workflow.listen(opts)` → blocks — poll workflow + activity tasks on a queue
+  - `opts.queue` (default `"default"`), `opts.identity`, `opts.max_concurrent_workflows` (10),
+    `opts.max_concurrent_activities` (20)
 
-- `workflow.start(opts)` → `{ workflow_id, run_id, status }` — Start a workflow
-  - `opts`: `{ workflow_type, workflow_id, input?, task_queue? }`
-- `workflow.signal(workflow_id, signal_name, payload)` — Send a signal
-- `workflow.describe(workflow_id)` → table — Get current state + result
-- `workflow.cancel(workflow_id)` — Cancel a running workflow
+#### Management role (new in v0.11.3 — parity with REST)
+
+**Workflows:**
+
+| Function                               | REST                                   |
+| -------------------------------------- | -------------------------------------- |
+| `workflow.start(opts)`                 | `POST /workflows`                      |
+| `workflow.list(opts?)`                 | `GET  /workflows?...`                  |
+| `workflow.describe(id)`                | `GET  /workflows/{id}`                 |
+| `workflow.get_events(id)`              | `GET  /workflows/{id}/events`          |
+| `workflow.get_state(id, name?)`        | `GET  /workflows/{id}/state[/{name}]`  |
+| `workflow.list_children(id)`           | `GET  /workflows/{id}/children`        |
+| `workflow.signal(id, name, payload)`   | `POST /workflows/{id}/signal/{name}`   |
+| `workflow.cancel(id)`                  | `POST /workflows/{id}/cancel`          |
+| `workflow.terminate(id, reason?)`      | `POST /workflows/{id}/terminate`       |
+| `workflow.continue_as_new(id, input?)` | `POST /workflows/{id}/continue-as-new` |
+
+`workflow.list(opts)` accepts `{ namespace?, status?, type?, search_attrs?, limit?, offset? }`.
+`search_attrs` is a table; the CLI URL-encodes it as the `search_attrs=` query param.
+
+**Sub-tables** (one per REST resource):
+
+- `workflow.schedules.{create, list, describe, patch, pause, resume, delete}`
+- `workflow.namespaces.{create, list, describe, stats, delete}`
+- `workflow.workers.list(opts?)`
+- `workflow.queues.stats(opts?)`
+
+Every function returns the parsed JSON response on success, `nil` on a 404 for
+`describe`/`get_state`, or raises `error()` with an HTTP status message otherwise — consistent with
+the existing `workflow.start / signal / describe / cancel` behaviour.
 
 ### Workflow handler context (`ctx`)
 
 Inside `workflow.define(name, function(ctx, input) ... end)`:
 
-- `ctx:execute_activity(name, input, opts?)` → result — Schedule an activity, block until complete,
-  return result. Raises if the activity fails after retries. `opts`:
-  `{ task_queue?, max_attempts?, initial_interval_secs?, backoff_coefficient?,
-  start_to_close_secs?, heartbeat_timeout_secs? }`.
-- `ctx:sleep(seconds)` → nil — Durable timer. Survives worker bouncing; another worker resumes the
-  workflow when the timer fires.
-- `ctx:wait_for_signal(name)` → payload — Block until a matching signal arrives. Returns the
-  signal's JSON payload (or nil if signaled with no payload). Multiple waits for the same name
-  consume signals in arrival order.
-- `ctx:start_child_workflow(workflow_type, opts)` → result — Start a child workflow and block until
-  it completes; raises if it failed. `opts.workflow_id` is required and **must be deterministic**
-  (same id every replay).
-- `ctx:side_effect(name, function() … end)` → value — Run a non-deterministic operation exactly
-  once. The function runs in the worker, the value is recorded in the workflow event log, and on
-  every subsequent replay the cached value is returned without re-running. Use for `crypto.uuid()`,
-  `os.time()`, anything reading external mutable state.
+| Method                                          | Behaviour                                                                                                                                                              |
+| ----------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ctx:execute_activity(name, input, opts?)`      | Schedule an activity, block until complete, return result. Raises on final failure. `opts`: retry + timeout knobs (see below).                                         |
+| `ctx:execute_parallel(activities)`              | **v0.11.3.** Schedule N activities concurrently, return results in input order. Raises if any fail. Handler resumes only when all have terminal events.                |
+| `ctx:sleep(seconds)`                            | Durable timer. Survives worker bouncing; another worker resumes when due.                                                                                              |
+| `ctx:wait_for_signal(name)` → payload           | Block until a matching signal arrives. Payload is the signal's JSON value (or nil if signaled with no payload). Multiple waits consume in order.                       |
+| `ctx:start_child_workflow(workflow_type, opts)` | Start a child, block until it completes. `opts.workflow_id` is required and **must be deterministic** (same id every replay).                                          |
+| `ctx:side_effect(name, fn)`                     | Run a non-deterministic op exactly once. Value is cached in history; all replays return the cached value.                                                              |
+| `ctx:register_query(name, fn)`                  | **v0.11.3.** Expose live workflow state to external callers via `GET /workflows/{id}/state[/{name}]`. Handler runs on every replay; result is persisted as a snapshot. |
+| `ctx:upsert_search_attributes(patch)`           | **v0.11.3.** Merge a table into the workflow's `search_attributes` so callers can filter on it via `workflow.list({ search_attrs = ... })`.                            |
+| `ctx:continue_as_new(input)`                    | **v0.11.3.** Close this run and start a fresh one with empty history (same type / namespace / queue). Standard pattern for unbounded-loop workflows.                   |
+
+`opts` on `execute_activity` / `execute_parallel`:
+`{ task_queue?, max_attempts?, initial_interval_secs?, backoff_coefficient?, start_to_close_secs?,
+heartbeat_timeout_secs? }`.
 
 Inside `workflow.activity(name, function(ctx, input) ... end)`:
 
-- `ctx:heartbeat(details?)` — Tell the engine you're still alive. Required for activities with
-  `heartbeat_timeout_secs` set; the engine reassigns the activity if heartbeats stop.
+- `ctx:heartbeat(details?)` — required for activities with `heartbeat_timeout_secs`; the engine
+  reassigns the activity if heartbeats stop.
 
 ### Crash safety
 
 Workflow code is **deterministic by replay**. Each `ctx:` call gets a per-execution sequence number
-and the engine persists `ActivityScheduled/Completed/Failed`, `TimerScheduled/Fired`,
-`SignalReceived`, `SideEffectRecorded`, `ChildWorkflowStarted/Completed/Failed`,
-`WorkflowAwaitingSignal`, `WorkflowCancelRequested` events. When a worker is asked to run a workflow
-task it receives the full event history; `ctx:` calls short-circuit to cached values for everything
-that's already in history, so the workflow always reaches the same state and the only thing that
-re-runs is the next unfulfilled step.
+and the engine persists every completed command as an event:
 
-Specific crash modes:
+```
+ActivityScheduled / Completed / Failed
+TimerScheduled / Fired
+SignalReceived                            WorkflowStarted / Completed / Failed / Cancelled
+SideEffectRecorded                        WorkflowAwaitingSignal / CancelRequested
+ChildWorkflowStarted / Completed / Failed
+```
 
-- **Activity worker dies mid-execution** — the activity's `last_heartbeat` ages out (per-activity
-  `heartbeat_timeout_secs`); the engine re-queues per the retry policy.
-- **Workflow worker dies mid-replay** — the workflow's `dispatch_last_heartbeat` ages out
-  (`ASSAY_WF_DISPATCH_TIMEOUT_SECS`, default 30s); any worker on the queue picks it up and replays
-  from the event log.
-- **Engine dies** — all state is in the DB. On restart, in-flight workflow + activity tasks become
-  claimable again as their heartbeats age out.
+When a worker picks up a workflow task it receives the full event history. `ctx:` calls
+short-circuit to cached values for everything already in history, so the workflow always reaches the
+same state and only the next unfulfilled step actually runs.
+
+| Failure mode                       | Recovery                                                                                                                             |
+| ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| Activity worker dies mid-execution | `last_heartbeat` ages out (per-activity `heartbeat_timeout_secs`); engine re-queues per retry policy.                                |
+| Workflow worker dies mid-replay    | `dispatch_last_heartbeat` ages out (`ASSAY_WF_DISPATCH_TIMEOUT_SECS`, default 30s); any worker on the queue picks it up and replays. |
+| Engine dies                        | All state in the DB. On restart, in-flight tasks become claimable again as heartbeats age out.                                       |
 
 `ctx:side_effect` is the escape hatch for any operation that would produce different values across
 replays (current time, random IDs, external HTTP). The result is recorded once on first execution
 and returned from cache thereafter, even after a worker crash.
 
-### Example — sequential activities + signal
+### Schedules (cron)
+
+Declarative recurring workflow starts. Scheduler runs on the leader node under Postgres; fires once
+across the cluster.
+
+```sh
+assay schedule create nightly \
+  --type Report \
+  --cron "0 0 2 * * *" \
+  --timezone Europe/Berlin \
+  --input '{"lookback_hours":24}'
+
+assay schedule patch   nightly --cron "0 0 3 * * *"   # in-place update (v0.11.3)
+assay schedule pause   nightly                        # scheduler skips paused (v0.11.3)
+assay schedule resume  nightly                        # recomputes next_run_at from now
+assay schedule delete  nightly
+```
+
+Cron uses the 6- or 7-field form (with seconds). `"0 * * * * *"` = every minute on the zero second.
+
+**Timezone (v0.11.3).** IANA name via `--timezone`. Default is `UTC`. The scheduler evaluates the
+cron in that zone; `next_run_at` is persisted as a UTC epoch.
+
+### Search attributes
+
+Indexed application-level metadata for filtering workflows. Set at `start`, updated at runtime via
+`ctx:upsert_search_attributes`, filtered on `list`:
+
+```lua
+-- set at start
+workflow.start({
+  workflow_type = "Ingest",
+  workflow_id   = "ing-42",
+  search_attributes = { env = "prod", tenant = "acme" },
+})
+
+-- update inside a running workflow
+ctx:upsert_search_attributes({ progress = 0.5, stage = "deploy" })
+
+-- filter list results (URL-encoded JSON server-side)
+workflow.list({ search_attrs = { env = "prod" } })
+```
+
+Postgres backs search with a `JSONB` column + `->>` operator; SQLite uses `json_extract`. Filters
+AND-join; unchanged keys are preserved across upserts.
+
+### Dashboard
+
+`/workflow/` (or just `/` — redirects). Real-time monitoring + tier-1 operator controls.
+
+| View      | Read                                                | Mutate                                                                            |
+| --------- | --------------------------------------------------- | --------------------------------------------------------------------------------- |
+| Workflows | List + filter (status, type, search_attrs)          | `+ Start workflow` form; per-row Signal / Cancel / Terminate                      |
+| Detail    | Metadata, event timeline, children, live state      | Signal / Cancel / Terminate / Continue-as-new; live `ctx:register_query` snapshot |
+| Schedules | List with timezone + paused state                   | Create (with timezone) / Edit (PATCH) / Pause / Resume / Delete                   |
+| Workers   | Identity, queue, last heartbeat                     | —                                                                                 |
+| Queues    | Pending + running per queue                         | —                                                                                 |
+| Settings  | Engine version, build profile, namespaces, API docs | Namespace create / delete                                                         |
+
+Status-bar footer always shows the engine version (fetched from `/api/v1/version`). Live list
+updates via SSE. Cache-busted asset URLs per startup.
+
+### Concepts
+
+| Concept           | Meaning                                                                                                                               |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| Activity          | A unit of concrete work with at-least-once semantics. Result is persisted before the workflow proceeds. Configurable retry + timeout. |
+| Workflow          | Deterministic orchestration of activities, sleeps, signals, child workflows. Full event history persisted; crashed worker → replay.   |
+| Task queue        | Named queue workers subscribe to. Workflows are routed to a queue; only workers on that queue claim them.                             |
+| Namespace         | Logical tenant. Workflows / schedules / workers are namespace-scoped. Default `main`.                                                 |
+| Signal            | Async message to a running workflow; consumed via `ctx:wait_for_signal`.                                                              |
+| Schedule          | Cron expression that starts a workflow recurringly. Leader-elected under Postgres so only one instance fires.                         |
+| Child workflow    | Workflow started by another workflow. Cancellation propagates parent → child recursively.                                             |
+| Side effect       | Non-deterministic op captured in history on first call so replays see the same value.                                                 |
+| Query handler     | `ctx:register_query` surface exposing live workflow state via `/state[/{name}]`. Snapshot written on every replay.                    |
+| Search attributes | Indexed metadata (JSON object) for filtering workflows; updatable at runtime.                                                         |
+| Archival stub     | Terminal workflow moved to S3 by the optional archiver; row stays in Postgres with `archive_uri` pointing at the bundle.              |
+
+### Example — approval-gated deploy with live state
 
 ```lua
 local workflow = require("assay.workflow")
 workflow.connect("http://assay.example.com", { token = env.get("ASSAY_TOKEN") })
 
 workflow.define("ApproveAndDeploy", function(ctx, input)
+  local state = { stage = "build", progress = 0 }
+  ctx:register_query("pipeline_state", function() return state end)
+
   local artifact = ctx:execute_activity("build", { ref = input.git_sha })
-  -- pause until a human signals "approve" via the API or dashboard
+  state.stage = "awaiting_approval"; state.progress = 0.33
+
   local approval = ctx:wait_for_signal("approve")
-  return ctx:execute_activity("deploy", {
-    image = artifact.image,
-    env = input.target_env,
-    approver = approval.by,
+  state.stage = "deploying"; state.progress = 0.66
+  ctx:upsert_search_attributes({ approver = approval.by })
+
+  local result = ctx:execute_activity("deploy", {
+    image = artifact.image, env = input.target_env, approver = approval.by,
   })
+  state.stage = "done"; state.progress = 1.0
+  return result
 end)
 
-workflow.activity("build", function(ctx, input)
-  local resp = http.post("https://ci/build", { ref = input.ref })
-  if resp.status ~= 200 then error("build failed: " .. resp.status) end
-  return { image = json.parse(resp.body).image }
-end)
-
-workflow.activity("deploy", function(ctx, input)
-  local resp = http.post("https://k8s/apply", input)
-  if resp.status ~= 200 then error("deploy failed: " .. resp.status) end
-  return { url = json.parse(resp.body).url, approver = input.approver }
-end)
+workflow.activity("build",  function(ctx, input) --[[ ... ]] end)
+workflow.activity("deploy", function(ctx, input) --[[ ... ]] end)
 
 workflow.listen({ queue = "deploys" })  -- blocks
 ```
 
-Start a run, signal approval, see the result:
+Drive it from the shell:
 
 ```sh
 assay workflow start --type ApproveAndDeploy --id deploy-1234 \
   --input '{"git_sha":"abc123","target_env":"staging"}'
 
+assay workflow state deploy-1234 pipeline_state   # "awaiting_approval"
+
 assay workflow signal deploy-1234 approve '{"by":"alice"}'
 
-assay workflow describe deploy-1234   # status: COMPLETED, result: {url, approver}
+assay workflow wait deploy-1234 --timeout 300   # exit 0 on COMPLETED, 1 on failure, 2 on timeout
 ```
-
-### Concepts
-
-- **Activity** — a unit of work with at-least-once semantics. Result persisted before progress
-  continues. Configurable retry policy, start-to-close timeout, heartbeat timeout.
-- **Workflow** — deterministic orchestration of activities, sleeps, signals, child workflows. Full
-  event history is persisted; a crashed worker → another worker replays from history.
-- **Task queue** — a named queue workers subscribe to. Workflows are routed to a queue; only workers
-  on that queue claim them.
-- **Namespace** — logical tenant. Workflows / schedules / workers in one namespace are invisible to
-  others. Default `main`. Manage via the dashboard or `POST /api/v1/namespaces`.
-- **Signal** — async message delivered to a running workflow; consumed via `ctx:wait_for_signal`.
-- **Schedule** — cron expression that starts a workflow recurringly. The engine's scheduler uses
-  leader election under Postgres so only one instance fires.
-- **Child workflow** — workflow started by another workflow. Cancellation propagates from parent to
-  all children recursively.
-- **Side effect** — non-deterministic operation captured in history on first call so all replays see
-  the same value.
-
-### Dashboard
-
-`/workflow/` (or just `/` — redirects). Real-time monitoring, dark/light, brand-aligned with
-[assay.rs](https://assay.rs). Views: workflows (list with status filter, drill-in to event
-timeline + children), schedules, workers, queues, namespaces, settings. Live updates via SSE.
-Cache-busted asset URLs (per-process startup stamp) so a deploy is reflected immediately.
 
 ### Notes
 
-- The whole engine + dashboard + Lua client is gated behind the `workflow` cargo feature, which is
-  **enabled by default**. To build assay without the engine:
-  `cargo install assay-lua --no-default-features --features cli,db,server`. When disabled,
-  `assay serve` prints an error instead of starting.
-- The cron crate used by the scheduler requires **6- or 7-field** cron expressions (with seconds).
-  The common 5-field form fails to parse. Use `0 * * * * *` for "every minute on the zero second" or
-  `* * * * * *` for "every second."
-- Parallel activities (Promise.all-style) are not yet supported. Use sequential
-  `ctx:execute_activity` calls or kick off independent child workflows. Tracked as a follow-up.
+- The whole engine + dashboard + Lua client is gated behind the `workflow` cargo feature (default
+  on). To build assay without it:
+  `cargo install assay-lua --no-default-features --features cli,db,server`.
+- The cron crate requires **6- or 7-field** expressions. The common 5-field form fails to parse.
 - The engine is also publishable as a standalone Rust crate (`assay-workflow`) for embedding in
-  non-Lua Rust applications.
+  non-Lua Rust apps. The CLI injects its own `CARGO_PKG_VERSION` via
+  `assay_workflow::api::serve_with_version` so `/api/v1/version` reflects the user-facing binary
+  version, not the internal crate version.
+- S3 archival is behind the `s3-archival` cargo feature (default off) and no-op at runtime unless
+  `ASSAY_ARCHIVE_S3_BUCKET` is set.

--- a/llms.txt
+++ b/llms.txt
@@ -1,7 +1,9 @@
 # Assay
 
-> Assay is a ~9 MB static binary that runs Lua scripts in Kubernetes. It replaces 50-250 MB
-> Python/Node/kubectl containers. One binary handles HTTP, database, crypto, WebSocket, and
+> Assay is a ~9 MB static binary that runs Lua scripts in Kubernetes, ships a native durable
+> workflow engine (`assay serve`), and exposes a full CLI (`assay workflow/schedule/namespace/
+> worker/queue/completion`) over the engine's REST API. It replaces 50-250 MB Python/Node/kubectl
+> containers. One binary handles HTTP, database, crypto, WebSocket, workflow orchestration, and
 > Kubernetes-native and AI agent service integrations. No `require()` for builtins — they are global.
 > Stdlib modules use `require("assay.<name>")` then `M.client(url, opts)` → `c:method()`.
 > Run `assay context <query>` to get LLM-ready method signatures for any module.
@@ -51,7 +53,6 @@
 ## Infrastructure
 - [assay.crossplane](https://assay.rs/modules/crossplane.html): Crossplane providers, XRDs, compositions
 - [assay.velero](https://assay.rs/modules/velero.html): Velero backups, restores, schedules
-- [assay.temporal](https://assay.rs/modules/temporal.html): Temporal — HTTP REST client, gRPC client, worker runtime with workflow coroutines
 - [assay.harbor](https://assay.rs/modules/harbor.html): Harbor registry, projects, vulnerability scanning
 
 ## Data & Storage
@@ -62,7 +63,11 @@
 - [assay.unleash](https://assay.rs/modules/unleash.html): Unleash feature flags, environments, strategies
 - [assay.healthcheck](https://assay.rs/modules/healthcheck.html): HTTP health checks, JSON path, latency
 
-## AI Agent & Workflow
+## Workflow Engine
+- [assay.workflow](https://assay.rs/modules/workflow.html): Durable workflow engine — `assay serve` runs engine with REST+SSE+dashboard; `require("assay.workflow")` registers handlers + exposes full management surface (list/start/signal/cancel/terminate/state/events/children/continue-as-new plus `.schedules`/`.namespaces`/`.workers`/`.queues` sub-tables). Deterministic replay, Postgres/SQLite backend, Ory-compatible JWT/API-key auth, optional S3 archival.
+- [assay CLI](https://assay.rs/modules/workflow.html#cli): `assay workflow/schedule/namespace/worker/queue/completion` subcommands over the engine's REST API. Config file + env vars + flags; output formats table/json/jsonl/yaml with TTY-adaptive default; JSON input indirection (@file, stdin, literal).
+
+## AI Agent
 - [AI Agents](https://assay.rs/modules/ai-agents.html): OpenClaw, GitHub, Gmail, Google Calendar, OAuth2, Email Triage
 
 ## Optional

--- a/site/pages/index.html
+++ b/site/pages/index.html
@@ -12,10 +12,10 @@
 
 
   <main>
-    <!-- v0.11.1 release banner -->
+    <!-- v0.11.3 release banner -->
     <a href="changelog.html" class="release-banner">
-      <span class="release-banner-tag">v0.11.1</span>
-      <span class="release-banner-text">Native durable workflow engine — deterministic-replay runtime, signals, durable timers, child workflows, crash recovery</span>
+      <span class="release-banner-tag">v0.11.3</span>
+      <span class="release-banner-text">Workflow engine enhancements — register_query, parallel activities, search attributes, schedule PATCH + timezone, full CLI (config file, wait, completion), tier-1 operator dashboard</span>
       <span class="release-banner-arrow">&rarr;</span>
     </a>
 
@@ -147,8 +147,8 @@
     <h2>Core Capabilities</h2>
     <section style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1.5rem; margin-bottom: 2rem;">
       <div class="card card-highlight">
-        <h3 style="margin-top: 0;">Workflow Engine <span style="color: var(--accent); font-size: 0.7rem; font-weight: 700; vertical-align: middle; padding: 2px 6px; border: 1px solid var(--accent); border-radius: 4px;">NEW v0.11.1</span></h3>
-        <p class="text-muted">Native durable workflow engine with deterministic-replay runtime. Activities, signals, durable timers, child workflows, side effects. Crash-safe by replay — workers can die mid-flight without losing work or duplicating side effects.</p>
+        <h3 style="margin-top: 0;">Workflow Engine <span style="color: var(--accent); font-size: 0.7rem; font-weight: 700; vertical-align: middle; padding: 2px 6px; border: 1px solid var(--accent); border-radius: 4px;">v0.11.3</span></h3>
+        <p class="text-muted">Native durable workflow engine with deterministic-replay runtime. Activities (sequential + parallel), signals, durable timers, child workflows, side effects, live state via <code>ctx:register_query</code>, search attributes, optional S3 archival. Crash-safe by replay — workers can die mid-flight without losing work or duplicating side effects.</p>
         <pre style="margin-bottom: 0;"><code>workflow.define("Deploy", function(ctx, in)
   local img = ctx:execute_activity("build", in)
   ctx:wait_for_signal("approve")
@@ -299,7 +299,7 @@ cargo install assay-lua
 
     <h3>mise</h3>
     <pre><code># .mise.toml
-"github:developerinlondon/assay" = "v0.11.1"</code></pre>
+"github:developerinlondon/assay" = "v0.11.3"</code></pre>
 
   </main>
 

--- a/src/cli/client.rs
+++ b/src/cli/client.rs
@@ -1,0 +1,224 @@
+//! HTTP client for the workflow engine REST API.
+//!
+//! Every method corresponds to one endpoint. Returns `anyhow::Result`
+//! with the HTTP status and response body folded into the error on
+//! non-2xx responses, so CLI callers can surface a useful message.
+
+use anyhow::{anyhow, Context, Result};
+use serde_json::Value;
+
+use crate::cli::GlobalOpts;
+
+pub struct EngineClient {
+    base: String,
+    http: reqwest::Client,
+    api_key: Option<String>,
+    namespace: String,
+}
+
+impl EngineClient {
+    pub fn new(opts: &GlobalOpts) -> Self {
+        Self {
+            base: format!("{}/api/v1", opts.engine_url.trim_end_matches('/')),
+            http: reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(30))
+                .build()
+                .expect("building reqwest client"),
+            api_key: opts.api_key.clone(),
+            namespace: opts.namespace.clone(),
+        }
+    }
+
+    fn with_auth(&self, mut req: reqwest::RequestBuilder) -> reqwest::RequestBuilder {
+        if let Some(ref key) = self.api_key {
+            req = req.header("Authorization", format!("Bearer {key}"));
+        }
+        req
+    }
+
+    async fn send(&self, req: reqwest::RequestBuilder, ctx: &str) -> Result<Value> {
+        let resp = self
+            .with_auth(req)
+            .send()
+            .await
+            .with_context(|| format!("{ctx}: engine unreachable at {}", self.base))?;
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        if !status.is_success() {
+            return Err(anyhow!(
+                "{ctx}: HTTP {status}: {}",
+                if body.is_empty() { "<empty>" } else { &body }
+            ));
+        }
+        if body.is_empty() {
+            return Ok(Value::Null);
+        }
+        serde_json::from_str(&body).with_context(|| format!("{ctx}: parsing response body"))
+    }
+
+    // ── Workflows ──────────────────────────────────────────
+
+    pub async fn workflow_list(
+        &self,
+        status: Option<&str>,
+        workflow_type: Option<&str>,
+        limit: Option<i64>,
+    ) -> Result<Value> {
+        let mut url = format!("{}/workflows?namespace={}", self.base, self.namespace);
+        if let Some(s) = status {
+            url.push_str(&format!("&status={s}"));
+        }
+        if let Some(t) = workflow_type {
+            url.push_str(&format!("&type={t}"));
+        }
+        if let Some(l) = limit {
+            url.push_str(&format!("&limit={l}"));
+        }
+        self.send(self.http.get(&url), "workflow list").await
+    }
+
+    pub async fn workflow_describe(&self, id: &str) -> Result<Value> {
+        let url = format!("{}/workflows/{id}", self.base);
+        self.send(self.http.get(&url), "workflow describe").await
+    }
+
+    pub async fn workflow_state(&self, id: &str, name: Option<&str>) -> Result<Value> {
+        let url = match name {
+            Some(n) => format!("{}/workflows/{id}/state/{n}", self.base),
+            None => format!("{}/workflows/{id}/state", self.base),
+        };
+        self.send(self.http.get(&url), "workflow state").await
+    }
+
+    pub async fn workflow_signal(
+        &self,
+        id: &str,
+        name: &str,
+        payload: Option<&Value>,
+    ) -> Result<()> {
+        let url = format!("{}/workflows/{id}/signal/{name}", self.base);
+        let body = serde_json::json!({ "payload": payload });
+        let _ = self
+            .send(self.http.post(&url).json(&body), "workflow signal")
+            .await?;
+        Ok(())
+    }
+
+    pub async fn workflow_cancel(&self, id: &str) -> Result<()> {
+        let url = format!("{}/workflows/{id}/cancel", self.base);
+        let _ = self
+            .send(self.http.post(&url), "workflow cancel")
+            .await?;
+        Ok(())
+    }
+
+    pub async fn workflow_terminate(&self, id: &str, reason: Option<&str>) -> Result<()> {
+        let url = format!("{}/workflows/{id}/terminate", self.base);
+        let body = serde_json::json!({ "reason": reason });
+        let _ = self
+            .send(self.http.post(&url).json(&body), "workflow terminate")
+            .await?;
+        Ok(())
+    }
+
+    // ── Schedules ──────────────────────────────────────────
+
+    pub async fn schedule_list(&self) -> Result<Value> {
+        let url = format!("{}/schedules?namespace={}", self.base, self.namespace);
+        self.send(self.http.get(&url), "schedule list").await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn schedule_create(
+        &self,
+        name: &str,
+        workflow_type: &str,
+        cron: &str,
+        timezone: Option<&str>,
+        input: Option<&Value>,
+        queue: Option<&str>,
+    ) -> Result<Value> {
+        let url = format!("{}/schedules", self.base);
+        let mut body = serde_json::json!({
+            "name": name,
+            "namespace": self.namespace,
+            "workflow_type": workflow_type,
+            "cron_expr": cron,
+        });
+        if let Some(tz) = timezone {
+            body["timezone"] = Value::String(tz.to_string());
+        }
+        if let Some(q) = queue {
+            body["task_queue"] = Value::String(q.to_string());
+        }
+        if let Some(i) = input {
+            body["input"] = i.clone();
+        }
+        self.send(self.http.post(&url).json(&body), "schedule create")
+            .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn schedule_patch(
+        &self,
+        name: &str,
+        cron: Option<&str>,
+        timezone: Option<&str>,
+        input: Option<&Value>,
+        queue: Option<&str>,
+        overlap: Option<&str>,
+    ) -> Result<Value> {
+        let url = format!(
+            "{}/schedules/{name}?namespace={}",
+            self.base, self.namespace
+        );
+        let mut body = serde_json::Map::new();
+        if let Some(v) = cron {
+            body.insert("cron_expr".into(), Value::String(v.to_string()));
+        }
+        if let Some(v) = timezone {
+            body.insert("timezone".into(), Value::String(v.to_string()));
+        }
+        if let Some(v) = input {
+            body.insert("input".into(), v.clone());
+        }
+        if let Some(v) = queue {
+            body.insert("task_queue".into(), Value::String(v.to_string()));
+        }
+        if let Some(v) = overlap {
+            body.insert("overlap_policy".into(), Value::String(v.to_string()));
+        }
+        self.send(
+            self.http.patch(&url).json(&Value::Object(body)),
+            "schedule patch",
+        )
+        .await
+    }
+
+    pub async fn schedule_pause(&self, name: &str) -> Result<Value> {
+        let url = format!(
+            "{}/schedules/{name}/pause?namespace={}",
+            self.base, self.namespace
+        );
+        self.send(self.http.post(&url), "schedule pause").await
+    }
+
+    pub async fn schedule_resume(&self, name: &str) -> Result<Value> {
+        let url = format!(
+            "{}/schedules/{name}/resume?namespace={}",
+            self.base, self.namespace
+        );
+        self.send(self.http.post(&url), "schedule resume").await
+    }
+
+    pub async fn schedule_delete(&self, name: &str) -> Result<()> {
+        let url = format!(
+            "{}/schedules/{name}?namespace={}",
+            self.base, self.namespace
+        );
+        let _ = self
+            .send(self.http.delete(&url), "schedule delete")
+            .await?;
+        Ok(())
+    }
+}

--- a/src/cli/client.rs
+++ b/src/cli/client.rs
@@ -58,10 +58,36 @@ impl EngineClient {
 
     // ── Workflows ──────────────────────────────────────────
 
+    pub async fn workflow_start(
+        &self,
+        workflow_type: &str,
+        workflow_id: &str,
+        input: Option<&Value>,
+        task_queue: Option<&str>,
+        search_attributes: Option<&Value>,
+    ) -> Result<Value> {
+        let url = format!("{}/workflows", self.base);
+        let mut body = serde_json::json!({
+            "namespace": self.namespace,
+            "workflow_type": workflow_type,
+            "workflow_id": workflow_id,
+            "task_queue": task_queue.unwrap_or("default"),
+        });
+        if let Some(v) = input {
+            body["input"] = v.clone();
+        }
+        if let Some(v) = search_attributes {
+            body["search_attributes"] = v.clone();
+        }
+        self.send(self.http.post(&url).json(&body), "workflow start")
+            .await
+    }
+
     pub async fn workflow_list(
         &self,
         status: Option<&str>,
         workflow_type: Option<&str>,
+        search_attrs: Option<&Value>,
         limit: Option<i64>,
     ) -> Result<Value> {
         let mut url = format!("{}/workflows?namespace={}", self.base, self.namespace);
@@ -73,6 +99,10 @@ impl EngineClient {
         }
         if let Some(l) = limit {
             url.push_str(&format!("&limit={l}"));
+        }
+        if let Some(attrs) = search_attrs {
+            let encoded = urlencoding_encode(&attrs.to_string());
+            url.push_str(&format!("&search_attrs={encoded}"));
         }
         self.send(self.http.get(&url), "workflow list").await
     }
@@ -88,6 +118,16 @@ impl EngineClient {
             None => format!("{}/workflows/{id}/state", self.base),
         };
         self.send(self.http.get(&url), "workflow state").await
+    }
+
+    pub async fn workflow_events(&self, id: &str) -> Result<Value> {
+        let url = format!("{}/workflows/{id}/events", self.base);
+        self.send(self.http.get(&url), "workflow events").await
+    }
+
+    pub async fn workflow_children(&self, id: &str) -> Result<Value> {
+        let url = format!("{}/workflows/{id}/children", self.base);
+        self.send(self.http.get(&url), "workflow children").await
     }
 
     pub async fn workflow_signal(
@@ -121,11 +161,33 @@ impl EngineClient {
         Ok(())
     }
 
+    pub async fn workflow_continue_as_new(
+        &self,
+        id: &str,
+        input: Option<&Value>,
+    ) -> Result<Value> {
+        let url = format!("{}/workflows/{id}/continue-as-new", self.base);
+        let body = serde_json::json!({ "input": input });
+        self.send(
+            self.http.post(&url).json(&body),
+            "workflow continue-as-new",
+        )
+        .await
+    }
+
     // ── Schedules ──────────────────────────────────────────
 
     pub async fn schedule_list(&self) -> Result<Value> {
         let url = format!("{}/schedules?namespace={}", self.base, self.namespace);
         self.send(self.http.get(&url), "schedule list").await
+    }
+
+    pub async fn schedule_describe(&self, name: &str) -> Result<Value> {
+        let url = format!(
+            "{}/schedules/{name}?namespace={}",
+            self.base, self.namespace
+        );
+        self.send(self.http.get(&url), "schedule describe").await
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -220,5 +282,79 @@ impl EngineClient {
             .send(self.http.delete(&url), "schedule delete")
             .await?;
         Ok(())
+    }
+
+    // ── Namespaces ─────────────────────────────────────────
+
+    pub async fn namespace_create(&self, name: &str) -> Result<()> {
+        let url = format!("{}/namespaces", self.base);
+        let body = serde_json::json!({ "name": name });
+        let _ = self
+            .send(self.http.post(&url).json(&body), "namespace create")
+            .await?;
+        Ok(())
+    }
+
+    pub async fn namespace_list(&self) -> Result<Value> {
+        let url = format!("{}/namespaces", self.base);
+        self.send(self.http.get(&url), "namespace list").await
+    }
+
+    pub async fn namespace_stats(&self, name: &str) -> Result<Value> {
+        let url = format!("{}/namespaces/{name}", self.base);
+        self.send(self.http.get(&url), "namespace describe").await
+    }
+
+    pub async fn namespace_delete(&self, name: &str) -> Result<()> {
+        let url = format!("{}/namespaces/{name}", self.base);
+        let _ = self
+            .send(self.http.delete(&url), "namespace delete")
+            .await?;
+        Ok(())
+    }
+
+    // ── Workers ────────────────────────────────────────────
+
+    pub async fn worker_list(&self) -> Result<Value> {
+        let url = format!("{}/workers?namespace={}", self.base, self.namespace);
+        self.send(self.http.get(&url), "worker list").await
+    }
+
+    // ── Queues ─────────────────────────────────────────────
+
+    pub async fn queue_stats(&self) -> Result<Value> {
+        let url = format!("{}/queues?namespace={}", self.base, self.namespace);
+        self.send(self.http.get(&url), "queue stats").await
+    }
+}
+
+/// Tiny URL encoder — just enough for JSON values in query params
+/// (no external crate dep).
+fn urlencoding_encode(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.bytes() {
+        match c {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(c as char)
+            }
+            _ => out.push_str(&format!("%{c:02X}")),
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::urlencoding_encode;
+
+    #[test]
+    fn encodes_json_like_strings() {
+        let encoded = urlencoding_encode(r#"{"env":"prod"}"#);
+        assert_eq!(encoded, "%7B%22env%22%3A%22prod%22%7D");
+    }
+
+    #[test]
+    fn leaves_safe_chars_alone() {
+        assert_eq!(urlencoding_encode("abc-123_XYZ"), "abc-123_XYZ");
     }
 }

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1,18 +1,24 @@
 //! CLI subcommand implementations — one async fn per subcommand.
 //!
 //! Each fn returns `ExitCode`:
-//!   - SUCCESS (0) on the happy path
-//!   - 1 on HTTP error, not-found, unreachable engine, or bad JSON input
+//!   - 0 (SUCCESS) on the happy path
+//!   - 1 on HTTP error, not-found, unreachable engine
+//!   - 2 on `workflow wait` timeout before the target status is reached
+//!   - 64 on usage errors (bad JSON input) — matches sysexits EX_USAGE
 //!
 //! Error messages go to stderr; results go to stdout. Keeps scripts
-//! composable — `assay workflow list > workflows.txt 2> errors.log`.
+//! composable: `assay workflow list > wfs.json 2> errors.log`.
 
+use std::io::IsTerminal;
 use std::process::ExitCode;
+use std::time::{Duration, Instant};
 
 use serde_json::Value;
 
 use crate::cli::client::EngineClient;
-use crate::cli::table::{print_table, value_as_str};
+use crate::cli::input::resolve_json;
+use crate::cli::output::{print_list, print_record};
+use crate::cli::table::value_as_str;
 use crate::cli::GlobalOpts;
 
 fn eprint_err(e: anyhow::Error) -> ExitCode {
@@ -20,44 +26,114 @@ fn eprint_err(e: anyhow::Error) -> ExitCode {
     ExitCode::from(1)
 }
 
-fn parse_json_input(raw: &str, what: &str) -> Result<Value, String> {
-    serde_json::from_str(raw).map_err(|e| format!("{what}: invalid JSON: {e}"))
+fn usage_error(msg: impl std::fmt::Display) -> ExitCode {
+    eprintln!("error: {msg}");
+    ExitCode::from(64)
 }
 
 // ── Workflows ──────────────────────────────────────────────
+
+pub async fn workflow_start(
+    opts: &GlobalOpts,
+    workflow_type: &str,
+    id: Option<String>,
+    input: Option<String>,
+    queue: Option<String>,
+    search_attrs: Option<String>,
+) -> ExitCode {
+    let client = EngineClient::new(opts);
+    let resolved_input = match input.as_deref() {
+        None => None,
+        Some(raw) => match resolve_json(raw, "--input") {
+            Ok(v) => Some(v),
+            Err(e) => return usage_error(e),
+        },
+    };
+    let resolved_attrs = match search_attrs.as_deref() {
+        None => None,
+        Some(raw) => match resolve_json(raw, "--search-attrs") {
+            Ok(v) => Some(v),
+            Err(e) => return usage_error(e),
+        },
+    };
+    let generated_id;
+    let workflow_id = match id.as_deref() {
+        Some(v) => v,
+        None => {
+            generated_id = format!(
+                "wf-{}-{}",
+                workflow_type.to_ascii_lowercase(),
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_millis())
+                    .unwrap_or(0)
+            );
+            &generated_id
+        }
+    };
+    match client
+        .workflow_start(
+            workflow_type,
+            workflow_id,
+            resolved_input.as_ref(),
+            queue.as_deref(),
+            resolved_attrs.as_ref(),
+        )
+        .await
+    {
+        Ok(v) => {
+            print_record(opts.output, &v);
+            ExitCode::SUCCESS
+        }
+        Err(e) => eprint_err(e),
+    }
+}
 
 pub async fn workflow_list(
     opts: &GlobalOpts,
     status: Option<String>,
     workflow_type: Option<String>,
+    search_attrs: Option<String>,
     limit: i64,
 ) -> ExitCode {
     let client = EngineClient::new(opts);
+    let resolved_attrs = match search_attrs.as_deref() {
+        None => None,
+        Some(raw) => match resolve_json(raw, "--search-attrs") {
+            Ok(v) => Some(v),
+            Err(e) => return usage_error(e),
+        },
+    };
     let result = client
-        .workflow_list(status.as_deref(), workflow_type.as_deref(), Some(limit))
+        .workflow_list(
+            status.as_deref(),
+            workflow_type.as_deref(),
+            resolved_attrs.as_ref(),
+            Some(limit),
+        )
         .await;
-    let Ok(Value::Array(workflows)) = result.as_ref().map(|v| v.clone()) else {
-        return match result {
-            Ok(_) => {
-                eprintln!("error: unexpected response shape (expected array)");
-                ExitCode::from(1)
-            }
-            Err(e) => eprint_err(e),
-        };
+    let workflows = match result {
+        Ok(Value::Array(v)) => v,
+        Ok(_) => {
+            eprintln!("error: unexpected response shape (expected array)");
+            return ExitCode::from(1);
+        }
+        Err(e) => return eprint_err(e),
     };
 
-    let rows: Vec<Vec<String>> = workflows
-        .iter()
-        .map(|w| {
+    print_list(
+        opts.output,
+        &workflows,
+        &["ID", "TYPE", "STATUS", "QUEUE"],
+        |w| {
             vec![
                 value_as_str(w, "id"),
                 value_as_str(w, "workflow_type"),
                 value_as_str(w, "status"),
                 value_as_str(w, "task_queue"),
             ]
-        })
-        .collect();
-    print_table(&["ID", "TYPE", "STATUS", "QUEUE"], &rows);
+        },
+    );
     ExitCode::SUCCESS
 }
 
@@ -65,7 +141,7 @@ pub async fn workflow_describe(opts: &GlobalOpts, id: &str) -> ExitCode {
     let client = EngineClient::new(opts);
     match client.workflow_describe(id).await {
         Ok(v) => {
-            println!("{}", serde_json::to_string_pretty(&v).unwrap_or_default());
+            print_record(opts.output, &v);
             ExitCode::SUCCESS
         }
         Err(e) => eprint_err(e),
@@ -76,11 +152,117 @@ pub async fn workflow_state(opts: &GlobalOpts, id: &str, name: Option<&str>) -> 
     let client = EngineClient::new(opts);
     match client.workflow_state(id, name).await {
         Ok(v) => {
-            println!("{}", serde_json::to_string_pretty(&v).unwrap_or_default());
+            print_record(opts.output, &v);
             ExitCode::SUCCESS
         }
         Err(e) => eprint_err(e),
     }
+}
+
+pub async fn workflow_events(opts: &GlobalOpts, id: &str, follow: bool) -> ExitCode {
+    let client = EngineClient::new(opts);
+    if follow {
+        return workflow_events_follow(opts, &client, id).await;
+    }
+    let result = client.workflow_events(id).await;
+    let events = match result {
+        Ok(Value::Array(v)) => v,
+        Ok(_) => {
+            eprintln!("error: unexpected response shape (expected array)");
+            return ExitCode::from(1);
+        }
+        Err(e) => return eprint_err(e),
+    };
+    print_list(
+        opts.output,
+        &events,
+        &["SEQ", "TYPE", "TIMESTAMP"],
+        |e| {
+            vec![
+                value_as_str(e, "seq"),
+                value_as_str(e, "event_type"),
+                value_as_str(e, "timestamp"),
+            ]
+        },
+    );
+    ExitCode::SUCCESS
+}
+
+/// Poll the event log every 500ms, printing new events as they arrive.
+/// Simpler + more predictable than a raw SSE subscription, and it
+/// works against any engine that implements `GET /workflows/{id}/events`
+/// — no extra server code, no reconnection dance. Stops when a terminal
+/// workflow event is seen.
+async fn workflow_events_follow(
+    opts: &GlobalOpts,
+    client: &EngineClient,
+    id: &str,
+) -> ExitCode {
+    let mut last_seq: i64 = -1;
+    loop {
+        let events = match client.workflow_events(id).await {
+            Ok(Value::Array(v)) => v,
+            Ok(_) => {
+                eprintln!("error: unexpected response shape (expected array)");
+                return ExitCode::from(1);
+            }
+            Err(e) => return eprint_err(e),
+        };
+        let mut terminal = false;
+        for ev in &events {
+            let seq = ev.get("seq").and_then(|v| v.as_i64()).unwrap_or(-1);
+            if seq <= last_seq {
+                continue;
+            }
+            last_seq = seq;
+            match opts.output {
+                crate::cli::Output::Table => println!(
+                    "{:>4}  {:<30}  {}",
+                    value_as_str(ev, "seq"),
+                    value_as_str(ev, "event_type"),
+                    value_as_str(ev, "timestamp"),
+                ),
+                _ => println!("{}", serde_json::to_string(ev).unwrap_or_default()),
+            }
+            let event_type = ev.get("event_type").and_then(|v| v.as_str()).unwrap_or("");
+            if matches!(
+                event_type,
+                "WorkflowCompleted" | "WorkflowFailed" | "WorkflowCancelled"
+            ) {
+                terminal = true;
+            }
+        }
+        if terminal {
+            return ExitCode::SUCCESS;
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+}
+
+pub async fn workflow_children(opts: &GlobalOpts, id: &str) -> ExitCode {
+    let client = EngineClient::new(opts);
+    let result = client.workflow_children(id).await;
+    let children = match result {
+        Ok(Value::Array(v)) => v,
+        Ok(_) => {
+            eprintln!("error: unexpected response shape (expected array)");
+            return ExitCode::from(1);
+        }
+        Err(e) => return eprint_err(e),
+    };
+    print_list(
+        opts.output,
+        &children,
+        &["ID", "TYPE", "STATUS"],
+        |c| {
+            vec![
+                value_as_str(c, "id"),
+                value_as_str(c, "workflow_type"),
+                value_as_str(c, "status"),
+            ]
+        },
+    );
+    ExitCode::SUCCESS
 }
 
 pub async fn workflow_signal(
@@ -92,17 +274,14 @@ pub async fn workflow_signal(
     let client = EngineClient::new(opts);
     let parsed = match payload.as_deref() {
         None => None,
-        Some(raw) => match parse_json_input(raw, "signal payload") {
+        Some(raw) => match resolve_json(raw, "signal payload") {
             Ok(v) => Some(v),
-            Err(e) => {
-                eprintln!("error: {e}");
-                return ExitCode::from(1);
-            }
+            Err(e) => return usage_error(e),
         },
     };
     match client.workflow_signal(id, name, parsed.as_ref()).await {
         Ok(()) => {
-            println!("signal '{name}' sent to {id}");
+            print_action_result(opts, &format!("signal '{name}' sent to {id}"));
             ExitCode::SUCCESS
         }
         Err(e) => eprint_err(e),
@@ -113,7 +292,7 @@ pub async fn workflow_cancel(opts: &GlobalOpts, id: &str) -> ExitCode {
     let client = EngineClient::new(opts);
     match client.workflow_cancel(id).await {
         Ok(()) => {
-            println!("cancel requested for {id}");
+            print_action_result(opts, &format!("cancel requested for {id}"));
             ExitCode::SUCCESS
         }
         Err(e) => eprint_err(e),
@@ -128,10 +307,90 @@ pub async fn workflow_terminate(
     let client = EngineClient::new(opts);
     match client.workflow_terminate(id, reason.as_deref()).await {
         Ok(()) => {
-            println!("{id} terminated");
+            print_action_result(opts, &format!("{id} terminated"));
             ExitCode::SUCCESS
         }
         Err(e) => eprint_err(e),
+    }
+}
+
+pub async fn workflow_continue_as_new(
+    opts: &GlobalOpts,
+    id: &str,
+    input: Option<String>,
+) -> ExitCode {
+    let client = EngineClient::new(opts);
+    let resolved_input = match input.as_deref() {
+        None => None,
+        Some(raw) => match resolve_json(raw, "--input") {
+            Ok(v) => Some(v),
+            Err(e) => return usage_error(e),
+        },
+    };
+    match client
+        .workflow_continue_as_new(id, resolved_input.as_ref())
+        .await
+    {
+        Ok(v) => {
+            print_record(opts.output, &v);
+            ExitCode::SUCCESS
+        }
+        Err(e) => eprint_err(e),
+    }
+}
+
+pub async fn workflow_wait(
+    opts: &GlobalOpts,
+    id: &str,
+    timeout_secs: u64,
+    target: Option<String>,
+) -> ExitCode {
+    let client = EngineClient::new(opts);
+    let deadline = Instant::now() + Duration::from_secs(timeout_secs);
+    let target = target.as_deref();
+    loop {
+        let v = match client.workflow_describe(id).await {
+            Ok(v) => v,
+            Err(e) => return eprint_err(e),
+        };
+        let status = v
+            .get("status")
+            .and_then(|s| s.as_str())
+            .unwrap_or("")
+            .to_string();
+
+        let matches_target = match target {
+            Some(t) => status.eq_ignore_ascii_case(t),
+            None => matches!(
+                status.as_str(),
+                "COMPLETED" | "FAILED" | "CANCELLED" | "TIMED_OUT"
+            ),
+        };
+
+        if matches_target {
+            // Human formats get a final describe; JSON-family prints the record.
+            match opts.output {
+                crate::cli::Output::Table => {
+                    if std::io::stdout().is_terminal() {
+                        println!("{id} {status}");
+                    }
+                }
+                _ => print_record(opts.output, &v),
+            }
+            return match status.as_str() {
+                "COMPLETED" => ExitCode::SUCCESS,
+                _ if target.is_some() => ExitCode::SUCCESS,
+                _ => ExitCode::from(1),
+            };
+        }
+
+        if Instant::now() >= deadline {
+            eprintln!(
+                "error: timeout after {timeout_secs}s waiting for {id} (last status: {status})"
+            );
+            return ExitCode::from(2);
+        }
+        tokio::time::sleep(Duration::from_millis(500)).await;
     }
 }
 
@@ -140,19 +399,20 @@ pub async fn workflow_terminate(
 pub async fn schedule_list(opts: &GlobalOpts) -> ExitCode {
     let client = EngineClient::new(opts);
     let result = client.schedule_list().await;
-    let Ok(Value::Array(schedules)) = result.as_ref().map(|v| v.clone()) else {
-        return match result {
-            Ok(_) => {
-                eprintln!("error: unexpected response shape (expected array)");
-                ExitCode::from(1)
-            }
-            Err(e) => eprint_err(e),
-        };
+    let schedules = match result {
+        Ok(Value::Array(v)) => v,
+        Ok(_) => {
+            eprintln!("error: unexpected response shape (expected array)");
+            return ExitCode::from(1);
+        }
+        Err(e) => return eprint_err(e),
     };
 
-    let rows: Vec<Vec<String>> = schedules
-        .iter()
-        .map(|s| {
+    print_list(
+        opts.output,
+        &schedules,
+        &["NAME", "TYPE", "CRON", "TZ", "PAUSED"],
+        |s| {
             vec![
                 value_as_str(s, "name"),
                 value_as_str(s, "workflow_type"),
@@ -160,10 +420,20 @@ pub async fn schedule_list(opts: &GlobalOpts) -> ExitCode {
                 value_as_str(s, "timezone"),
                 value_as_str(s, "paused"),
             ]
-        })
-        .collect();
-    print_table(&["NAME", "TYPE", "CRON", "TZ", "PAUSED"], &rows);
+        },
+    );
     ExitCode::SUCCESS
+}
+
+pub async fn schedule_describe(opts: &GlobalOpts, name: &str) -> ExitCode {
+    let client = EngineClient::new(opts);
+    match client.schedule_describe(name).await {
+        Ok(v) => {
+            print_record(opts.output, &v);
+            ExitCode::SUCCESS
+        }
+        Err(e) => eprint_err(e),
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -179,12 +449,9 @@ pub async fn schedule_create(
     let client = EngineClient::new(opts);
     let parsed_input = match input.as_deref() {
         None => None,
-        Some(raw) => match parse_json_input(raw, "--input") {
+        Some(raw) => match resolve_json(raw, "--input") {
             Ok(v) => Some(v),
-            Err(e) => {
-                eprintln!("error: {e}");
-                return ExitCode::from(1);
-            }
+            Err(e) => return usage_error(e),
         },
     };
     match client
@@ -199,7 +466,7 @@ pub async fn schedule_create(
         .await
     {
         Ok(v) => {
-            println!("{}", serde_json::to_string_pretty(&v).unwrap_or_default());
+            print_record(opts.output, &v);
             ExitCode::SUCCESS
         }
         Err(e) => eprint_err(e),
@@ -222,21 +489,17 @@ pub async fn schedule_patch(
         && queue.is_none()
         && overlap.is_none()
     {
-        eprintln!(
-            "error: schedule patch: at least one of \
-             --cron/--timezone/--input/--queue/--overlap is required"
+        return usage_error(
+            "schedule patch: at least one of \
+             --cron/--timezone/--input/--queue/--overlap is required",
         );
-        return ExitCode::from(1);
     }
     let client = EngineClient::new(opts);
     let parsed_input = match input.as_deref() {
         None => None,
-        Some(raw) => match parse_json_input(raw, "--input") {
+        Some(raw) => match resolve_json(raw, "--input") {
             Ok(v) => Some(v),
-            Err(e) => {
-                eprintln!("error: {e}");
-                return ExitCode::from(1);
-            }
+            Err(e) => return usage_error(e),
         },
     };
     match client
@@ -251,7 +514,7 @@ pub async fn schedule_patch(
         .await
     {
         Ok(v) => {
-            println!("{}", serde_json::to_string_pretty(&v).unwrap_or_default());
+            print_record(opts.output, &v);
             ExitCode::SUCCESS
         }
         Err(e) => eprint_err(e),
@@ -262,7 +525,7 @@ pub async fn schedule_pause(opts: &GlobalOpts, name: &str) -> ExitCode {
     let client = EngineClient::new(opts);
     match client.schedule_pause(name).await {
         Ok(_) => {
-            println!("{name} paused");
+            print_action_result(opts, &format!("{name} paused"));
             ExitCode::SUCCESS
         }
         Err(e) => eprint_err(e),
@@ -273,7 +536,7 @@ pub async fn schedule_resume(opts: &GlobalOpts, name: &str) -> ExitCode {
     let client = EngineClient::new(opts);
     match client.schedule_resume(name).await {
         Ok(_) => {
-            println!("{name} resumed");
+            print_action_result(opts, &format!("{name} resumed"));
             ExitCode::SUCCESS
         }
         Err(e) => eprint_err(e),
@@ -284,9 +547,135 @@ pub async fn schedule_delete(opts: &GlobalOpts, name: &str) -> ExitCode {
     let client = EngineClient::new(opts);
     match client.schedule_delete(name).await {
         Ok(()) => {
-            println!("{name} deleted");
+            print_action_result(opts, &format!("{name} deleted"));
             ExitCode::SUCCESS
         }
         Err(e) => eprint_err(e),
+    }
+}
+
+// ── Namespaces ─────────────────────────────────────────────
+
+pub async fn namespace_create(opts: &GlobalOpts, name: &str) -> ExitCode {
+    let client = EngineClient::new(opts);
+    match client.namespace_create(name).await {
+        Ok(()) => {
+            print_action_result(opts, &format!("namespace '{name}' created"));
+            ExitCode::SUCCESS
+        }
+        Err(e) => eprint_err(e),
+    }
+}
+
+pub async fn namespace_list(opts: &GlobalOpts) -> ExitCode {
+    let client = EngineClient::new(opts);
+    let result = client.namespace_list().await;
+    let items = match result {
+        Ok(Value::Array(v)) => v,
+        Ok(_) => {
+            eprintln!("error: unexpected response shape (expected array)");
+            return ExitCode::from(1);
+        }
+        Err(e) => return eprint_err(e),
+    };
+    print_list(opts.output, &items, &["NAME", "CREATED"], |n| {
+        vec![value_as_str(n, "name"), value_as_str(n, "created_at")]
+    });
+    ExitCode::SUCCESS
+}
+
+pub async fn namespace_describe(opts: &GlobalOpts, name: &str) -> ExitCode {
+    let client = EngineClient::new(opts);
+    match client.namespace_stats(name).await {
+        Ok(v) => {
+            print_record(opts.output, &v);
+            ExitCode::SUCCESS
+        }
+        Err(e) => eprint_err(e),
+    }
+}
+
+pub async fn namespace_delete(opts: &GlobalOpts, name: &str) -> ExitCode {
+    let client = EngineClient::new(opts);
+    match client.namespace_delete(name).await {
+        Ok(()) => {
+            print_action_result(opts, &format!("namespace '{name}' deleted"));
+            ExitCode::SUCCESS
+        }
+        Err(e) => eprint_err(e),
+    }
+}
+
+// ── Workers ────────────────────────────────────────────────
+
+pub async fn worker_list(opts: &GlobalOpts) -> ExitCode {
+    let client = EngineClient::new(opts);
+    let result = client.worker_list().await;
+    let workers = match result {
+        Ok(Value::Array(v)) => v,
+        Ok(_) => {
+            eprintln!("error: unexpected response shape (expected array)");
+            return ExitCode::from(1);
+        }
+        Err(e) => return eprint_err(e),
+    };
+    print_list(
+        opts.output,
+        &workers,
+        &["ID", "IDENTITY", "QUEUE", "ACTIVE", "LAST HEARTBEAT"],
+        |w| {
+            vec![
+                value_as_str(w, "id"),
+                value_as_str(w, "identity"),
+                value_as_str(w, "task_queue"),
+                value_as_str(w, "active_tasks"),
+                value_as_str(w, "last_heartbeat"),
+            ]
+        },
+    );
+    ExitCode::SUCCESS
+}
+
+// ── Queues ─────────────────────────────────────────────────
+
+pub async fn queue_stats(opts: &GlobalOpts) -> ExitCode {
+    let client = EngineClient::new(opts);
+    let result = client.queue_stats().await;
+    let queues = match result {
+        Ok(Value::Array(v)) => v,
+        Ok(_) => {
+            eprintln!("error: unexpected response shape (expected array)");
+            return ExitCode::from(1);
+        }
+        Err(e) => return eprint_err(e),
+    };
+    print_list(
+        opts.output,
+        &queues,
+        &["QUEUE", "PENDING", "RUNNING", "WORKERS"],
+        |q| {
+            vec![
+                value_as_str(q, "queue"),
+                value_as_str(q, "pending_activities"),
+                value_as_str(q, "running_activities"),
+                value_as_str(q, "workers"),
+            ]
+        },
+    );
+    ExitCode::SUCCESS
+}
+
+// ── Helpers ────────────────────────────────────────────────
+
+/// For side-effect subcommands (signal, cancel, pause, …): print a
+/// human confirmation on table output; print `{"ok":true,"message":…}`
+/// on JSON-family outputs so scripts can parse the result.
+fn print_action_result(opts: &GlobalOpts, message: &str) {
+    match opts.output {
+        crate::cli::Output::Table => println!("{message}"),
+        _ => {
+            let v = serde_json::json!({ "ok": true, "message": message });
+            print_record(opts.output, &v);
+        }
     }
 }

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1,0 +1,292 @@
+//! CLI subcommand implementations — one async fn per subcommand.
+//!
+//! Each fn returns `ExitCode`:
+//!   - SUCCESS (0) on the happy path
+//!   - 1 on HTTP error, not-found, unreachable engine, or bad JSON input
+//!
+//! Error messages go to stderr; results go to stdout. Keeps scripts
+//! composable — `assay workflow list > workflows.txt 2> errors.log`.
+
+use std::process::ExitCode;
+
+use serde_json::Value;
+
+use crate::cli::client::EngineClient;
+use crate::cli::table::{print_table, value_as_str};
+use crate::cli::GlobalOpts;
+
+fn eprint_err(e: anyhow::Error) -> ExitCode {
+    eprintln!("error: {e:#}");
+    ExitCode::from(1)
+}
+
+fn parse_json_input(raw: &str, what: &str) -> Result<Value, String> {
+    serde_json::from_str(raw).map_err(|e| format!("{what}: invalid JSON: {e}"))
+}
+
+// ── Workflows ──────────────────────────────────────────────
+
+pub async fn workflow_list(
+    opts: &GlobalOpts,
+    status: Option<String>,
+    workflow_type: Option<String>,
+    limit: i64,
+) -> ExitCode {
+    let client = EngineClient::new(opts);
+    let result = client
+        .workflow_list(status.as_deref(), workflow_type.as_deref(), Some(limit))
+        .await;
+    let Ok(Value::Array(workflows)) = result.as_ref().map(|v| v.clone()) else {
+        return match result {
+            Ok(_) => {
+                eprintln!("error: unexpected response shape (expected array)");
+                ExitCode::from(1)
+            }
+            Err(e) => eprint_err(e),
+        };
+    };
+
+    let rows: Vec<Vec<String>> = workflows
+        .iter()
+        .map(|w| {
+            vec![
+                value_as_str(w, "id"),
+                value_as_str(w, "workflow_type"),
+                value_as_str(w, "status"),
+                value_as_str(w, "task_queue"),
+            ]
+        })
+        .collect();
+    print_table(&["ID", "TYPE", "STATUS", "QUEUE"], &rows);
+    ExitCode::SUCCESS
+}
+
+pub async fn workflow_describe(opts: &GlobalOpts, id: &str) -> ExitCode {
+    let client = EngineClient::new(opts);
+    match client.workflow_describe(id).await {
+        Ok(v) => {
+            println!("{}", serde_json::to_string_pretty(&v).unwrap_or_default());
+            ExitCode::SUCCESS
+        }
+        Err(e) => eprint_err(e),
+    }
+}
+
+pub async fn workflow_state(opts: &GlobalOpts, id: &str, name: Option<&str>) -> ExitCode {
+    let client = EngineClient::new(opts);
+    match client.workflow_state(id, name).await {
+        Ok(v) => {
+            println!("{}", serde_json::to_string_pretty(&v).unwrap_or_default());
+            ExitCode::SUCCESS
+        }
+        Err(e) => eprint_err(e),
+    }
+}
+
+pub async fn workflow_signal(
+    opts: &GlobalOpts,
+    id: &str,
+    name: &str,
+    payload: Option<String>,
+) -> ExitCode {
+    let client = EngineClient::new(opts);
+    let parsed = match payload.as_deref() {
+        None => None,
+        Some(raw) => match parse_json_input(raw, "signal payload") {
+            Ok(v) => Some(v),
+            Err(e) => {
+                eprintln!("error: {e}");
+                return ExitCode::from(1);
+            }
+        },
+    };
+    match client.workflow_signal(id, name, parsed.as_ref()).await {
+        Ok(()) => {
+            println!("signal '{name}' sent to {id}");
+            ExitCode::SUCCESS
+        }
+        Err(e) => eprint_err(e),
+    }
+}
+
+pub async fn workflow_cancel(opts: &GlobalOpts, id: &str) -> ExitCode {
+    let client = EngineClient::new(opts);
+    match client.workflow_cancel(id).await {
+        Ok(()) => {
+            println!("cancel requested for {id}");
+            ExitCode::SUCCESS
+        }
+        Err(e) => eprint_err(e),
+    }
+}
+
+pub async fn workflow_terminate(
+    opts: &GlobalOpts,
+    id: &str,
+    reason: Option<String>,
+) -> ExitCode {
+    let client = EngineClient::new(opts);
+    match client.workflow_terminate(id, reason.as_deref()).await {
+        Ok(()) => {
+            println!("{id} terminated");
+            ExitCode::SUCCESS
+        }
+        Err(e) => eprint_err(e),
+    }
+}
+
+// ── Schedules ──────────────────────────────────────────────
+
+pub async fn schedule_list(opts: &GlobalOpts) -> ExitCode {
+    let client = EngineClient::new(opts);
+    let result = client.schedule_list().await;
+    let Ok(Value::Array(schedules)) = result.as_ref().map(|v| v.clone()) else {
+        return match result {
+            Ok(_) => {
+                eprintln!("error: unexpected response shape (expected array)");
+                ExitCode::from(1)
+            }
+            Err(e) => eprint_err(e),
+        };
+    };
+
+    let rows: Vec<Vec<String>> = schedules
+        .iter()
+        .map(|s| {
+            vec![
+                value_as_str(s, "name"),
+                value_as_str(s, "workflow_type"),
+                value_as_str(s, "cron_expr"),
+                value_as_str(s, "timezone"),
+                value_as_str(s, "paused"),
+            ]
+        })
+        .collect();
+    print_table(&["NAME", "TYPE", "CRON", "TZ", "PAUSED"], &rows);
+    ExitCode::SUCCESS
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn schedule_create(
+    opts: &GlobalOpts,
+    name: &str,
+    workflow_type: &str,
+    cron: &str,
+    timezone: Option<String>,
+    input: Option<String>,
+    queue: Option<String>,
+) -> ExitCode {
+    let client = EngineClient::new(opts);
+    let parsed_input = match input.as_deref() {
+        None => None,
+        Some(raw) => match parse_json_input(raw, "--input") {
+            Ok(v) => Some(v),
+            Err(e) => {
+                eprintln!("error: {e}");
+                return ExitCode::from(1);
+            }
+        },
+    };
+    match client
+        .schedule_create(
+            name,
+            workflow_type,
+            cron,
+            timezone.as_deref(),
+            parsed_input.as_ref(),
+            queue.as_deref(),
+        )
+        .await
+    {
+        Ok(v) => {
+            println!("{}", serde_json::to_string_pretty(&v).unwrap_or_default());
+            ExitCode::SUCCESS
+        }
+        Err(e) => eprint_err(e),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn schedule_patch(
+    opts: &GlobalOpts,
+    name: &str,
+    cron: Option<String>,
+    timezone: Option<String>,
+    input: Option<String>,
+    queue: Option<String>,
+    overlap: Option<String>,
+) -> ExitCode {
+    if cron.is_none()
+        && timezone.is_none()
+        && input.is_none()
+        && queue.is_none()
+        && overlap.is_none()
+    {
+        eprintln!(
+            "error: schedule patch: at least one of \
+             --cron/--timezone/--input/--queue/--overlap is required"
+        );
+        return ExitCode::from(1);
+    }
+    let client = EngineClient::new(opts);
+    let parsed_input = match input.as_deref() {
+        None => None,
+        Some(raw) => match parse_json_input(raw, "--input") {
+            Ok(v) => Some(v),
+            Err(e) => {
+                eprintln!("error: {e}");
+                return ExitCode::from(1);
+            }
+        },
+    };
+    match client
+        .schedule_patch(
+            name,
+            cron.as_deref(),
+            timezone.as_deref(),
+            parsed_input.as_ref(),
+            queue.as_deref(),
+            overlap.as_deref(),
+        )
+        .await
+    {
+        Ok(v) => {
+            println!("{}", serde_json::to_string_pretty(&v).unwrap_or_default());
+            ExitCode::SUCCESS
+        }
+        Err(e) => eprint_err(e),
+    }
+}
+
+pub async fn schedule_pause(opts: &GlobalOpts, name: &str) -> ExitCode {
+    let client = EngineClient::new(opts);
+    match client.schedule_pause(name).await {
+        Ok(_) => {
+            println!("{name} paused");
+            ExitCode::SUCCESS
+        }
+        Err(e) => eprint_err(e),
+    }
+}
+
+pub async fn schedule_resume(opts: &GlobalOpts, name: &str) -> ExitCode {
+    let client = EngineClient::new(opts);
+    match client.schedule_resume(name).await {
+        Ok(_) => {
+            println!("{name} resumed");
+            ExitCode::SUCCESS
+        }
+        Err(e) => eprint_err(e),
+    }
+}
+
+pub async fn schedule_delete(opts: &GlobalOpts, name: &str) -> ExitCode {
+    let client = EngineClient::new(opts);
+    match client.schedule_delete(name).await {
+        Ok(()) => {
+            println!("{name} deleted");
+            ExitCode::SUCCESS
+        }
+        Err(e) => eprint_err(e),
+    }
+}

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -1,0 +1,156 @@
+//! YAML config file discovery, parsing, and precedence merge.
+//!
+//! Operators deploy assay in a pod with a config file mounted at
+//! `/etc/assay/config.yaml`. Inside the pod `assay workflow list` "just
+//! works" without anyone needing to set env vars or flags. Avoids baking
+//! credentials into process environments, which leak into `ps` output and
+//! child processes.
+//!
+//! Discovery order (first match wins):
+//!   1. `--config PATH` (explicit)
+//!   2. `ASSAY_CONFIG_FILE` (explicit override)
+//!   3. `$XDG_CONFIG_HOME/assay/config.yaml`
+//!   4. `$HOME/.config/assay/config.yaml`
+//!   5. `/etc/assay/config.yaml`
+//!
+//! A missing file is not an error — callers fall through to flag / env
+//! / default precedence on every field.
+
+use std::path::PathBuf;
+
+use serde::Deserialize;
+
+/// Parsed config file. Every field optional so partial configs work.
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields, default)]
+pub struct ConfigFile {
+    pub engine_url: Option<String>,
+    /// Literal API key / bearer token. Prefer `api_key_file` when the
+    /// config file itself might be committed to a repo or ConfigMap.
+    pub api_key: Option<String>,
+    /// Path to a file containing the API key. File contents are read
+    /// at startup, trimmed of trailing whitespace, and used as the
+    /// bearer token. Takes precedence over `api_key` when both are set.
+    pub api_key_file: Option<PathBuf>,
+    pub namespace: Option<String>,
+    /// Default output format — `table`, `json`, `jsonl`, or `yaml`.
+    pub output: Option<String>,
+}
+
+/// Discover and load the config file (if any).
+///
+/// If `explicit` is provided (from `--config` or `ASSAY_CONFIG_FILE`),
+/// it's the only path tried and a missing file is an error. Otherwise
+/// we probe the well-known locations in order and return the first one
+/// that exists. Returns `None` if no config file is found.
+pub fn load(explicit: Option<&str>) -> Result<Option<ConfigFile>, String> {
+    if let Some(path) = explicit {
+        let text = std::fs::read_to_string(path)
+            .map_err(|e| format!("reading config file {path}: {e}"))?;
+        let cfg: ConfigFile = serde_yml::from_str(&text)
+            .map_err(|e| format!("parsing {path}: {e}"))?;
+        return Ok(Some(cfg));
+    }
+    for path in discovery_paths() {
+        if path.exists() {
+            let text = std::fs::read_to_string(&path)
+                .map_err(|e| format!("reading {}: {e}", path.display()))?;
+            let cfg: ConfigFile = serde_yml::from_str(&text)
+                .map_err(|e| format!("parsing {}: {e}", path.display()))?;
+            return Ok(Some(cfg));
+        }
+    }
+    Ok(None)
+}
+
+fn discovery_paths() -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    if let Ok(xdg) = std::env::var("XDG_CONFIG_HOME") {
+        paths.push(PathBuf::from(xdg).join("assay/config.yaml"));
+    }
+    if let Ok(home) = std::env::var("HOME") {
+        paths.push(PathBuf::from(home).join(".config/assay/config.yaml"));
+    }
+    paths.push(PathBuf::from("/etc/assay/config.yaml"));
+    paths
+}
+
+/// Resolve the api-key value from config-file fields. `api_key_file`
+/// wins if present; its contents are read and trimmed. Returns `None`
+/// if neither is set.
+pub fn resolve_api_key(cfg: &ConfigFile) -> Result<Option<String>, String> {
+    if let Some(ref path) = cfg.api_key_file {
+        let content = std::fs::read_to_string(path)
+            .map_err(|e| format!("reading api_key_file {}: {e}", path.display()))?;
+        return Ok(Some(content.trim().to_string()));
+    }
+    Ok(cfg.api_key.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn missing_config_file_is_ok() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("nope.yaml");
+        // `HOME` is unset for this test so discovery falls through; we just
+        // pass the explicit path which must error because it's missing.
+        let err = load(Some(path.to_str().unwrap())).unwrap_err();
+        assert!(err.contains("reading"));
+    }
+
+    #[test]
+    fn loads_explicit_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.yaml");
+        std::fs::write(
+            &path,
+            "engine_url: https://example.com\nnamespace: custom\noutput: json\n",
+        )
+        .unwrap();
+        let cfg = load(Some(path.to_str().unwrap())).unwrap().unwrap();
+        assert_eq!(cfg.engine_url.as_deref(), Some("https://example.com"));
+        assert_eq!(cfg.namespace.as_deref(), Some("custom"));
+        assert_eq!(cfg.output.as_deref(), Some("json"));
+    }
+
+    #[test]
+    fn api_key_file_wins_over_literal() {
+        let tmp = tempfile::tempdir().unwrap();
+        let key_path = tmp.path().join("key.txt");
+        std::fs::write(&key_path, "  secret-from-file\n").unwrap();
+        let cfg = ConfigFile {
+            api_key: Some("from-literal".into()),
+            api_key_file: Some(key_path),
+            ..ConfigFile::default()
+        };
+        let resolved = resolve_api_key(&cfg).unwrap().unwrap();
+        assert_eq!(resolved, "secret-from-file");
+    }
+
+    #[test]
+    fn api_key_literal_when_no_file() {
+        let cfg = ConfigFile {
+            api_key: Some("only-literal".into()),
+            ..ConfigFile::default()
+        };
+        let resolved = resolve_api_key(&cfg).unwrap().unwrap();
+        assert_eq!(resolved, "only-literal");
+    }
+
+    #[test]
+    fn no_api_key_returns_none() {
+        let cfg = ConfigFile::default();
+        assert!(resolve_api_key(&cfg).unwrap().is_none());
+    }
+
+    #[test]
+    fn unknown_keys_rejected() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.yaml");
+        std::fs::write(&path, "engine_url: x\nwhat_is_this: 5\n").unwrap();
+        assert!(load(Some(path.to_str().unwrap())).is_err());
+    }
+}

--- a/src/cli/input.rs
+++ b/src/cli/input.rs
@@ -1,0 +1,66 @@
+//! JSON-input argument resolution — literal / `@file` / `-` stdin.
+//!
+//! Saves shell-quoting pain on `--input`, `--search-attrs`, and signal
+//! payloads. Shape matches `curl`'s `@file` convention so users who
+//! already script against REST APIs don't have to learn a new idiom.
+
+use std::io::Read;
+
+use serde_json::Value;
+
+/// Resolve a user-provided JSON argument to a `serde_json::Value`.
+///
+/// - `-`       read the whole of stdin and parse
+/// - `@PATH`   read the file and parse
+/// - anything else: parse directly
+///
+/// Returns an error message suitable for printing to stderr on failure.
+pub fn resolve_json(raw: &str, what: &str) -> Result<Value, String> {
+    if raw == "-" {
+        let mut s = String::new();
+        std::io::stdin()
+            .read_to_string(&mut s)
+            .map_err(|e| format!("{what}: reading stdin: {e}"))?;
+        serde_json::from_str(&s).map_err(|e| format!("{what}: invalid JSON on stdin: {e}"))
+    } else if let Some(path) = raw.strip_prefix('@') {
+        let content = std::fs::read_to_string(path)
+            .map_err(|e| format!("{what}: reading {path}: {e}"))?;
+        serde_json::from_str(&content)
+            .map_err(|e| format!("{what}: invalid JSON in {path}: {e}"))
+    } else {
+        serde_json::from_str(raw).map_err(|e| format!("{what}: invalid JSON: {e}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_literal_json() {
+        let v = resolve_json(r#"{"a":1}"#, "x").unwrap();
+        assert_eq!(v["a"], 1);
+    }
+
+    #[test]
+    fn parses_file_json() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("input.json");
+        std::fs::write(&path, r#"{"b":"y"}"#).unwrap();
+        let arg = format!("@{}", path.display());
+        let v = resolve_json(&arg, "x").unwrap();
+        assert_eq!(v["b"], "y");
+    }
+
+    #[test]
+    fn invalid_literal_returns_helpful_error() {
+        let err = resolve_json("not json", "payload").unwrap_err();
+        assert!(err.contains("payload: invalid JSON"));
+    }
+
+    #[test]
+    fn missing_file_returns_helpful_error() {
+        let err = resolve_json("@/nonexistent/file", "payload").unwrap_err();
+        assert!(err.contains("reading"));
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,0 +1,47 @@
+//! `assay workflow …` / `assay schedule …` CLI subcommand implementations.
+//!
+//! These are thin HTTP clients over the workflow engine's REST API. The
+//! `assay.workflow` Lua stdlib mirrors the same surface programmatically;
+//! this CLI exists for operators at a terminal (kubectl exec into a pod,
+//! ad-hoc debugging, shell scripts). Lua scripts are the preferred path
+//! for automation.
+
+pub mod client;
+pub mod commands;
+pub mod table;
+
+/// Global flags + env fallbacks shared by every CLI subcommand.
+///
+/// Precedence is flag → env → hardcoded default. No config-file support
+/// in this release (see `.claude/plans/06-*.md` for the scope rationale).
+#[derive(Clone, Debug)]
+pub struct GlobalOpts {
+    pub engine_url: String,
+    pub api_key: Option<String>,
+    pub namespace: String,
+}
+
+impl GlobalOpts {
+    pub fn resolve(
+        flag_engine_url: Option<&str>,
+        flag_api_key: Option<&str>,
+        flag_namespace: Option<&str>,
+    ) -> Self {
+        let engine_url = flag_engine_url
+            .map(String::from)
+            .or_else(|| std::env::var("ASSAY_ENGINE_URL").ok())
+            .unwrap_or_else(|| "http://127.0.0.1:8080".to_string());
+        let api_key = flag_api_key
+            .map(String::from)
+            .or_else(|| std::env::var("ASSAY_API_KEY").ok());
+        let namespace = flag_namespace
+            .map(String::from)
+            .or_else(|| std::env::var("ASSAY_NAMESPACE").ok())
+            .unwrap_or_else(|| "main".to_string());
+        Self {
+            engine_url,
+            api_key,
+            namespace,
+        }
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,4 +1,4 @@
-//! `assay workflow …` / `assay schedule …` CLI subcommand implementations.
+//! `assay` CLI subcommand implementations for the workflow engine.
 //!
 //! These are thin HTTP clients over the workflow engine's REST API. The
 //! `assay.workflow` Lua stdlib mirrors the same surface programmatically;
@@ -8,40 +8,105 @@
 
 pub mod client;
 pub mod commands;
+pub mod config;
+pub mod input;
+pub mod output;
 pub mod table;
 
-/// Global flags + env fallbacks shared by every CLI subcommand.
-///
-/// Precedence is flag → env → hardcoded default. No config-file support
-/// in this release (see `.claude/plans/06-*.md` for the scope rationale).
+use std::process::ExitCode;
+
+pub use output::Output;
+
+/// Global config resolved from (in precedence order): CLI flags,
+/// environment variables, optional YAML config file, hardcoded defaults.
 #[derive(Clone, Debug)]
 pub struct GlobalOpts {
     pub engine_url: String,
     pub api_key: Option<String>,
     pub namespace: String,
+    pub output: Output,
+}
+
+/// Inputs from the clap layer — flag overrides only. Env vars are read
+/// inside `resolve` so flag > env > config-file > default precedence is
+/// implemented once in a single place.
+#[derive(Default)]
+pub struct GlobalFlags<'a> {
+    pub engine_url: Option<&'a str>,
+    pub api_key: Option<&'a str>,
+    pub namespace: Option<&'a str>,
+    pub output: Option<&'a str>,
+    pub config: Option<&'a str>,
 }
 
 impl GlobalOpts {
-    pub fn resolve(
-        flag_engine_url: Option<&str>,
-        flag_api_key: Option<&str>,
-        flag_namespace: Option<&str>,
-    ) -> Self {
-        let engine_url = flag_engine_url
+    /// Build a resolved `GlobalOpts` from CLI flags + environment +
+    /// config file. Returns an exit code if something fatal happened
+    /// during config loading (bad YAML, unknown keys, unreadable
+    /// `api_key_file`) so callers can bail cleanly.
+    pub fn resolve(flags: GlobalFlags) -> Result<Self, ExitCode> {
+        let explicit_cfg = flags
+            .config
+            .map(String::from)
+            .or_else(|| std::env::var("ASSAY_CONFIG_FILE").ok());
+        let cfg = match config::load(explicit_cfg.as_deref()) {
+            Ok(Some(c)) => c,
+            Ok(None) => config::ConfigFile::default(),
+            Err(e) => {
+                eprintln!("error: {e}");
+                return Err(ExitCode::from(1));
+            }
+        };
+
+        let file_api_key = match config::resolve_api_key(&cfg) {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!("error: {e}");
+                return Err(ExitCode::from(1));
+            }
+        };
+
+        let engine_url = flags
+            .engine_url
             .map(String::from)
             .or_else(|| std::env::var("ASSAY_ENGINE_URL").ok())
+            .or(cfg.engine_url)
             .unwrap_or_else(|| "http://127.0.0.1:8080".to_string());
-        let api_key = flag_api_key
+        let api_key = flags
+            .api_key
             .map(String::from)
-            .or_else(|| std::env::var("ASSAY_API_KEY").ok());
-        let namespace = flag_namespace
+            .or_else(|| std::env::var("ASSAY_API_KEY").ok())
+            .or(file_api_key);
+        let namespace = flags
+            .namespace
             .map(String::from)
             .or_else(|| std::env::var("ASSAY_NAMESPACE").ok())
+            .or(cfg.namespace)
             .unwrap_or_else(|| "main".to_string());
-        Self {
+
+        let output_str = flags
+            .output
+            .map(String::from)
+            .or_else(|| std::env::var("ASSAY_OUTPUT").ok())
+            .or(cfg.output);
+        let output = match output_str {
+            Some(s) => match Output::from_user_string(&s) {
+                Some(o) => o,
+                None => {
+                    eprintln!(
+                        "error: unknown output format '{s}' (expected table, json, jsonl, yaml)"
+                    );
+                    return Err(ExitCode::from(1));
+                }
+            },
+            None => Output::tty_adaptive_default(),
+        };
+
+        Ok(Self {
             engine_url,
             api_key,
             namespace,
-        }
+            output,
+        })
     }
 }

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -1,0 +1,132 @@
+//! Output format plumbing for CLI subcommands.
+//!
+//! Four formats:
+//!   - `Table`  — column-aligned human-readable, default on TTY
+//!   - `Json`   — single pretty-printed JSON document, default when piped
+//!   - `Jsonl`  — one compact JSON doc per line (streaming-friendly)
+//!   - `Yaml`   — single YAML document
+//!
+//! Subcommands describe their data with `RenderList` (tabular) or
+//! `RenderRecord` (one object) and the `Printer` handles format
+//! selection.
+
+use std::io::IsTerminal;
+use std::str::FromStr;
+
+use serde_json::Value;
+
+use crate::cli::table::print_table;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Output {
+    Table,
+    Json,
+    Jsonl,
+    Yaml,
+}
+
+impl Output {
+    /// Default when the user hasn't specified `--output` or set
+    /// `ASSAY_OUTPUT` / `output:` in the config file. `table` on a TTY,
+    /// `json` when stdout is redirected (shell pipe, `> file`).
+    pub fn tty_adaptive_default() -> Self {
+        if std::io::stdout().is_terminal() {
+            Self::Table
+        } else {
+            Self::Json
+        }
+    }
+
+    /// Resolve a format from a user-provided string, ignoring case.
+    /// Returns None if the value doesn't match any known format.
+    pub fn from_user_string(s: &str) -> Option<Self> {
+        Self::from_str(s).ok()
+    }
+}
+
+impl FromStr for Output {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, String> {
+        match s.to_ascii_lowercase().as_str() {
+            "table" => Ok(Self::Table),
+            "json" => Ok(Self::Json),
+            "jsonl" => Ok(Self::Jsonl),
+            "yaml" | "yml" => Ok(Self::Yaml),
+            other => Err(format!(
+                "unknown output format '{other}' (expected table, json, jsonl, yaml)"
+            )),
+        }
+    }
+}
+
+/// Print a list-of-records in the configured format.
+///
+/// `headers` + `row_for` are only used for `Output::Table`; other formats
+/// render the raw JSON value. Keeps table formatting isolated from JSON
+/// shape so the REST response structure stays the source of truth.
+pub fn print_list(
+    format: Output,
+    items: &[Value],
+    headers: &[&str],
+    row_for: impl Fn(&Value) -> Vec<String>,
+) {
+    match format {
+        Output::Table => {
+            let rows: Vec<Vec<String>> = items.iter().map(&row_for).collect();
+            print_table(headers, &rows);
+        }
+        Output::Json => {
+            let v = Value::Array(items.to_vec());
+            println!("{}", serde_json::to_string_pretty(&v).unwrap_or_default());
+        }
+        Output::Jsonl => {
+            for item in items {
+                println!("{}", serde_json::to_string(item).unwrap_or_default());
+            }
+        }
+        Output::Yaml => {
+            let v = Value::Array(items.to_vec());
+            match serde_yml::to_string(&v) {
+                Ok(s) => print!("{s}"),
+                Err(e) => eprintln!("error: serialising yaml: {e}"),
+            }
+        }
+    }
+}
+
+/// Print a single record. Table format falls back to pretty JSON —
+/// records don't have natural column shape, and tabular display of a
+/// single object is noisier than JSON.
+pub fn print_record(format: Output, value: &Value) {
+    match format {
+        Output::Table | Output::Json => {
+            println!(
+                "{}",
+                serde_json::to_string_pretty(value).unwrap_or_default()
+            );
+        }
+        Output::Jsonl => {
+            println!("{}", serde_json::to_string(value).unwrap_or_default());
+        }
+        Output::Yaml => match serde_yml::to_string(value) {
+            Ok(s) => print!("{s}"),
+            Err(e) => eprintln!("error: serialising yaml: {e}"),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_output_formats() {
+        assert_eq!(Output::from_str("table").unwrap(), Output::Table);
+        assert_eq!(Output::from_str("JSON").unwrap(), Output::Json);
+        assert_eq!(Output::from_str("jsonl").unwrap(), Output::Jsonl);
+        assert_eq!(Output::from_str("yaml").unwrap(), Output::Yaml);
+        assert_eq!(Output::from_str("yml").unwrap(), Output::Yaml);
+        assert!(Output::from_str("junk").is_err());
+    }
+}

--- a/src/cli/table.rs
+++ b/src/cli/table.rs
@@ -1,0 +1,66 @@
+//! Plain column-aligned table printer for CLI output.
+//!
+//! Two-pass: compute column widths across header + every row, then print
+//! each row padded to those widths. No colors, no unicode borders — keeps
+//! output copy-pasteable and script-consumable via `awk` / `cut`.
+
+/// Print a header row plus `rows` aligned so every column is at least
+/// the width of its longest value.
+pub fn print_table(headers: &[&str], rows: &[Vec<String>]) {
+    let mut widths: Vec<usize> = headers.iter().map(|h| h.len()).collect();
+    for row in rows {
+        for (i, cell) in row.iter().enumerate() {
+            if i < widths.len() && cell.len() > widths[i] {
+                widths[i] = cell.len();
+            }
+        }
+    }
+    print_row(headers.iter().map(|s| s.to_string()).collect(), &widths);
+    // No separator line — the alignment alone is enough.
+    for row in rows {
+        print_row(row.clone(), &widths);
+    }
+}
+
+fn print_row(cells: Vec<String>, widths: &[usize]) {
+    let n = cells.len().min(widths.len());
+    let parts: Vec<String> = (0..n)
+        .map(|i| {
+            if i + 1 == n {
+                // Last cell: no trailing padding, easier to pipe.
+                cells[i].clone()
+            } else {
+                format!("{:<width$}", cells[i], width = widths[i])
+            }
+        })
+        .collect();
+    println!("{}", parts.join("  "));
+}
+
+/// Common helpers for serde_json::Value formatting.
+pub fn value_as_str(v: &serde_json::Value, key: &str) -> String {
+    match v.get(key) {
+        Some(serde_json::Value::String(s)) => s.clone(),
+        Some(serde_json::Value::Null) | None => "-".to_string(),
+        Some(other) => other.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn value_as_str_handles_missing_and_null() {
+        let v = serde_json::json!({ "a": "x", "b": null });
+        assert_eq!(value_as_str(&v, "a"), "x");
+        assert_eq!(value_as_str(&v, "b"), "-");
+        assert_eq!(value_as_str(&v, "missing"), "-");
+    }
+
+    #[test]
+    fn value_as_str_renders_numbers() {
+        let v = serde_json::json!({ "n": 42 });
+        assert_eq!(value_as_str(&v, "n"), "42");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,11 +129,42 @@ enum Commands {
         #[command(subcommand)]
         command: ScheduleCommands,
     },
+    /// Manage namespaces
+    Namespace {
+        #[command(flatten)]
+        global: CliEngineOpts,
+        #[command(subcommand)]
+        command: NamespaceCommands,
+    },
+    /// Inspect workers registered with the engine
+    Worker {
+        #[command(flatten)]
+        global: CliEngineOpts,
+        #[command(subcommand)]
+        command: WorkerCommands,
+    },
+    /// Inspect task-queue stats
+    Queue {
+        #[command(flatten)]
+        global: CliEngineOpts,
+        #[command(subcommand)]
+        command: QueueCommands,
+    },
+    /// Generate shell completion scripts.
+    ///
+    /// Pipe the output into the appropriate shell-completion location:
+    ///   bash:  assay completion bash > /etc/bash_completion.d/assay
+    ///   zsh:   assay completion zsh  > "${fpath[1]}/_assay"
+    ///   fish:  assay completion fish > ~/.config/fish/completions/assay.fish
+    Completion {
+        /// Target shell.
+        shell: clap_complete::Shell,
+    },
 }
 
-/// Global flags shared by `workflow` and `schedule` subcommands. Each
-/// backed by an env var so pods can drop these into their environment
-/// without passing flags on every invocation.
+/// Global flags shared by `workflow` / `schedule` / `namespace` / `worker` /
+/// `queue` subcommands. Each backed by an env var so pods can drop these
+/// into their environment without passing flags on every invocation.
 #[derive(clap::Args, Debug)]
 struct CliEngineOpts {
     /// Workflow engine base URL (default http://127.0.0.1:8080 / $ASSAY_ENGINE_URL).
@@ -146,16 +177,59 @@ struct CliEngineOpts {
     /// Target namespace (default "main" / $ASSAY_NAMESPACE).
     #[arg(long, global = true, env = "ASSAY_NAMESPACE")]
     namespace: Option<String>,
+    /// Output format: table | json | jsonl | yaml.
+    /// Default is `table` on a TTY and `json` when stdout is piped.
+    #[arg(long, global = true, env = "ASSAY_OUTPUT")]
+    output: Option<String>,
+    /// Path to a YAML config file. Discovery order: --config flag,
+    /// ASSAY_CONFIG_FILE, $XDG_CONFIG_HOME/assay/config.yaml,
+    /// $HOME/.config/assay/config.yaml, /etc/assay/config.yaml.
+    #[arg(long, global = true, env = "ASSAY_CONFIG_FILE")]
+    config: Option<String>,
+}
+
+impl CliEngineOpts {
+    fn as_flags(&self) -> cli::GlobalFlags<'_> {
+        cli::GlobalFlags {
+            engine_url: self.engine_url.as_deref(),
+            api_key: self.api_key.as_deref(),
+            namespace: self.namespace.as_deref(),
+            output: self.output.as_deref(),
+            config: self.config.as_deref(),
+        }
+    }
 }
 
 #[derive(Subcommand, Debug)]
 enum WorkflowCommands {
+    /// Start a new workflow run
+    Start {
+        /// Workflow type name
+        #[arg(long = "type")]
+        workflow_type: String,
+        /// Workflow ID (auto-generated if omitted)
+        #[arg(long)]
+        id: Option<String>,
+        /// JSON input. Literal, `@file.json`, or `-` for stdin.
+        #[arg(long)]
+        input: Option<String>,
+        /// Task queue (default "default")
+        #[arg(long)]
+        queue: Option<String>,
+        /// JSON search attributes (indexed metadata for filtering).
+        /// Literal, `@file.json`, or `-` for stdin.
+        #[arg(long)]
+        search_attrs: Option<String>,
+    },
     /// List workflows
     List {
         #[arg(long)]
         status: Option<String>,
         #[arg(long = "type")]
         workflow_type: Option<String>,
+        /// Filter by search attributes. Literal JSON, `@file.json`, or `-` for stdin.
+        #[arg(long)]
+        search_attrs: Option<String>,
         #[arg(long, default_value = "20")]
         limit: i64,
     },
@@ -172,13 +246,26 @@ enum WorkflowCommands {
         /// Query handler name (omit to dump all registered queries)
         name: Option<String>,
     },
+    /// Read a workflow's event log, optionally streaming new events.
+    Events {
+        /// Workflow ID
+        id: String,
+        /// Poll for new events every 500ms until the workflow terminates.
+        #[arg(long)]
+        follow: bool,
+    },
+    /// List a parent workflow's child workflows
+    Children {
+        /// Parent workflow ID
+        id: String,
+    },
     /// Send a signal to a workflow
     Signal {
         /// Workflow ID
         id: String,
         /// Signal name
         name: String,
-        /// JSON payload
+        /// JSON payload. Literal, `@file.json`, or `-` for stdin.
         payload: Option<String>,
     },
     /// Cancel a workflow
@@ -193,12 +280,74 @@ enum WorkflowCommands {
         #[arg(long)]
         reason: Option<String>,
     },
+    /// Close out a workflow and start a fresh run with the same type,
+    /// namespace, and task queue. Client-side continue-as-new — distinct
+    /// from the worker-side `ctx:continue_as_new`.
+    #[command(name = "continue-as-new")]
+    ContinueAsNew {
+        /// Workflow ID
+        id: String,
+        /// JSON input for the new run. Literal, `@file.json`, or `-` for stdin.
+        #[arg(long)]
+        input: Option<String>,
+    },
+    /// Block until a workflow reaches a terminal state (or a specific
+    /// target status). Exits 0 on COMPLETED / match, 1 on FAILED /
+    /// CANCELLED / TIMED_OUT (when no target), 2 on timeout.
+    Wait {
+        /// Workflow ID
+        id: String,
+        /// Max seconds to wait (default 300)
+        #[arg(long, default_value = "300")]
+        timeout: u64,
+        /// Specific status to wait for (default: any terminal status)
+        #[arg(long)]
+        target: Option<String>,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+enum NamespaceCommands {
+    /// Create a namespace
+    Create {
+        /// Namespace name
+        name: String,
+    },
+    /// List namespaces
+    List,
+    /// Describe a namespace (includes live counts)
+    Describe {
+        /// Namespace name
+        name: String,
+    },
+    /// Delete a namespace
+    Delete {
+        /// Namespace name
+        name: String,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+enum WorkerCommands {
+    /// List registered workers
+    List,
+}
+
+#[derive(Subcommand, Debug)]
+enum QueueCommands {
+    /// Pending / running activity counts per task queue
+    Stats,
 }
 
 #[derive(Subcommand, Debug)]
 enum ScheduleCommands {
     /// List schedules
     List,
+    /// Describe a single schedule
+    Describe {
+        /// Schedule name
+        name: String,
+    },
     /// Create a schedule
     Create {
         /// Schedule name
@@ -389,22 +538,43 @@ async fn main() -> ExitCode {
             ExitCode::from(1)
         }
         Some(Commands::Workflow { global, command }) => {
-            let opts = cli::GlobalOpts::resolve(
-                global.engine_url.as_deref(),
-                global.api_key.as_deref(),
-                global.namespace.as_deref(),
-            );
+            let opts = match cli::GlobalOpts::resolve(global.as_flags()) {
+                Ok(o) => o,
+                Err(code) => return code,
+            };
             match command {
+                WorkflowCommands::Start {
+                    workflow_type,
+                    id,
+                    input,
+                    queue,
+                    search_attrs,
+                } => {
+                    cli::commands::workflow_start(
+                        &opts, &workflow_type, id, input, queue, search_attrs,
+                    )
+                    .await
+                }
                 WorkflowCommands::List {
                     status,
                     workflow_type,
+                    search_attrs,
                     limit,
-                } => cli::commands::workflow_list(&opts, status, workflow_type, limit).await,
+                } => {
+                    cli::commands::workflow_list(&opts, status, workflow_type, search_attrs, limit)
+                        .await
+                }
                 WorkflowCommands::Describe { id } => {
                     cli::commands::workflow_describe(&opts, &id).await
                 }
                 WorkflowCommands::State { id, name } => {
                     cli::commands::workflow_state(&opts, &id, name.as_deref()).await
+                }
+                WorkflowCommands::Events { id, follow } => {
+                    cli::commands::workflow_events(&opts, &id, follow).await
+                }
+                WorkflowCommands::Children { id } => {
+                    cli::commands::workflow_children(&opts, &id).await
                 }
                 WorkflowCommands::Signal { id, name, payload } => {
                     cli::commands::workflow_signal(&opts, &id, &name, payload).await
@@ -413,16 +583,26 @@ async fn main() -> ExitCode {
                 WorkflowCommands::Terminate { id, reason } => {
                     cli::commands::workflow_terminate(&opts, &id, reason).await
                 }
+                WorkflowCommands::ContinueAsNew { id, input } => {
+                    cli::commands::workflow_continue_as_new(&opts, &id, input).await
+                }
+                WorkflowCommands::Wait {
+                    id,
+                    timeout,
+                    target,
+                } => cli::commands::workflow_wait(&opts, &id, timeout, target).await,
             }
         }
         Some(Commands::Schedule { global, command }) => {
-            let opts = cli::GlobalOpts::resolve(
-                global.engine_url.as_deref(),
-                global.api_key.as_deref(),
-                global.namespace.as_deref(),
-            );
+            let opts = match cli::GlobalOpts::resolve(global.as_flags()) {
+                Ok(o) => o,
+                Err(code) => return code,
+            };
             match command {
                 ScheduleCommands::List => cli::commands::schedule_list(&opts).await,
+                ScheduleCommands::Describe { name } => {
+                    cli::commands::schedule_describe(&opts, &name).await
+                }
                 ScheduleCommands::Create {
                     name,
                     workflow_type,
@@ -463,6 +643,60 @@ async fn main() -> ExitCode {
                 }
                 ScheduleCommands::Delete { name } => {
                     cli::commands::schedule_delete(&opts, &name).await
+                }
+            }
+        }
+        Some(Commands::Namespace { global, command }) => {
+            let opts = match cli::GlobalOpts::resolve(global.as_flags()) {
+                Ok(o) => o,
+                Err(code) => return code,
+            };
+            match command {
+                NamespaceCommands::Create { name } => {
+                    cli::commands::namespace_create(&opts, &name).await
+                }
+                NamespaceCommands::List => cli::commands::namespace_list(&opts).await,
+                NamespaceCommands::Describe { name } => {
+                    cli::commands::namespace_describe(&opts, &name).await
+                }
+                NamespaceCommands::Delete { name } => {
+                    cli::commands::namespace_delete(&opts, &name).await
+                }
+            }
+        }
+        Some(Commands::Worker { global, command }) => {
+            let opts = match cli::GlobalOpts::resolve(global.as_flags()) {
+                Ok(o) => o,
+                Err(code) => return code,
+            };
+            match command {
+                WorkerCommands::List => cli::commands::worker_list(&opts).await,
+            }
+        }
+        Some(Commands::Queue { global, command }) => {
+            let opts = match cli::GlobalOpts::resolve(global.as_flags()) {
+                Ok(o) => o,
+                Err(code) => return code,
+            };
+            match command {
+                QueueCommands::Stats => cli::commands::queue_stats(&opts).await,
+            }
+        }
+        Some(Commands::Completion { shell }) => {
+            use clap::CommandFactory;
+            let mut cmd = Cli::command();
+            // Buffer first so we can exit cleanly on a broken pipe
+            // (e.g. `assay completion bash | head`): clap_complete's
+            // default writer panics on BrokenPipe.
+            let mut buf: Vec<u8> = Vec::new();
+            clap_complete::generate(shell, &mut cmd, "assay", &mut buf);
+            use std::io::Write;
+            match std::io::stdout().write_all(&buf) {
+                Ok(()) => ExitCode::SUCCESS,
+                Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => ExitCode::SUCCESS,
+                Err(e) => {
+                    eprintln!("error: writing completion: {e}");
+                    ExitCode::from(1)
                 }
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod checks;
+mod cli;
 mod config;
 mod lua;
 mod output;
@@ -116,14 +117,35 @@ enum Commands {
     },
     /// Manage workflows
     Workflow {
+        #[command(flatten)]
+        global: CliEngineOpts,
         #[command(subcommand)]
         command: WorkflowCommands,
     },
     /// Manage schedules
     Schedule {
+        #[command(flatten)]
+        global: CliEngineOpts,
         #[command(subcommand)]
         command: ScheduleCommands,
     },
+}
+
+/// Global flags shared by `workflow` and `schedule` subcommands. Each
+/// backed by an env var so pods can drop these into their environment
+/// without passing flags on every invocation.
+#[derive(clap::Args, Debug)]
+struct CliEngineOpts {
+    /// Workflow engine base URL (default http://127.0.0.1:8080 / $ASSAY_ENGINE_URL).
+    #[arg(long, global = true, env = "ASSAY_ENGINE_URL")]
+    engine_url: Option<String>,
+    /// Bearer token. CLI forwards it as `Authorization: Bearer <value>`;
+    /// the engine decides whether it's an API key or a JWT.
+    #[arg(long, global = true, env = "ASSAY_API_KEY")]
+    api_key: Option<String>,
+    /// Target namespace (default "main" / $ASSAY_NAMESPACE).
+    #[arg(long, global = true, env = "ASSAY_NAMESPACE")]
+    namespace: Option<String>,
 }
 
 #[derive(Subcommand, Debug)]
@@ -132,7 +154,7 @@ enum WorkflowCommands {
     List {
         #[arg(long)]
         status: Option<String>,
-        #[arg(long, name = "type")]
+        #[arg(long = "type")]
         workflow_type: Option<String>,
         #[arg(long, default_value = "20")]
         limit: i64,
@@ -141,6 +163,14 @@ enum WorkflowCommands {
     Describe {
         /// Workflow ID
         id: String,
+    },
+    /// Read the latest state snapshot written by `ctx:register_query` handlers.
+    /// With a query name, returns just that query's value; without, the full map.
+    State {
+        /// Workflow ID
+        id: String,
+        /// Query handler name (omit to dump all registered queries)
+        name: Option<String>,
     },
     /// Send a signal to a workflow
     Signal {
@@ -173,14 +203,33 @@ enum ScheduleCommands {
     Create {
         /// Schedule name
         name: String,
-        #[arg(long, name = "type")]
+        #[arg(long = "type")]
         workflow_type: String,
         #[arg(long)]
         cron: String,
+        /// IANA timezone for cron evaluation (default UTC)
+        #[arg(long)]
+        timezone: Option<String>,
         #[arg(long)]
         input: Option<String>,
         #[arg(long, default_value = "default")]
         queue: String,
+    },
+    /// Apply a partial update to a schedule. Only fields present are
+    /// changed; unchanged fields keep their values.
+    Patch {
+        /// Schedule name
+        name: String,
+        #[arg(long)]
+        cron: Option<String>,
+        #[arg(long)]
+        timezone: Option<String>,
+        #[arg(long)]
+        input: Option<String>,
+        #[arg(long)]
+        queue: Option<String>,
+        #[arg(long)]
+        overlap: Option<String>,
     },
     /// Pause a schedule
     Pause {
@@ -339,15 +388,83 @@ async fn main() -> ExitCode {
             eprintln!("assay serve: workflow engine not compiled (enable 'workflow' feature)");
             ExitCode::from(1)
         }
-        Some(Commands::Workflow { command }) => {
-            eprintln!("assay workflow: {command:?}");
-            eprintln!("workflow management not yet implemented (v0.11.1)");
-            ExitCode::from(1)
+        Some(Commands::Workflow { global, command }) => {
+            let opts = cli::GlobalOpts::resolve(
+                global.engine_url.as_deref(),
+                global.api_key.as_deref(),
+                global.namespace.as_deref(),
+            );
+            match command {
+                WorkflowCommands::List {
+                    status,
+                    workflow_type,
+                    limit,
+                } => cli::commands::workflow_list(&opts, status, workflow_type, limit).await,
+                WorkflowCommands::Describe { id } => {
+                    cli::commands::workflow_describe(&opts, &id).await
+                }
+                WorkflowCommands::State { id, name } => {
+                    cli::commands::workflow_state(&opts, &id, name.as_deref()).await
+                }
+                WorkflowCommands::Signal { id, name, payload } => {
+                    cli::commands::workflow_signal(&opts, &id, &name, payload).await
+                }
+                WorkflowCommands::Cancel { id } => cli::commands::workflow_cancel(&opts, &id).await,
+                WorkflowCommands::Terminate { id, reason } => {
+                    cli::commands::workflow_terminate(&opts, &id, reason).await
+                }
+            }
         }
-        Some(Commands::Schedule { command }) => {
-            eprintln!("assay schedule: {command:?}");
-            eprintln!("schedule management not yet implemented (v0.11.1)");
-            ExitCode::from(1)
+        Some(Commands::Schedule { global, command }) => {
+            let opts = cli::GlobalOpts::resolve(
+                global.engine_url.as_deref(),
+                global.api_key.as_deref(),
+                global.namespace.as_deref(),
+            );
+            match command {
+                ScheduleCommands::List => cli::commands::schedule_list(&opts).await,
+                ScheduleCommands::Create {
+                    name,
+                    workflow_type,
+                    cron,
+                    timezone,
+                    input,
+                    queue,
+                } => {
+                    cli::commands::schedule_create(
+                        &opts,
+                        &name,
+                        &workflow_type,
+                        &cron,
+                        timezone,
+                        input,
+                        Some(queue),
+                    )
+                    .await
+                }
+                ScheduleCommands::Patch {
+                    name,
+                    cron,
+                    timezone,
+                    input,
+                    queue,
+                    overlap,
+                } => {
+                    cli::commands::schedule_patch(
+                        &opts, &name, cron, timezone, input, queue, overlap,
+                    )
+                    .await
+                }
+                ScheduleCommands::Pause { name } => {
+                    cli::commands::schedule_pause(&opts, &name).await
+                }
+                ScheduleCommands::Resume { name } => {
+                    cli::commands::schedule_resume(&opts, &name).await
+                }
+                ScheduleCommands::Delete { name } => {
+                    cli::commands::schedule_delete(&opts, &name).await
+                }
+            }
         }
         None => {
             if let Some(ref file) = cli.file {

--- a/src/main.rs
+++ b/src/main.rs
@@ -759,7 +759,14 @@ async fn serve_with_store<S: assay_workflow::WorkflowStore>(
     }
 
     let engine = assay_workflow::Engine::start(store);
-    if let Err(e) = assay_workflow::api::serve(engine, port, auth_mode).await {
+    if let Err(e) = assay_workflow::api::serve_with_version(
+        engine,
+        port,
+        auth_mode,
+        Some(env!("CARGO_PKG_VERSION")),
+    )
+    .await
+    {
         error!("Engine server error: {e}");
         return ExitCode::from(1);
     }

--- a/stdlib/workflow.lua
+++ b/stdlib/workflow.lua
@@ -517,6 +517,27 @@ function M._make_workflow_ctx(workflow_id, history)
         error("workflow ctx: yielded but resumed unexpectedly")
     end
 
+    --- Merge a JSON object into the workflow's stored `search_attributes`
+    --- so external callers can filter the list endpoint on application-
+    --- level metadata. Keys in the patch overwrite existing keys; keys
+    --- not in the patch are preserved.
+    ---
+    --- Typical use: tag the workflow with progress / tenant / env so
+    --- dashboards can filter by them:
+    ---
+    ---   ctx:upsert_search_attributes({ progress = 0.5, stage = "deploy" })
+    function ctx:upsert_search_attributes(patch)
+        check_cancel()
+        if type(patch) ~= "table" then
+            error("ctx:upsert_search_attributes: patch must be a table")
+        end
+        coroutine.yield({
+            type = "UpsertSearchAttributes",
+            patch = patch,
+        })
+        error("workflow ctx: yielded but resumed unexpectedly")
+    end
+
     --- End this run and start a fresh one with the same workflow type,
     --- namespace, and task queue but an empty event history. Use for
     --- unbounded-loop workflows (pollers, schedulers) whose event log

--- a/stdlib/workflow.lua
+++ b/stdlib/workflow.lua
@@ -440,6 +440,31 @@ function M._make_workflow_ctx(workflow_id, history)
         error("workflow ctx: yielded but resumed unexpectedly")
     end
 
+    --- End this run and start a fresh one with the same workflow type,
+    --- namespace, and task queue but an empty event history. Use for
+    --- unbounded-loop workflows (pollers, schedulers) whose event log
+    --- would otherwise grow forever.
+    ---
+    --- The new run's id is derived from the current one (with a timestamp
+    --- suffix) and its `input` is whatever you pass here. The current run
+    --- is marked COMPLETED.
+    ---
+    --- Typically the last thing a handler calls:
+    ---
+    ---   workflow.define("Poller", function(ctx, input)
+    ---       local items = ctx:execute_activity("poll", input)
+    ---       ctx:sleep(60)
+    ---       return ctx:continue_as_new({ cursor = items.next_cursor })
+    ---   end)
+    function ctx:continue_as_new(input)
+        check_cancel()
+        coroutine.yield({
+            type = "ContinueAsNew",
+            input = input,
+        })
+        error("workflow ctx: yielded but resumed unexpectedly")
+    end
+
     --- Register a named query handler that exposes live workflow state to
     --- external callers via `GET /api/v1/workflows/{id}/state` (all handlers)
     --- or `GET /api/v1/workflows/{id}/state/{name}` (one handler).

--- a/stdlib/workflow.lua
+++ b/stdlib/workflow.lua
@@ -259,7 +259,13 @@ function M._handle_workflow_task(task)
     if coroutine.status(co) == "dead" then
         return with_snapshot({{ type = "CompleteWorkflow", result = yielded_or_returned }})
     end
-    -- Yielded a command — submit it and let a subsequent replay continue
+    -- Yielded a command (or a batch) — submit and let a subsequent replay continue.
+    -- Parallel activities yield `{ _batch = true, commands = {...} }` so we
+    -- can submit N commands from a single handler run without bouncing the
+    -- workflow N times through the dispatch loop.
+    if type(yielded_or_returned) == "table" and yielded_or_returned._batch then
+        return with_snapshot(yielded_or_returned.commands)
+    end
     return with_snapshot({ yielded_or_returned })
 end
 
@@ -365,6 +371,77 @@ function M._make_workflow_ctx(workflow_id, history)
             heartbeat_timeout_secs = opts and opts.heartbeat_timeout_secs,
         })
         -- Unreachable in single-yield mode — yielding ends this replay.
+        error("workflow ctx: yielded but resumed unexpectedly")
+    end
+
+    --- Schedule multiple activities concurrently and return their results in
+    --- the same order. On replay: if all N activities have completed events
+    --- in history, returns immediately with a list of results. If any are
+    --- missing, yields a batch of ScheduleActivity commands for the missing
+    --- ones — the engine schedules them idempotently (on `seq`) and the
+    --- workflow is re-dispatched on each completion. The workflow proceeds
+    --- past this call only when every activity has a terminal event.
+    ---
+    --- Each completion triggers a replay that yields another batch of
+    --- missing commands; because `schedule_activity` is idempotent on
+    --- `(workflow_id, seq)`, repeated scheduling of the same seq is a
+    --- no-op at the store layer.
+    ---
+    --- If any activity fails after exhausting its retries, this call raises
+    --- with that activity's error. Per-activity retry/timeout opts are
+    --- passed through, same as `ctx:execute_activity`.
+    ---
+    --- Usage:
+    ---   local results = ctx:execute_parallel({
+    ---       { name = "check_a", input = { id = 1 } },
+    ---       { name = "check_b", input = { id = 2 } },
+    ---       { name = "check_c", input = { id = 3 } },
+    ---   })
+    ---   -- results[1], results[2], results[3] are in input order
+    function ctx:execute_parallel(activities)
+        check_cancel()
+        if type(activities) ~= "table" or #activities == 0 then
+            error("ctx:execute_parallel: activities must be a non-empty list")
+        end
+        local seqs, results, all_done, first_error = {}, {}, true, nil
+        local pending_cmds = {}
+        for i, a in ipairs(activities) do
+            activity_seq = activity_seq + 1
+            seqs[i] = activity_seq
+            local r = activity_results[activity_seq]
+            if r then
+                if r.ok then
+                    results[i] = r.value
+                else
+                    first_error = first_error
+                        or ("activity '" .. (a.name or "?")
+                            .. "' failed: " .. tostring(r.err))
+                end
+            else
+                all_done = false
+                local opts = a.opts or {}
+                pending_cmds[#pending_cmds + 1] = {
+                    type = "ScheduleActivity",
+                    seq = activity_seq,
+                    name = a.name,
+                    task_queue = opts.task_queue or "default",
+                    input = a.input,
+                    max_attempts = opts.max_attempts,
+                    initial_interval_secs = opts.initial_interval_secs,
+                    backoff_coefficient = opts.backoff_coefficient,
+                    start_to_close_secs = opts.start_to_close_secs,
+                    heartbeat_timeout_secs = opts.heartbeat_timeout_secs,
+                }
+            end
+        end
+        if all_done then
+            if first_error then error(first_error) end
+            return results
+        end
+        -- Yield a BATCH: a table with `_batch = true` so the worker's
+        -- replay loop recognises it and submits every command in order
+        -- instead of wrapping a single command.
+        coroutine.yield({ _batch = true, commands = pending_cmds })
         error("workflow ctx: yielded but resumed unexpectedly")
     end
 

--- a/stdlib/workflow.lua
+++ b/stdlib/workflow.lua
@@ -207,11 +207,16 @@ function M._poll_activity_task(queue)
 end
 
 --- Run the workflow handler against the current event history. Returns
---- the list of commands to submit back to the engine — exactly one of:
----  * a single yielded command (`ScheduleActivity`, etc.) when the
----    handler reached an unfulfilled step
----  * `CompleteWorkflow` when the handler returned normally
----  * `FailWorkflow` when the handler raised an error
+--- the list of commands to submit back to the engine. Shape:
+---   * (optional) `RecordSnapshot` command when `ctx:register_query` was
+---     called — always emitted first so the latest state is persisted
+---     before any scheduling / completion decisions
+---   * then one terminal or scheduling command:
+---     - a single yielded command (`ScheduleActivity`, etc.) when the
+---       handler reached an unfulfilled step
+---     - `CompleteWorkflow` when the handler returned normally
+---     - `FailWorkflow` when the handler raised an error
+---     - `CancelWorkflow` when cancellation was requested
 ---
 --- One yield per replay keeps the model simple; future versions can batch
 --- commands when a workflow yields multiple parallel awaits in one go.
@@ -228,21 +233,58 @@ function M._handle_workflow_task(task)
     local co = coroutine.create(function() return handler(ctx, task.input) end)
 
     local ok, yielded_or_returned = coroutine.resume(co)
+
+    -- Collect registered query results into a snapshot. Runs on every replay
+    -- so the latest state is always visible via GET /workflows/{id}/state.
+    -- `_collect_snapshot` returns nil when no queries were registered, so
+    -- workflows that don't use `ctx:register_query` don't pay the cost.
+    local snapshot_cmd = M._collect_snapshot(ctx)
+    local function with_snapshot(cmds)
+        if snapshot_cmd then
+            table.insert(cmds, 1, snapshot_cmd)
+        end
+        return cmds
+    end
+
     if not ok then
         local err = tostring(yielded_or_returned)
         -- Cancellation is a clean exit, not a failure — translate the
         -- sentinel raised by ctx:check_cancel back into a CancelWorkflow
         -- command so the engine flips status to CANCELLED (not FAILED).
         if err:find("__ASSAY_WORKFLOW_CANCELLED__", 1, true) then
-            return {{ type = "CancelWorkflow" }}
+            return with_snapshot({{ type = "CancelWorkflow" }})
         end
-        return {{ type = "FailWorkflow", error = err }}
+        return with_snapshot({{ type = "FailWorkflow", error = err }})
     end
     if coroutine.status(co) == "dead" then
-        return {{ type = "CompleteWorkflow", result = yielded_or_returned }}
+        return with_snapshot({{ type = "CompleteWorkflow", result = yielded_or_returned }})
     end
     -- Yielded a command — submit it and let a subsequent replay continue
-    return { yielded_or_returned }
+    return with_snapshot({ yielded_or_returned })
+end
+
+--- Build a RecordSnapshot command from any query handlers registered via
+--- `ctx:register_query`. Returns nil if no handlers were registered, so
+--- workflows that don't expose state don't emit snapshot commands.
+---
+--- Each handler runs once per replay. A handler that errors is dropped
+--- from the snapshot rather than crashing the workflow — queries are a
+--- best-effort read-through, not load-bearing.
+function M._collect_snapshot(ctx)
+    if not ctx._queries or not next(ctx._queries) then
+        return nil
+    end
+    local state = {}
+    for name, fn in pairs(ctx._queries) do
+        local ok, value = pcall(fn)
+        if ok then
+            state[name] = value
+        end
+    end
+    if next(state) == nil then
+        return nil
+    end
+    return { type = "RecordSnapshot", state = state }
 end
 
 --- Build the workflow ctx object used during replay. Each `ctx:` call
@@ -396,6 +438,38 @@ function M._make_workflow_ctx(workflow_id, history)
             task_queue = opts.task_queue or "default",
         })
         error("workflow ctx: yielded but resumed unexpectedly")
+    end
+
+    --- Register a named query handler that exposes live workflow state to
+    --- external callers via `GET /api/v1/workflows/{id}/state` (all handlers)
+    --- or `GET /api/v1/workflows/{id}/state/{name}` (one handler).
+    ---
+    --- The handler is invoked on every worker replay, after the workflow
+    --- coroutine yields or returns. Its result is serialised as JSON and
+    --- persisted as a snapshot keyed by the current event seq. Because
+    --- workflow handlers replay deterministically, the closure captures
+    --- the latest values of any local variables it references.
+    ---
+    --- Usage:
+    ---   workflow.define("Pipeline", function(ctx, input)
+    ---       local state = { stage = "init" }
+    ---       ctx:register_query("pipeline_state", function() return state end)
+    ---       state.stage = "running"
+    ---       ctx:execute_activity("step1", {})
+    ---       state.stage = "done"
+    ---   end)
+    ---
+    --- A handler that raises is dropped from the snapshot rather than
+    --- crashing the workflow — queries are a best-effort read-through.
+    function ctx:register_query(name, fn)
+        if type(name) ~= "string" or name == "" then
+            error("ctx:register_query: name must be a non-empty string")
+        end
+        if type(fn) ~= "function" then
+            error("ctx:register_query: handler must be a function")
+        end
+        self._queries = self._queries or {}
+        self._queries[name] = fn
     end
 
     --- Block until a signal with the given name arrives. Returns the

--- a/stdlib/workflow.lua
+++ b/stdlib/workflow.lua
@@ -45,6 +45,15 @@ local _activities = {}
 local _worker_id = nil
 local _auth_token = nil
 
+--- Minimal URL-encoder for query params. Covers the characters we actually
+--- emit from this stdlib: namespace names, schedule names, JSON filter
+--- payloads. Not a full RFC 3986 encoder.
+local function url_encode(s)
+    return (tostring(s):gsub("([^A-Za-z0-9%-_.~])", function(c)
+        return string.format("%%%02X", string.byte(c))
+    end))
+end
+
 --- Connect to the workflow engine.
 --- @param url string Engine URL (e.g. "http://localhost:8080")
 --- @param opts? table Optional: { token = "Bearer ..." }
@@ -118,6 +127,279 @@ function M.cancel(workflow_id)
     if resp.status ~= 200 then
         error("workflow.cancel failed: " .. (resp.body or "unknown error"))
     end
+end
+
+--- Terminate a workflow immediately with a reason (harder than cancel: no
+--- graceful handler cleanup, workflow goes straight to FAILED).
+function M.terminate(workflow_id, reason)
+    local body = reason and { reason = reason } or {}
+    local resp = M._api("POST", "/workflows/" .. workflow_id .. "/terminate", body)
+    if resp.status ~= 200 then
+        error("workflow.terminate failed: " .. (resp.body or "unknown error"))
+    end
+end
+
+--- List workflows in a namespace with optional filters.
+--- @param opts? table { namespace?, status?, type?, search_attrs?, limit?, offset? }
+--- @return table array of workflow records
+function M.list(opts)
+    opts = opts or {}
+    local params = {}
+    if opts.namespace then params[#params + 1] = "namespace=" .. url_encode(opts.namespace) end
+    if opts.status then params[#params + 1] = "status=" .. url_encode(opts.status) end
+    if opts.type then params[#params + 1] = "type=" .. url_encode(opts.type) end
+    if opts.search_attrs then
+        params[#params + 1] = "search_attrs="
+            .. url_encode(json.encode(opts.search_attrs))
+    end
+    if opts.limit then params[#params + 1] = "limit=" .. tostring(opts.limit) end
+    if opts.offset then params[#params + 1] = "offset=" .. tostring(opts.offset) end
+    local path = "/workflows"
+    if #params > 0 then path = path .. "?" .. table.concat(params, "&") end
+    local resp = M._api("GET", path)
+    if resp.status ~= 200 then
+        error("workflow.list failed: " .. (resp.body or "unknown error"))
+    end
+    return json.parse(resp.body)
+end
+
+--- Fetch the full event history of a workflow.
+function M.get_events(workflow_id)
+    local resp = M._api("GET", "/workflows/" .. workflow_id .. "/events")
+    if resp.status ~= 200 then
+        error("workflow.get_events failed: " .. (resp.body or "unknown error"))
+    end
+    return json.parse(resp.body)
+end
+
+--- Read the latest snapshot written by `ctx:register_query` handlers.
+--- With a query name, returns just that query's value. Without, returns
+--- the full snapshot table.
+--- @param workflow_id string
+--- @param name? string Specific query handler name
+--- @return table|any state or single value
+function M.get_state(workflow_id, name)
+    local path = "/workflows/" .. workflow_id .. "/state"
+    if name then path = path .. "/" .. name end
+    local resp = M._api("GET", path)
+    if resp.status == 404 then
+        return nil -- no snapshot recorded yet (or unknown query name)
+    end
+    if resp.status ~= 200 then
+        error("workflow.get_state failed: " .. (resp.body or "unknown error"))
+    end
+    return json.parse(resp.body)
+end
+
+--- List a parent workflow's child workflows.
+function M.list_children(workflow_id)
+    local resp = M._api("GET", "/workflows/" .. workflow_id .. "/children")
+    if resp.status ~= 200 then
+        error("workflow.list_children failed: " .. (resp.body or "unknown error"))
+    end
+    return json.parse(resp.body)
+end
+
+--- Close out `workflow_id` and start a fresh run with the same type,
+--- namespace, and task queue. This is the *client-side* variant of
+--- continue-as-new: called from outside the workflow handler. The
+--- worker-side `ctx:continue_as_new(input)` does the same thing from
+--- inside a workflow handler.
+--- @param workflow_id string The workflow to close out
+--- @param input? any JSON-encodable input for the new run
+--- @return table workflow record for the new run
+function M.continue_as_new(workflow_id, input)
+    local body = { input = input }
+    local resp = M._api(
+        "POST",
+        "/workflows/" .. workflow_id .. "/continue-as-new",
+        body
+    )
+    if resp.status ~= 201 then
+        error("workflow.continue_as_new failed: " .. (resp.body or "unknown error"))
+    end
+    return json.parse(resp.body)
+end
+
+-- ── Schedules ───────────────────────────────────────────────
+--- Schedule CRUD + lifecycle. Each call returns the schedule record
+--- (create/describe/patch/pause/resume) or raises on HTTP error.
+
+M.schedules = {}
+
+--- Create a new cron schedule.
+--- @param opts table {
+---   name, workflow_type, cron_expr, timezone?, input?,
+---   task_queue?, overlap_policy?, namespace?
+--- }
+function M.schedules.create(opts)
+    if not opts or not opts.name or not opts.workflow_type or not opts.cron_expr then
+        error("workflow.schedules.create: name, workflow_type, cron_expr required")
+    end
+    local resp = M._api("POST", "/schedules", opts)
+    if resp.status ~= 201 then
+        error("workflow.schedules.create failed: " .. (resp.body or "unknown error"))
+    end
+    return json.parse(resp.body)
+end
+
+--- List schedules in a namespace.
+--- @param opts? table { namespace? }
+function M.schedules.list(opts)
+    local ns = (opts and opts.namespace) or "main"
+    local resp = M._api("GET", "/schedules?namespace=" .. url_encode(ns))
+    if resp.status ~= 200 then
+        error("workflow.schedules.list failed: " .. (resp.body or "unknown error"))
+    end
+    return json.parse(resp.body)
+end
+
+--- Describe one schedule.
+function M.schedules.describe(name, opts)
+    local ns = (opts and opts.namespace) or "main"
+    local resp = M._api(
+        "GET",
+        "/schedules/" .. url_encode(name) .. "?namespace=" .. url_encode(ns)
+    )
+    if resp.status == 404 then return nil end
+    if resp.status ~= 200 then
+        error("workflow.schedules.describe failed: " .. (resp.body or "unknown error"))
+    end
+    return json.parse(resp.body)
+end
+
+--- Apply an in-place patch to a schedule. Only fields present in the
+--- patch are updated; unchanged fields keep their values.
+--- @param name string
+--- @param patch table { cron_expr?, timezone?, input?, task_queue?, overlap_policy? }
+--- @param opts? table { namespace? }
+function M.schedules.patch(name, patch, opts)
+    local ns = (opts and opts.namespace) or "main"
+    local resp = M._api(
+        "PATCH",
+        "/schedules/" .. url_encode(name) .. "?namespace=" .. url_encode(ns),
+        patch or {}
+    )
+    if resp.status ~= 200 then
+        error("workflow.schedules.patch failed: " .. (resp.body or "unknown error"))
+    end
+    return json.parse(resp.body)
+end
+
+--- Pause a schedule (the scheduler skips it until resumed).
+function M.schedules.pause(name, opts)
+    local ns = (opts and opts.namespace) or "main"
+    local resp = M._api(
+        "POST",
+        "/schedules/" .. url_encode(name) .. "/pause?namespace=" .. url_encode(ns)
+    )
+    if resp.status ~= 200 then
+        error("workflow.schedules.pause failed: " .. (resp.body or "unknown error"))
+    end
+    return json.parse(resp.body)
+end
+
+--- Resume a paused schedule. Does not backfill missed fires — next fire
+--- is whatever the cron expression says from now.
+function M.schedules.resume(name, opts)
+    local ns = (opts and opts.namespace) or "main"
+    local resp = M._api(
+        "POST",
+        "/schedules/" .. url_encode(name) .. "/resume?namespace=" .. url_encode(ns)
+    )
+    if resp.status ~= 200 then
+        error("workflow.schedules.resume failed: " .. (resp.body or "unknown error"))
+    end
+    return json.parse(resp.body)
+end
+
+--- Delete a schedule. Any in-flight workflow it triggered keeps running
+--- — deletion only stops future fires.
+function M.schedules.delete(name, opts)
+    local ns = (opts and opts.namespace) or "main"
+    local resp = M._api(
+        "DELETE",
+        "/schedules/" .. url_encode(name) .. "?namespace=" .. url_encode(ns)
+    )
+    if resp.status ~= 200 then
+        error("workflow.schedules.delete failed: " .. (resp.body or "unknown error"))
+    end
+end
+
+-- ── Namespaces ──────────────────────────────────────────────
+
+M.namespaces = {}
+
+--- Create a namespace. The endpoint returns no body on success; returns
+--- nothing from Lua on success, raises on error.
+function M.namespaces.create(name)
+    local resp = M._api("POST", "/namespaces", { name = name })
+    if resp.status ~= 201 and resp.status ~= 200 then
+        error("workflow.namespaces.create failed: " .. (resp.body or "unknown error"))
+    end
+end
+
+--- List namespaces.
+function M.namespaces.list()
+    local resp = M._api("GET", "/namespaces")
+    if resp.status ~= 200 then
+        error("workflow.namespaces.list failed: " .. (resp.body or "unknown error"))
+    end
+    return json.parse(resp.body)
+end
+
+--- Get per-namespace stats (total, running, pending, completed, failed,
+--- schedules, workers). Same endpoint as describe — the stats are the
+--- response body.
+function M.namespaces.stats(name)
+    local resp = M._api("GET", "/namespaces/" .. url_encode(name))
+    if resp.status ~= 200 then
+        error("workflow.namespaces.stats failed: " .. (resp.body or "unknown error"))
+    end
+    return json.parse(resp.body)
+end
+
+--- Alias of `stats` for symmetry with schedules.describe etc.
+function M.namespaces.describe(name)
+    return M.namespaces.stats(name)
+end
+
+--- Delete a namespace.
+function M.namespaces.delete(name)
+    local resp = M._api("DELETE", "/namespaces/" .. url_encode(name))
+    if resp.status ~= 200 then
+        error("workflow.namespaces.delete failed: " .. (resp.body or "unknown error"))
+    end
+end
+
+-- ── Workers ─────────────────────────────────────────────────
+
+M.workers = {}
+
+--- List registered workers (and their last heartbeat).
+--- @param opts? table { namespace? }
+function M.workers.list(opts)
+    local ns = (opts and opts.namespace) or "main"
+    local resp = M._api("GET", "/workers?namespace=" .. url_encode(ns))
+    if resp.status ~= 200 then
+        error("workflow.workers.list failed: " .. (resp.body or "unknown error"))
+    end
+    return json.parse(resp.body)
+end
+
+-- ── Queues ──────────────────────────────────────────────────
+
+M.queues = {}
+
+--- Pending/running activity counts per task queue.
+--- @param opts? table { namespace? }
+function M.queues.stats(opts)
+    local ns = (opts and opts.namespace) or "main"
+    local resp = M._api("GET", "/queues?namespace=" .. url_encode(ns))
+    if resp.status ~= 200 then
+        error("workflow.queues.stats failed: " .. (resp.body or "unknown error"))
+    end
+    return json.parse(resp.body)
 end
 
 --- Start listening for tasks. Blocks until cancelled.
@@ -656,6 +938,8 @@ function M._api(method, path, body)
         return http.get(url, opts)
     elseif method == "POST" then
         return http.post(url, body or {}, opts)
+    elseif method == "PATCH" then
+        return http.patch(url, body or {}, opts)
     elseif method == "DELETE" then
         return http.delete(url, opts)
     else

--- a/tests/workflow_store.rs
+++ b/tests/workflow_store.rs
@@ -28,6 +28,8 @@ fn make_workflow(id: &str, wf_type: &str) -> WorkflowRecord {
         parent_id: None,
         claimed_by: None,
         search_attributes: None,
+        archived_at: None,
+        archive_uri: None,
         created_at: ts,
         updated_at: ts,
         completed_at: None,
@@ -403,4 +405,66 @@ async fn worker_register_heartbeat_remove() {
 
     let workers = store.list_workers("main").await.unwrap();
     assert!(workers.is_empty());
+}
+
+/// F7 — list_archivable_workflows returns terminal workflows past the
+/// cutoff, and mark_archived_and_purge deletes dependent rows + retains
+/// the stub with archive_uri set.
+#[tokio::test]
+async fn archivable_list_and_purge() {
+    let store = test_store().await;
+
+    // Three workflows: one completed long ago, one completed recently,
+    // one still running. Only the first should be archivable at cutoff.
+    let mut old = make_workflow("wf-old", "Type");
+    old.status = "COMPLETED".to_string();
+    old.completed_at = Some(100.0);
+    old.updated_at = 100.0;
+    store.create_workflow(&old).await.unwrap();
+    store
+        .append_event(&WorkflowEvent {
+            id: None,
+            workflow_id: "wf-old".to_string(),
+            seq: 1,
+            event_type: "WorkflowStarted".to_string(),
+            payload: None,
+            timestamp: 100.0,
+        })
+        .await
+        .unwrap();
+
+    let mut recent = make_workflow("wf-recent", "Type");
+    recent.status = "COMPLETED".to_string();
+    recent.completed_at = Some(now());
+    store.create_workflow(&recent).await.unwrap();
+
+    let running = make_workflow("wf-running", "Type");
+    store.create_workflow(&running).await.unwrap();
+
+    // Cutoff between the old and recent ones → only `wf-old` matches.
+    let archivable = store
+        .list_archivable_workflows(now() - 1.0, 10)
+        .await
+        .unwrap();
+    let ids: Vec<&str> = archivable.iter().map(|w| w.id.as_str()).collect();
+    assert_eq!(ids, vec!["wf-old"]);
+
+    // Purge + stub: row remains, events cleared, archive_uri set.
+    store
+        .mark_archived_and_purge("wf-old", "s3://bucket/wf-old.json", now())
+        .await
+        .unwrap();
+
+    let stub = store.get_workflow("wf-old").await.unwrap().unwrap();
+    assert!(stub.archived_at.is_some());
+    assert_eq!(stub.archive_uri.as_deref(), Some("s3://bucket/wf-old.json"));
+
+    let events = store.list_events("wf-old").await.unwrap();
+    assert!(events.is_empty(), "events should be purged");
+
+    // Running + recent workflows untouched
+    let running_still = store.get_workflow("wf-running").await.unwrap().unwrap();
+    assert!(running_still.archived_at.is_none());
+    let recent_still = store.get_workflow("wf-recent").await.unwrap().unwrap();
+    assert!(recent_still.archived_at.is_none());
 }

--- a/tests/workflow_store.rs
+++ b/tests/workflow_store.rs
@@ -27,6 +27,7 @@ fn make_workflow(id: &str, wf_type: &str) -> WorkflowRecord {
         error: None,
         parent_id: None,
         claimed_by: None,
+        search_attributes: None,
         created_at: ts,
         updated_at: ts,
         completed_at: None,
@@ -72,20 +73,23 @@ async fn workflow_list_filter_by_status() {
         .unwrap();
 
     let running = store
-        .list_workflows("main", Some(WorkflowStatus::Running), None, 100, 0)
+        .list_workflows("main", Some(WorkflowStatus::Running), None, None, 100, 0)
         .await
         .unwrap();
     assert_eq!(running.len(), 1);
     assert_eq!(running[0].id, "wf-1");
 
     let pending = store
-        .list_workflows("main", Some(WorkflowStatus::Pending), None, 100, 0)
+        .list_workflows("main", Some(WorkflowStatus::Pending), None, None, 100, 0)
         .await
         .unwrap();
     assert_eq!(pending.len(), 1);
     assert_eq!(pending[0].id, "wf-2");
 
-    let all = store.list_workflows("main", None, None, 100, 0).await.unwrap();
+    let all = store
+        .list_workflows("main", None, None, None, 100, 0)
+        .await
+        .unwrap();
     assert_eq!(all.len(), 2);
 }
 
@@ -323,6 +327,7 @@ async fn schedule_crud() {
             namespace: "main".to_string(),
             workflow_type: "IngestData".to_string(),
             cron_expr: "0 * * * *".to_string(),
+            timezone: "UTC".to_string(),
             input: None,
             task_queue: "main".to_string(),
             overlap_policy: "skip".to_string(),


### PR DESCRIPTION
## Summary

v0.11.3 release bundle. Four layers of work shipping together:

1. **Engine features** (plan 04) — seven additive capabilities in the workflow engine
2. **Lua stdlib completeness** (plan 06) — `assay.workflow` gains 1:1 parity with the REST API
3. **CLI fill-stubs** (plan 06) — turn the v0.11.2 parser-only stubs into real commands
4. **Full CLI surface** (plan 05) — config file, output formats, shell completion, wait, events, namespace/worker/queue trees, JSON input indirection

## Engine features

- **`ctx:register_query`** — live workflow state via `GET /workflows/{id}/state[/{name}]`
- **`ctx:continue_as_new`** Lua surface — close out and restart with empty event history
- **`ctx:execute_parallel`** — batch-scheduled activities run concurrently
- **Search attributes** — settable at start, updatable at runtime, filterable via `?search_attrs=...`
- **Schedule `PATCH` / `pause` / `resume`** — in-place schedule updates
- **Cron timezone** — IANA timezone field on schedules (`chrono-tz`)
- **Optional S3 archival** — `s3-archival` cargo feature + env-var config

## Lua stdlib additions

New top-level client ops: `workflow.list`, `terminate`, `get_events`, `get_state`, `list_children`, `continue_as_new` (client-side).

New sub-tables:
- `workflow.schedules.{create, list, describe, patch, pause, resume, delete}`
- `workflow.namespaces.{create, list, describe, stats, delete}`
- `workflow.workers.list` / `workflow.queues.stats`

## Full CLI

Every subcommand runs for real — no stubs anywhere in the tree.

```
assay workflow
  start --type T [--id] [--input JSON] [--queue] [--search-attrs JSON]
  list [--status] [--type] [--search-attrs JSON] [--limit]
  describe <id>
  state <id> [<query-name>]              # register_query reader
  events <id> [--follow]                 # GET + poll-stream-until-terminal
  children <id>
  signal <id> <name> [payload-as-json-or-@file-or--]
  cancel <id>
  terminate <id> [--reason]
  continue-as-new <id> [--input]         # client-side
  wait <id> [--timeout] [--target]       # exit 0/1/2 for scripts

assay schedule
  list / describe / create / patch / pause / resume / delete
  (create supports --timezone; patch is new in v0.11.3)

assay namespace   create | list | describe | delete
assay worker      list
assay queue       stats
assay completion  <bash|zsh|fish|powershell|elvish>
```

**Global options** — flag / env / config-file / default precedence:
- `--engine-url` / `ASSAY_ENGINE_URL` (default `http://127.0.0.1:8080`)
- `--api-key` / `ASSAY_API_KEY` (bearer token)
- `--namespace` / `ASSAY_NAMESPACE` (default `main`)
- `--output` / `ASSAY_OUTPUT` — `table` / `json` / `jsonl` / `yaml`; TTY-adaptive default
- `--config` / `ASSAY_CONFIG_FILE` — YAML config file

**Config file** — discovery order: flag → env → `\$XDG_CONFIG_HOME/assay/config.yaml` → `~/.config/assay/config.yaml` → `/etc/assay/config.yaml`. Fields: `engine_url`, `api_key`, `api_key_file` (preferred — keeps the secret out of the committed config), `namespace`, `output`.

**JSON input anywhere** — `--input`/`--search-attrs`/signal payload accept literal JSON, `@file.json`, or `-` for stdin.

**Exit codes:** 0 success · 1 HTTP/not-found/unreachable · 2 `workflow wait` timeout · 64 usage error.

**Shell completion** — `assay completion <shell> > /etc/bash_completion.d/assay` (or the zsh/fish equivalent). Graceful SIGPIPE so `| head` doesn't panic. Adds one crate dep: `clap_complete`.

## Breaking for crate embedders

- `Engine::start_workflow` gains `search_attributes: Option<&str>`
- `WorkflowStore::list_workflows` gains `search_attrs_filter: Option<&str>`
- `WorkflowRecord` gains `search_attributes`, `archived_at`, `archive_uri`
- `WorkflowSchedule` gains `timezone`

REST callers unaffected — all new fields optional on request bodies.

## Schema migrations

Both SQLite and Postgres pick up new columns idempotently — Postgres via `ADD COLUMN IF NOT EXISTS`, SQLite via `pragma_table_info` pre-check before `ALTER TABLE ADD COLUMN`. Fresh installs get them from `CREATE TABLE` and the ALTERs are no-ops.

## Tests

**36 orchestration tests** (end-to-end, real assay subprocess + engine):
- Register_query, continue_as_new, execute_parallel, search attributes, Lua stdlib management surface round-trip
- 13 CLI integration tests: workflow list/describe/start/wait; schedule full lifecycle + patch; namespace lifecycle; worker/queue empty; output formats (table/json/jsonl/yaml) round-trip; stdin input; config file supplies URL; completion generates for bash/zsh/fish/powershell/elvish

**API-level tests:** schedule patch/pause/resume happy path + 404 + invalid tz.
**Unit tests:** scheduler timezone (4), config precedence + api_key_file trim (5), output format parsing, input indirection.
**Store-level:** archival cutoff + transactional purge.

`cargo test` green. `cargo clippy --all-targets -- -D warnings` clean. `cargo build --features s3-archival` green.

## Plan docs

- `.claude/plans/04-v0.11.3-workflow-enhancements.md` — engine features
- `.claude/plans/05-v0.11.3-cli-subcommands.md` — comprehensive CLI design (now fully implemented)
- `.claude/plans/06-v0.11.3-stdlib-completeness-and-cli-fill.md` — stdlib + CLI fill-stubs milestone

## Philosophy note

Going forward: features land fully across every layer (clap → REST → store → Lua) before merge, or stay hidden entirely until they do. This PR is the last place in the codebase with "not yet implemented" stubs — they're all gone now.