### PR TITLE
docs(agents): default PR assignee to developerinlondon

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,22 @@ Follow this sequence for every PR merge into `main`, even as an admin who could 
 protection. Branch protection is the enforcement layer, the process below is the discipline
 layer — protection is the last line of defence, not the only one.
 
+### 0. Create the PR with the right assignee
+
+Every PR in this repo is owned by the repo owner — `developerinlondon`. Always pass
+`--assignee developerinlondon` (or `--assignee @me` when you're authenticated as that user)
+when running `gh pr create`:
+
+```sh
+gh pr create --title "..." --body "..." --assignee developerinlondon
+```
+
+If you forget at creation time, fix it immediately with:
+
+```sh
+gh pr edit <PR> --add-assignee developerinlondon
+```
+
 ### 1. Wait for CI to settle fully
 
 ```sh


### PR DESCRIPTION
## Summary

Adds step 0 to the **PR merge process** in `AGENTS.md`: every `gh pr create` invocation in this repo must pass `--assignee developerinlondon` so PRs are owned from creation time. Includes the fallback `gh pr edit --add-assignee` command for cases where assignment was missed.

## Why

PR ownership should be unambiguous from creation — the repo owner is the default reviewer and merger, and unassigned PRs leave "who's on the hook for this" implicit. Codifying it in AGENTS.md makes it a reflex for future sessions.

## Test plan

- [x] This PR is itself created with `--assignee developerinlondon` — demonstrates the practice.
- [ ] Wait for CI via `gh pr checks <this> --watch`, squash-merge, verify post-merge `main` CI green.