### PR TITLE
feat(auth): combined JWT + API-key mode for assay serve (v0.11.4)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,33 @@ This applies to all files in the repo: `stdlib/`, `src/`, `tests/`, `*.md`, `*.h
 `CHANGELOG.md`, and any commit/PR text. The only legitimate exception is the copyright holder's name
 in `LICENSE`/`NOTICE`/`CLA.md`.
 
+## Release docs checklist
+
+Every release (patch, minor, or major) must update **all** of the following before the PR merges —
+never ship a release that only touches source + CHANGELOG. The site and llms.txt drift silently if
+you forget them, and agents downstream (including future-you) see stale information.
+
+- `Cargo.toml` — bump `version` under `[package]`.
+- `CHANGELOG.md` — new section at the top; describe the OIDC/Kubernetes/HTTP scenario enabled, not a
+  specific consumer.
+- `docs/modules/*.md` — any module whose surface changed.
+- `README.md`, `SKILL.md`, `AGENTS.md`, `skills/assay/SKILL.md` — auth / CLI / API tables if touched.
+- `llms.txt` (root) — one-liner module descriptors.
+- `site/pages/index.html` — the release banner (`v0.x.y` tag + copy) and any version badge on
+  feature cards (e.g. the Workflow Engine card).
+- `site/static/llms.txt` — this is the site's static teaser; keep it reasonably fresh (it's not
+  auto-generated from the root `llms.txt`).
+- Any site page that references the previous version in prose or code (e.g. the
+  `mise` / `crates.io` install snippets on `index.html`).
+
+Verify with a grep for the previous version before opening the PR:
+
+```sh
+grep -rn "v0.PREVIOUS" . --include="*.md" --include="*.html" --include="*.toml" --include="*.txt"
+```
+
+The only matches that should remain are historical CHANGELOG entries.
+
 ## What is Assay
 
 General-purpose enhanced Lua runtime. Single ~11 MB static binary with batteries included: HTTP

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 All notable changes to Assay are documented here.
 
+## [0.11.4] - 2026-04-17
+
+### Added
+
+- **Combined JWT + API-key authentication for `assay serve`.** `--auth-issuer` and
+  `--auth-api-key` can now be set on the same invocation. When both are enabled, the
+  auth middleware dispatches on token shape:
+
+  - Bearer tokens that parse as a JWS header are validated against the OIDC issuer's
+    JWKS.
+  - Bearer tokens that are not JWT-shaped are hashed and looked up in the API-key
+    store.
+
+  A semantically-invalid JWT (expired, wrong issuer / audience, forged signature) is
+  rejected on the JWT path and is **not** retried as an API key — a token that looks
+  like a JWT is treated as a JWT. This lets a single server accept short-lived OIDC
+  user tokens from a browser session and long-lived machine API keys from a CI job
+  without the caller picking a mode up front.
+
+### Changed
+
+- **`AuthMode` is now a struct** (`api_key: bool`, `jwt: Option<JwtConfig>`) instead of
+  an enum with three variants. Library constructors are unchanged in shape —
+  `AuthMode::no_auth()`, `AuthMode::api_key()`, `AuthMode::jwt(issuer, audience)` — and
+  a new `AuthMode::combined(issuer, audience)` enables both paths. `AuthMode::is_enabled()`
+  replaces `!matches!(.., NoAuth)` call sites.
+
+  Breaking for downstream Rust consumers that matched on `AuthMode::NoAuth | ApiKey |
+  Jwt { .. }`. The `assay` binary and REST / dashboard users are unaffected.
+
+### Docs
+
+- `docs/modules/workflow.md` auth table adds the combined-mode row and documents the
+  token-shape dispatch rule.
+
 ## [0.11.3] - 2026-04-16
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,7 @@ checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "assay-lua"
-version = "0.11.3"
+version = "0.11.4"
 dependencies = [
  "anyhow",
  "assay-workflow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "crates/assay-workflow"]
 
 [package]
 name = "assay-lua"
-version = "0.11.3"
+version = "0.11.4"
 categories = ["command-line-utilities", "development-tools::testing"]
 edition = "2024"
 homepage = "https://assay.rs"

--- a/crates/assay-workflow/src/api/auth.rs
+++ b/crates/assay-workflow/src/api/auth.rs
@@ -19,26 +19,83 @@ const JWKS_CACHE_TTL: Duration = Duration::from_secs(300); // 5 minutes
 
 // ── Auth Mode ───────────────────────────────────────────────
 
-/// Auth configuration — determines which mode the engine runs in.
+/// Auth configuration for the engine's HTTP API.
+///
+/// Both authentication methods (JWT and API key) can be enabled at the same time.
+/// When both are enabled, the middleware dispatches on token shape — tokens that
+/// parse as a JWS header are validated as JWTs, everything else is validated as
+/// an API key. This lets the same server accept long-lived machine API keys
+/// alongside short-lived OIDC-issued user tokens without the caller picking a
+/// mode up front.
 #[derive(Clone, Debug, Default)]
-pub enum AuthMode {
-    /// No authentication — all requests allowed (dev mode).
-    #[default]
-    NoAuth,
-    /// API key authentication — Bearer token validated against hashed keys in DB.
-    ApiKey,
-    /// JWT/OIDC — validate Bearer JWT signature against JWKS from the issuer.
-    Jwt {
-        issuer: String,
-        audience: Option<String>,
-        jwks_cache: Arc<JwksCache>,
-    },
+pub struct AuthMode {
+    /// API-key authentication enabled. When true, Bearer tokens that are not
+    /// JWT-shaped are validated against the `api_keys` table.
+    pub api_key: bool,
+    /// JWT authentication enabled. When set, Bearer tokens that parse as a
+    /// JWS header are validated against the issuer's JWKS.
+    pub jwt: Option<JwtConfig>,
+}
+
+/// JWT validation configuration.
+#[derive(Clone, Debug)]
+pub struct JwtConfig {
+    pub issuer: String,
+    pub audience: Option<String>,
+    pub jwks_cache: Arc<JwksCache>,
 }
 
 impl AuthMode {
-    /// Create a JWT auth mode that fetches JWKS from the issuer's OIDC discovery.
+    /// Open access — no authentication. All requests allowed.
+    pub fn no_auth() -> Self {
+        Self::default()
+    }
+
+    /// JWT/OIDC only. Tokens are validated against the issuer's JWKS.
     pub fn jwt(issuer: String, audience: Option<String>) -> Self {
-        Self::Jwt {
+        Self {
+            api_key: false,
+            jwt: Some(JwtConfig::new(issuer, audience)),
+        }
+    }
+
+    /// API key only. Bearer tokens are hashed and looked up in the store.
+    pub fn api_key() -> Self {
+        Self {
+            api_key: true,
+            jwt: None,
+        }
+    }
+
+    /// Both JWT and API key. Tokens that parse as JWTs take the JWT path;
+    /// everything else takes the API-key path.
+    pub fn combined(issuer: String, audience: Option<String>) -> Self {
+        Self {
+            api_key: true,
+            jwt: Some(JwtConfig::new(issuer, audience)),
+        }
+    }
+
+    /// True if any authentication method is enabled.
+    pub fn is_enabled(&self) -> bool {
+        self.api_key || self.jwt.is_some()
+    }
+
+    /// Human-readable summary for startup logging.
+    pub fn describe(&self) -> String {
+        match (self.jwt.as_ref(), self.api_key) {
+            (None, false) => "no-auth (open access)".to_string(),
+            (None, true) => "api-key".to_string(),
+            (Some(c), false) => format!("jwt (issuer: {})", c.issuer),
+            (Some(c), true) => format!("jwt (issuer: {}) + api-key", c.issuer),
+        }
+    }
+}
+
+impl JwtConfig {
+    /// Build a JwtConfig with a fresh JWKS cache pointed at `issuer`'s OIDC discovery endpoint.
+    pub fn new(issuer: String, audience: Option<String>) -> Self {
+        Self {
             jwks_cache: Arc::new(JwksCache::new(issuer.clone())),
             issuer,
             audience,
@@ -196,19 +253,46 @@ fn find_key_in_set(jwks: &JwkSet, kid: &str) -> Option<DecodingKey> {
 // ── Middleware ───────────────────────────────────────────────
 
 /// Axum middleware that enforces authentication based on the configured mode.
+///
+/// When both JWT and API-key auth are enabled, dispatch is based on token shape:
+/// if the Bearer token parses as a JWS header it takes the JWT path, otherwise
+/// the API-key path. A semantically-invalid JWT (expired, forged signature, wrong
+/// audience) is rejected and is *not* retried as an API key — a token that looks
+/// like a JWT is treated as a JWT.
 pub async fn auth_middleware<S: WorkflowStore>(
     State(state): State<Arc<AppState<S>>>,
     request: Request,
     next: Next,
 ) -> Response {
-    match &state.auth_mode {
-        AuthMode::NoAuth => next.run(request).await,
-        AuthMode::ApiKey => validate_api_key(state, request, next).await,
-        AuthMode::Jwt {
-            issuer,
-            audience,
-            jwks_cache,
-        } => validate_jwt(issuer, audience.as_deref(), jwks_cache, request, next).await,
+    let auth = &state.auth_mode;
+
+    if !auth.is_enabled() {
+        return next.run(request).await;
+    }
+
+    let token = match extract_bearer(&request) {
+        Some(t) => t,
+        None => return auth_error("Missing Authorization: Bearer <token>"),
+    };
+
+    if jsonwebtoken::decode_header(token).is_ok() {
+        match &auth.jwt {
+            Some(jwt) => {
+                validate_jwt(
+                    &jwt.issuer,
+                    jwt.audience.as_deref(),
+                    &jwt.jwks_cache,
+                    request,
+                    next,
+                )
+                .await
+            }
+            None => auth_error("JWT authentication is not enabled on this server"),
+        }
+    } else if auth.api_key {
+        validate_api_key(state, request, next).await
+    } else {
+        auth_error("Token is not a valid JWT and API-key authentication is not enabled")
     }
 }
 

--- a/crates/assay-workflow/src/api/mod.rs
+++ b/crates/assay-workflow/src/api/mod.rs
@@ -38,7 +38,7 @@ pub struct AppState<S: WorkflowStore> {
 
 /// Build the full API router.
 pub fn router<S: WorkflowStore + 'static>(state: Arc<AppState<S>>) -> Router {
-    let needs_auth = !matches!(state.auth_mode, AuthMode::NoAuth);
+    let needs_auth = state.auth_mode.is_enabled();
 
     let api = Router::new()
         .nest("/api/v1", api_v1_router())
@@ -96,11 +96,7 @@ pub async fn serve_with_version<S: WorkflowStore + 'static>(
 ) -> anyhow::Result<()> {
     let (event_tx, _) = broadcast::channel(1024);
 
-    let mode_desc = match &auth_mode {
-        AuthMode::NoAuth => "no-auth (open access)".to_string(),
-        AuthMode::ApiKey => "api-key".to_string(),
-        AuthMode::Jwt { issuer, .. } => format!("jwt (issuer: {issuer})"),
-    };
+    let mode_desc = auth_mode.describe();
 
     let state = Arc::new(AppState {
         engine: Arc::new(engine),

--- a/crates/assay-workflow/tests/api_integration.rs
+++ b/crates/assay-workflow/tests/api_integration.rs
@@ -11,7 +11,7 @@ async fn start_test_server() -> (String, tokio::task::JoinHandle<()>) {
     let state = Arc::new(assay_workflow::api::AppState {
         engine: Arc::new(engine),
         event_tx,
-        auth_mode: assay_workflow::api::auth::AuthMode::NoAuth,
+        auth_mode: assay_workflow::api::auth::AuthMode::no_auth(),
         binary_version: None,
     });
 

--- a/crates/assay-workflow/tests/auth_test.rs
+++ b/crates/assay-workflow/tests/auth_test.rs
@@ -1,4 +1,4 @@
-use assay_workflow::api::auth::{generate_api_key, hash_api_key, AuthMode, JwksCache};
+use assay_workflow::api::auth::{generate_api_key, hash_api_key, AuthMode, JwksCache, JwtConfig};
 use assay_workflow::{Engine, SqliteStore, WorkflowStore};
 use jsonwebtoken::jwk::{
     CommonParameters, Jwk, JwkSet, KeyAlgorithm, PublicKeyUse, RSAKeyParameters, RSAKeyType,
@@ -90,27 +90,36 @@ fn sign_jwt(keys: &TestKeys, claims: &serde_json::Value) -> String {
     jsonwebtoken::encode(&header, claims, &keys.encoding_key).unwrap()
 }
 
-fn jwt_auth_mode(keys: &TestKeys) -> AuthMode {
+fn jwt_config(keys: &TestKeys, audience: Option<&str>) -> JwtConfig {
     let cache = JwksCache::with_jwks(
         "https://auth.example.com".to_string(),
         keys.jwk_set.clone(),
     );
-    AuthMode::Jwt {
+    JwtConfig {
         issuer: "https://auth.example.com".to_string(),
-        audience: None,
+        audience: audience.map(|s| s.to_string()),
         jwks_cache: Arc::new(cache),
     }
 }
 
+fn jwt_auth_mode(keys: &TestKeys) -> AuthMode {
+    AuthMode {
+        api_key: false,
+        jwt: Some(jwt_config(keys, None)),
+    }
+}
+
 fn jwt_auth_mode_with_audience(keys: &TestKeys, audience: &str) -> AuthMode {
-    let cache = JwksCache::with_jwks(
-        "https://auth.example.com".to_string(),
-        keys.jwk_set.clone(),
-    );
-    AuthMode::Jwt {
-        issuer: "https://auth.example.com".to_string(),
-        audience: Some(audience.to_string()),
-        jwks_cache: Arc::new(cache),
+    AuthMode {
+        api_key: false,
+        jwt: Some(jwt_config(keys, Some(audience))),
+    }
+}
+
+fn combined_auth_mode(keys: &TestKeys) -> AuthMode {
+    AuthMode {
+        api_key: true,
+        jwt: Some(jwt_config(keys, None)),
     }
 }
 
@@ -126,7 +135,7 @@ fn future_exp() -> u64 {
 
 #[tokio::test]
 async fn no_auth_allows_all_requests() {
-    let (url, _h) = start_server(AuthMode::NoAuth).await;
+    let (url, _h) = start_server(AuthMode::no_auth()).await;
 
     let resp = client()
         .get(format!("{url}/api/v1/health"))
@@ -147,7 +156,7 @@ async fn no_auth_allows_all_requests() {
 
 #[tokio::test]
 async fn api_key_rejects_no_token() {
-    let (url, _h) = start_server(AuthMode::ApiKey).await;
+    let (url, _h) = start_server(AuthMode::api_key()).await;
 
     let resp = client()
         .get(format!("{url}/api/v1/workflows"))
@@ -159,7 +168,7 @@ async fn api_key_rejects_no_token() {
 
 #[tokio::test]
 async fn api_key_rejects_invalid_key() {
-    let (url, _h) = start_server(AuthMode::ApiKey).await;
+    let (url, _h) = start_server(AuthMode::api_key()).await;
 
     let resp = client()
         .get(format!("{url}/api/v1/workflows"))
@@ -185,7 +194,7 @@ async fn api_key_accepts_valid_key() {
         .await
         .unwrap();
 
-    let (url, _h) = start_server_with_store(store, AuthMode::ApiKey).await;
+    let (url, _h) = start_server_with_store(store, AuthMode::api_key()).await;
 
     let resp = client()
         .get(format!("{url}/api/v1/workflows"))
@@ -356,4 +365,143 @@ async fn jwt_rejects_different_rsa_key() {
         .await
         .unwrap();
     assert_eq!(resp.status(), 401);
+}
+
+// ── Combined mode (JWT + API key on the same server) ─────────
+
+#[tokio::test]
+async fn combined_accepts_valid_jwt() {
+    let keys = generate_test_rsa_keys();
+    let (url, _h) = start_server(combined_auth_mode(&keys)).await;
+
+    let token = sign_jwt(
+        &keys,
+        &serde_json::json!({
+            "iss": "https://auth.example.com",
+            "exp": future_exp(),
+            "sub": "user-1",
+        }),
+    );
+
+    let resp = client()
+        .get(format!("{url}/api/v1/workflows"))
+        .header("Authorization", format!("Bearer {token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+}
+
+#[tokio::test]
+async fn combined_accepts_valid_api_key() {
+    let keys = generate_test_rsa_keys();
+    let store = SqliteStore::new("sqlite::memory:").await.unwrap();
+
+    let api_key = generate_api_key();
+    let hash = hash_api_key(&api_key);
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs_f64();
+    store
+        .create_api_key(&hash, "assay_test...", None, now)
+        .await
+        .unwrap();
+
+    let (url, _h) = start_server_with_store(store, combined_auth_mode(&keys)).await;
+
+    let resp = client()
+        .get(format!("{url}/api/v1/workflows"))
+        .header("Authorization", format!("Bearer {api_key}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+}
+
+#[tokio::test]
+async fn combined_rejects_missing_token() {
+    let keys = generate_test_rsa_keys();
+    let (url, _h) = start_server(combined_auth_mode(&keys)).await;
+
+    let resp = client()
+        .get(format!("{url}/api/v1/workflows"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 401);
+}
+
+#[tokio::test]
+async fn combined_rejects_garbage_token() {
+    let keys = generate_test_rsa_keys();
+    let (url, _h) = start_server(combined_auth_mode(&keys)).await;
+
+    // Not JWT-shaped, not a stored API key — should fail the API-key lookup.
+    let resp = client()
+        .get(format!("{url}/api/v1/workflows"))
+        .header("Authorization", "Bearer assay_not_a_real_key_abcd")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 401);
+}
+
+#[tokio::test]
+async fn combined_rejects_expired_jwt_without_api_key_fallback() {
+    // An expired JWT is JWT-shaped, so the middleware takes the JWT path
+    // and rejects it there — it must NOT silently be retried as an API key.
+    let keys = generate_test_rsa_keys();
+    let (url, _h) = start_server(combined_auth_mode(&keys)).await;
+
+    let token = sign_jwt(
+        &keys,
+        &serde_json::json!({
+            "iss": "https://auth.example.com",
+            "exp": 1_000_000_000u64, // 2001 — long expired
+        }),
+    );
+
+    let resp = client()
+        .get(format!("{url}/api/v1/workflows"))
+        .header("Authorization", format!("Bearer {token}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 401);
+}
+
+// ── AuthMode helpers ─────────────────────────────────────────
+
+#[test]
+fn describe_no_auth() {
+    assert_eq!(AuthMode::no_auth().describe(), "no-auth (open access)");
+}
+
+#[test]
+fn describe_api_key_only() {
+    assert_eq!(AuthMode::api_key().describe(), "api-key");
+}
+
+#[test]
+fn describe_jwt_only() {
+    let m = AuthMode::jwt("https://auth.example.com".to_string(), None);
+    assert_eq!(m.describe(), "jwt (issuer: https://auth.example.com)");
+}
+
+#[test]
+fn describe_combined() {
+    let m = AuthMode::combined("https://auth.example.com".to_string(), None);
+    assert_eq!(
+        m.describe(),
+        "jwt (issuer: https://auth.example.com) + api-key"
+    );
+}
+
+#[test]
+fn is_enabled_reflects_state() {
+    assert!(!AuthMode::no_auth().is_enabled());
+    assert!(AuthMode::api_key().is_enabled());
+    assert!(AuthMode::jwt("https://auth.example.com".to_string(), None).is_enabled());
+    assert!(AuthMode::combined("https://auth.example.com".to_string(), None).is_enabled());
 }

--- a/crates/assay-workflow/tests/orchestration.rs
+++ b/crates/assay-workflow/tests/orchestration.rs
@@ -20,7 +20,7 @@ async fn start_test_server() -> (String, tokio::task::JoinHandle<()>) {
     let state = Arc::new(assay_workflow::api::AppState {
         engine: Arc::new(engine),
         event_tx,
-        auth_mode: assay_workflow::api::auth::AuthMode::NoAuth,
+        auth_mode: assay_workflow::api::auth::AuthMode::no_auth(),
         binary_version: None,
     });
 

--- a/docs/modules/workflow.md
+++ b/docs/modules/workflow.md
@@ -31,13 +31,26 @@ assay serve --backend postgres://u:p@h:5432/assay     # Postgres (multi-instance
 DATABASE_URL=postgres://... assay serve               # backend from env (keeps creds out of argv)
 ```
 
-Auth modes (mutually exclusive):
+Auth modes:
 
 | Flag                                        | Behaviour                                                                                                                                         |
 | ------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--no-auth` (default)                       | Open access. Use only behind a trusted gateway.                                                                                                   |
 | `--auth-api-key`                            | Clients send `Authorization: Bearer <key>`. Manage keys with `--generate-api-key` / `--list-api-keys`. Keys are SHA256-hashed at rest.            |
 | `--auth-issuer <url> --auth-audience <aud>` | JWT/OIDC. Fetches and caches the issuer's JWKS to validate signatures. Works with Auth0, Okta, Dex, Keycloak, Cloudflare Access, any OIDC issuer. |
+| `--auth-api-key` + `--auth-issuer …`        | Combined. Tokens that parse as a JWS header take the JWT path; everything else takes the API-key path. Same server accepts both token types on `Authorization: Bearer`. |
+
+**Combined mode dispatch** (when both `--auth-issuer` and `--auth-api-key` are set):
+
+- `Authorization: Bearer <jwt>` — validated against JWKS. Rejected if expired / wrong
+  issuer / wrong audience / bad signature. A semantically-invalid JWT is **not** silently
+  retried as an API key.
+- `Authorization: Bearer <api-key>` — hashed and looked up in the store.
+- `Authorization: Bearer <garbage>` — 401.
+
+Combined mode lets the same server serve short-lived OIDC user tokens (from a browser
+session) alongside long-lived machine API keys (from a CI job) without the caller picking
+a mode up front.
 
 **Multi-instance deployment.** SQLite is single-instance only (engine takes an `engine_lock` row at
 startup). For Kubernetes / Docker Swarm, use Postgres: the cron scheduler picks a leader via

--- a/llms.txt
+++ b/llms.txt
@@ -64,7 +64,7 @@
 - [assay.healthcheck](https://assay.rs/modules/healthcheck.html): HTTP health checks, JSON path, latency
 
 ## Workflow Engine
-- [assay.workflow](https://assay.rs/modules/workflow.html): Durable workflow engine — `assay serve` runs engine with REST+SSE+dashboard; `require("assay.workflow")` registers handlers + exposes full management surface (list/start/signal/cancel/terminate/state/events/children/continue-as-new plus `.schedules`/`.namespaces`/`.workers`/`.queues` sub-tables). Deterministic replay, Postgres/SQLite backend, Ory-compatible JWT/API-key auth, optional S3 archival.
+- [assay.workflow](https://assay.rs/modules/workflow.html): Durable workflow engine — `assay serve` runs engine with REST+SSE+dashboard; `require("assay.workflow")` registers handlers + exposes full management surface (list/start/signal/cancel/terminate/state/events/children/continue-as-new plus `.schedules`/`.namespaces`/`.workers`/`.queues` sub-tables). Deterministic replay, Postgres/SQLite backend, Ory-compatible JWT/API-key auth (both modes can be enabled on the same server; middleware dispatches on token shape), optional S3 archival.
 - [assay CLI](https://assay.rs/modules/workflow.html#cli): `assay workflow/schedule/namespace/worker/queue/completion` subcommands over the engine's REST API. Config file + env vars + flags; output formats table/json/jsonl/yaml with TTY-adaptive default; JSON input indirection (@file, stdin, literal).
 
 ## AI Agent

--- a/site/pages/index.html
+++ b/site/pages/index.html
@@ -12,10 +12,10 @@
 
 
   <main>
-    <!-- v0.11.3 release banner -->
+    <!-- v0.11.4 release banner -->
     <a href="changelog.html" class="release-banner">
-      <span class="release-banner-tag">v0.11.3</span>
-      <span class="release-banner-text">Workflow engine enhancements — register_query, parallel activities, search attributes, schedule PATCH + timezone, full CLI (config file, wait, completion), tier-1 operator dashboard</span>
+      <span class="release-banner-tag">v0.11.4</span>
+      <span class="release-banner-text">Combined JWT + API-key authentication for <code>assay serve</code> — run both auth modes on the same server; middleware dispatches on token shape</span>
       <span class="release-banner-arrow">&rarr;</span>
     </a>
 
@@ -147,7 +147,7 @@
     <h2>Core Capabilities</h2>
     <section style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1.5rem; margin-bottom: 2rem;">
       <div class="card card-highlight">
-        <h3 style="margin-top: 0;">Workflow Engine <span style="color: var(--accent); font-size: 0.7rem; font-weight: 700; vertical-align: middle; padding: 2px 6px; border: 1px solid var(--accent); border-radius: 4px;">v0.11.3</span></h3>
+        <h3 style="margin-top: 0;">Workflow Engine <span style="color: var(--accent); font-size: 0.7rem; font-weight: 700; vertical-align: middle; padding: 2px 6px; border: 1px solid var(--accent); border-radius: 4px;">v0.11.4</span></h3>
         <p class="text-muted">Native durable workflow engine with deterministic-replay runtime. Activities (sequential + parallel), signals, durable timers, child workflows, side effects, live state via <code>ctx:register_query</code>, search attributes, optional S3 archival. Crash-safe by replay — workers can die mid-flight without losing work or duplicating side effects.</p>
         <pre style="margin-bottom: 0;"><code>workflow.define("Deploy", function(ctx, in)
   local img = ctx:execute_activity("build", in)
@@ -299,7 +299,7 @@ cargo install assay-lua
 
     <h3>mise</h3>
     <pre><code># .mise.toml
-"github:developerinlondon/assay" = "v0.11.3"</code></pre>
+"github:developerinlondon/assay" = "v0.11.4"</code></pre>
 
   </main>
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,13 +99,15 @@ enum Commands {
         /// Disable authentication (open access, default)
         #[arg(long)]
         no_auth: bool,
-        /// OIDC issuer URL for JWT validation
+        /// OIDC issuer URL for JWT validation. May be combined with `--auth-api-key`:
+        /// tokens that parse as JWTs take the JWT path, everything else the API-key path.
         #[arg(long)]
         auth_issuer: Option<String>,
-        /// Expected JWT audience
+        /// Expected JWT audience (required only when your tokens set the `aud` claim).
         #[arg(long)]
         auth_audience: Option<String>,
-        /// Enable API key authentication mode
+        /// Enable API-key authentication. May be combined with `--auth-issuer` to run both
+        /// modes simultaneously (see `--auth-issuer`).
         #[arg(long)]
         auth_api_key: bool,
         /// Generate a new API key and exit
@@ -508,15 +510,18 @@ async fn main() -> ExitCode {
             generate_api_key,
             list_api_keys,
         }) => {
-            let auth_mode = if let Some(issuer) = auth_issuer {
-                assay_workflow::api::auth::AuthMode::jwt(issuer, auth_audience)
-            } else if auth_api_key {
-                assay_workflow::api::auth::AuthMode::ApiKey
-            } else {
-                assay_workflow::api::auth::AuthMode::NoAuth
+            let auth_mode = match (auth_issuer, auth_api_key) {
+                (Some(issuer), true) => {
+                    assay_workflow::api::auth::AuthMode::combined(issuer, auth_audience)
+                }
+                (Some(issuer), false) => {
+                    assay_workflow::api::auth::AuthMode::jwt(issuer, auth_audience)
+                }
+                (None, true) => assay_workflow::api::auth::AuthMode::api_key(),
+                (None, false) => assay_workflow::api::auth::AuthMode::no_auth(),
             };
 
-            if no_auth && !matches!(auth_mode, assay_workflow::api::auth::AuthMode::NoAuth) {
+            if no_auth && auth_mode.is_enabled() {
                 eprintln!("Warning: --no-auth is redundant when --auth-issuer or --auth-api-key is set");
             }
 


### PR DESCRIPTION
## Summary

- Allow `--auth-issuer` and `--auth-api-key` together on `assay serve`. When both are set, the auth middleware dispatches on token shape: tokens that parse as a JWS header take the JWT path, everything else takes the API-key path.
- A semantically-invalid JWT (expired, wrong issuer/audience, forged signature) is rejected on the JWT path and is **not** silently retried as an API key.
- Lets one server serve short-lived OIDC user tokens (browser session) and long-lived machine API keys (CI job) without the caller picking a mode up front.

## Why

Running a single workflow engine behind OIDC is easy. Running the same engine from CI (where OIDC flows are awkward and a long-lived token is simpler) is also easy. Running *both* against the same engine required either separate deployments or a front-door proxy that translated between modes. Combined mode collapses that into one server with no breaking change for existing single-mode deployments.

## What changed

### Engine — `crates/assay-workflow`

- `AuthMode` refactored from enum (`NoAuth | ApiKey | Jwt { .. }`) to struct (`api_key: bool`, `jwt: Option<JwtConfig>`). Constructors `no_auth()`, `jwt(issuer, audience)`, `api_key()`, new `combined(issuer, audience)`. Helpers `is_enabled()` and `describe()`.
- `auth_middleware` dispatches on `jsonwebtoken::decode_header(token).is_ok()`. JWT-shaped → JWT path; otherwise API-key path.
- **Breaking for downstream Rust consumers** that match on the old enum variants. The `assay` binary, REST API, and dashboard are unaffected.

### CLI — `src/main.rs`

- `--auth-issuer` and `--auth-api-key` are no longer mutually exclusive. Setting both builds `AuthMode::combined(..)`. `--no-auth` still conflicts with any auth flag (now detected via `is_enabled()`).
- CLI docstrings note the combinability.

### Tests

- Migrated `auth_test.rs`, `orchestration.rs`, `api_integration.rs` to the new constructor API.
- **Added** 5 combined-mode tests + 5 describe/is_enabled helper tests:
  - `combined_accepts_valid_jwt`
  - `combined_accepts_valid_api_key`
  - `combined_rejects_missing_token`
  - `combined_rejects_garbage_token`
  - `combined_rejects_expired_jwt_without_api_key_fallback` (guards the no-fallthrough semantics)
  - `describe_*` + `is_enabled_reflects_state`

### Docs

- `CHANGELOG.md` — new v0.11.4 entry.
- `docs/modules/workflow.md` — auth modes table: combined row + dispatch semantics block.
- `llms.txt` — mention combinability.
- `site/pages/index.html` — release banner to v0.11.4, workflow-card version badge, `mise` install snippet.
- `AGENTS.md` — **new "Release docs checklist" section** enumerating every file that drifts between releases (site banner, llms.txt, install snippets) plus the grep to catch stale version refs. Prevents this miss in future releases.

### Version

- `Cargo.toml` + `Cargo.lock`: `0.11.3` → `0.11.4`.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test -p assay-workflow --test auth_test` — 21 passed (11 pre-existing regression + 5 combined + 5 helper)
- [x] `cargo test --workspace --no-fail-fast` — full suite green
- [ ] Manual smoke: `assay serve --auth-issuer https://auth.example.com --auth-api-key` starts cleanly; JWT and API key calls both accepted; garbage token rejected.
- [ ] After merge: tag `v0.11.4`, trigger release GHA (crates.io, npm, GHCR, GitHub release, docs site).