### PR TITLE
fix(release): v0.11.5 — re-release for crates.io publish

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,29 +41,73 @@ in `LICENSE`/`NOTICE`/`CLA.md`.
 ## Release docs checklist
 
 Every release (patch, minor, or major) must update **all** of the following before the PR merges —
-never ship a release that only touches source + CHANGELOG. The site and llms.txt drift silently if
-you forget them, and agents downstream (including future-you) see stale information.
+never ship a release that only touches source + CHANGELOG. The site, llms.txt, and sub-crate
+manifests drift silently if you forget them, and agents downstream (including future-you) see
+stale information.
 
-- `Cargo.toml` — bump `version` under `[package]`.
-- `CHANGELOG.md` — new section at the top; describe the OIDC/Kubernetes/HTTP scenario enabled, not a
-  specific consumer.
+### Version bumps
+
+- `Cargo.toml` (workspace root) — bump `[package].version` for the `assay-lua` binary crate.
+- **`crates/*/Cargo.toml`** — each sub-crate follows **independent semver tied to its own public
+  Rust API**, not the binary's version. Today that's `crates/assay-workflow/Cargo.toml`. Skip this
+  and the crates.io publish step of the release workflow fails at tag push time (the crate version
+  already exists on the index).
+- When a sub-crate version bumps, the workspace root `Cargo.toml` dependency spec must bump to
+  match (e.g. `assay-workflow = { ..., version = "0.2" }`). Cargo's lockfile will regenerate on the
+  next build; commit the resulting `Cargo.lock` update.
+
+### Pre-1.0 semver: patch bumps by default
+
+**Every release bumps the patch digit. Never jump the minor without an explicit conversation.**
+
+Rationale: assay is pre-1.0. Both the binary (`assay-lua`) and the engine library
+(`assay-workflow`) are young and do not have a stable promised API yet. A minor bump on a 0.x
+crate conventionally signals a breaking change to downstream Cargo consumers — which matters
+once there are downstream consumers. While there aren't, a patch bump is both sufficient and
+keeps Cargo dep specs (`version = "0.1"` = `^0.1`, `version = "0.11"` = `^0.11`) stable across
+the upgrade.
+
+- `assay-lua` (binary): always patch bump (`0.11.4 → 0.11.5`) unless the user says otherwise.
+- `assay-workflow` (engine sub-crate): always patch bump (`0.1.2 → 0.1.3`) unless the user says
+  otherwise.
+- **Don't pick a minor bump unilaterally.** If a change looks like it justifies one (e.g. a
+  public enum becomes a struct, a trait signature changes), surface the tradeoff to the user and
+  ask before touching the version field. Discussion first, edit second.
+
+The binary version and sub-crate version are independent. It's normal for `assay-lua 0.11.5` to
+ship `assay-workflow 0.1.3`; they have unrelated bump cadences.
+
+### Non-source files
+
+- `CHANGELOG.md` — new section at the top; describe the OIDC/Kubernetes/HTTP scenario enabled, not
+  a specific consumer.
 - `docs/modules/*.md` — any module whose surface changed.
-- `README.md`, `SKILL.md`, `AGENTS.md`, `skills/assay/SKILL.md` — auth / CLI / API tables if touched.
+- `README.md`, `SKILL.md`, `AGENTS.md`, `skills/assay/SKILL.md` — auth / CLI / API tables if
+  touched.
 - `llms.txt` (root) — one-liner module descriptors.
 - `site/pages/index.html` — the release banner (`v0.x.y` tag + copy) and any version badge on
   feature cards (e.g. the Workflow Engine card).
-- `site/static/llms.txt` — this is the site's static teaser; keep it reasonably fresh (it's not
-  auto-generated from the root `llms.txt`).
-- Any site page that references the previous version in prose or code (e.g. the
-  `mise` / `crates.io` install snippets on `index.html`).
+- `site/static/llms.txt` — site's static teaser; keep it reasonably fresh (not auto-generated from
+  the root `llms.txt`).
+- Any site page that references the previous version in prose or code (e.g. the `mise` /
+  `crates.io` install snippets on `index.html`).
 
-Verify with a grep for the previous version before opening the PR:
+### Verification before opening the PR
 
 ```sh
+# No stale version references in shipping content:
 grep -rn "v0.PREVIOUS" . --include="*.md" --include="*.html" --include="*.toml" --include="*.txt"
+
+# Every crate manifest version field matches what you intend to publish:
+grep -E '^version = ' Cargo.toml crates/*/Cargo.toml
+
+# Dep spec in the root Cargo.toml tracks the sub-crate bump:
+grep -A0 'assay-workflow' Cargo.toml | grep 'version ='
 ```
 
-The only matches that should remain are historical CHANGELOG entries.
+Only matches that should remain for the first grep are historical CHANGELOG entries and
+"introduced in vX.Y.Z" feature markers. The second and third greps exist because v0.11.4's
+crates.io publish failed when the sub-crate version was missed — do not skip them.
 
 ## What is Assay
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to Assay are documented here.
 
+## [0.11.5] - 2026-04-17
+
+### Changed
+
+- **`assay-workflow` crate version** bumped to `0.1.3` (from `0.1.2`) — carries the
+  v0.11.4 `AuthMode` refactor from enum to struct. Per assay's pre-1.0 policy of
+  patch-bumps-by-default, both crates stay in their current minor tracks until there's
+  a deliberate decision to signal API instability to downstream consumers.
+
+### Fixed
+
+- **crates.io publish.** v0.11.4 shipped the binary (GHCR, npm, Linux/macOS artefacts,
+  GitHub release) but its crates.io publish failed because `assay-workflow` was still
+  pinned to `0.1.2` — the same version already published for v0.11.3. v0.11.5 is a
+  re-release of v0.11.4's code with both crates' versions bumped so the publish
+  actually lands on crates.io.
+
+### Docs
+
+- `AGENTS.md` "Release docs checklist" gains an explicit note about `crates/*/Cargo.toml`
+  and the independent-versioning policy for sub-crates — the gap that caused the v0.11.4
+  crates.io failure.
+
 ## [0.11.4] - 2026-04-17
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,7 @@ checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "assay-lua"
-version = "0.11.4"
+version = "0.11.5"
 dependencies = [
  "anyhow",
  "assay-workflow",
@@ -128,7 +128,7 @@ dependencies = [
 
 [[package]]
 name = "assay-workflow"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "aws-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "crates/assay-workflow"]
 
 [package]
 name = "assay-lua"
-version = "0.11.4"
+version = "0.11.5"
 categories = ["command-line-utilities", "development-tools::testing"]
 edition = "2024"
 homepage = "https://assay.rs"

--- a/crates/assay-workflow/Cargo.toml
+++ b/crates/assay-workflow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-workflow"
-version = "0.1.2"
+version = "0.1.3"
 categories = ["asynchronous", "database"]
 edition = "2024"
 keywords = ["workflow", "durable-execution", "orchestration", "task-queue"]

--- a/site/pages/index.html
+++ b/site/pages/index.html
@@ -12,9 +12,9 @@
 
 
   <main>
-    <!-- v0.11.4 release banner -->
+    <!-- v0.11.5 release banner -->
     <a href="changelog.html" class="release-banner">
-      <span class="release-banner-tag">v0.11.4</span>
+      <span class="release-banner-tag">v0.11.5</span>
       <span class="release-banner-text">Combined JWT + API-key authentication for <code>assay serve</code> — run both auth modes on the same server; middleware dispatches on token shape</span>
       <span class="release-banner-arrow">&rarr;</span>
     </a>
@@ -147,7 +147,7 @@
     <h2>Core Capabilities</h2>
     <section style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1.5rem; margin-bottom: 2rem;">
       <div class="card card-highlight">
-        <h3 style="margin-top: 0;">Workflow Engine <span style="color: var(--accent); font-size: 0.7rem; font-weight: 700; vertical-align: middle; padding: 2px 6px; border: 1px solid var(--accent); border-radius: 4px;">v0.11.4</span></h3>
+        <h3 style="margin-top: 0;">Workflow Engine <span style="color: var(--accent); font-size: 0.7rem; font-weight: 700; vertical-align: middle; padding: 2px 6px; border: 1px solid var(--accent); border-radius: 4px;">v0.11.5</span></h3>
         <p class="text-muted">Native durable workflow engine with deterministic-replay runtime. Activities (sequential + parallel), signals, durable timers, child workflows, side effects, live state via <code>ctx:register_query</code>, search attributes, optional S3 archival. Crash-safe by replay — workers can die mid-flight without losing work or duplicating side effects.</p>
         <pre style="margin-bottom: 0;"><code>workflow.define("Deploy", function(ctx, in)
   local img = ctx:execute_activity("build", in)
@@ -299,7 +299,7 @@ cargo install assay-lua
 
     <h3>mise</h3>
     <pre><code># .mise.toml
-"github:developerinlondon/assay" = "v0.11.4"</code></pre>
+"github:developerinlondon/assay" = "v0.11.5"</code></pre>
 
   </main>
 


### PR DESCRIPTION
## Summary

v0.11.4 shipped successfully to GHCR, npm, GitHub releases, and the Linux/macOS binary artefacts, but **crates.io publish failed** because `crates/assay-workflow/Cargo.toml` was still at `0.1.2` — the version already published for v0.11.3. This PR re-releases v0.11.4's code as **v0.11.5** with both crate versions bumped so the crates.io publish actually lands.

No functional changes from v0.11.4.

## What changed

| File | Change |
|---|---|
| `crates/assay-workflow/Cargo.toml` | `0.1.2` → `0.1.3` |
| `Cargo.toml` (workspace root) | `assay-lua` `0.11.4` → `0.11.5`. Dep spec `assay-workflow = { ..., version = "0.1" }` unchanged — `^0.1` still matches `0.1.3`. |
| `Cargo.lock` | regenerated |
| `CHANGELOG.md` | new v0.11.5 entry explaining the re-release + the patch-bumps-by-default policy |
| `site/pages/index.html` | release banner v0.11.4 → v0.11.5; workflow-card version badge; `mise` install snippet |

## Policy additions in `AGENTS.md`

1. **Pre-1.0 semver: patch bumps by default.** Both `assay-lua` and `assay-workflow` stay in their current minor tracks until there's a deliberate decision to signal API instability. Minor bumps are never picked unilaterally — discussion first, edit second.
2. **Release docs checklist** expanded to mandate:
   - `crates/*/Cargo.toml` sub-crate version bumps (the gap that caused this miss)
   - Three verification greps before opening a release PR:
     - Stale version refs in `*.md` / `*.html` / `*.toml` / `*.txt`
     - Every crate manifest's `version = ...` field
     - Root dep spec tracking the sub-crate bump

## Test plan

- [x] `cargo build --workspace` clean with new versions
- [x] Version alignment verified: `grep -E '^version = ' Cargo.toml crates/*/Cargo.toml`
- [x] Root dep spec (`^0.1`) still matches `assay-workflow 0.1.3`
- [ ] After merge: tag `v0.11.5`, watch release GHA. Expect all jobs green including crates-io (publishes both `assay-workflow 0.1.3` and `assay-lua 0.11.5`).