### PR TITLE
fix(postgres): sanitise_schema — drops comment-only lines before split (v0.11.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 All notable changes to Assay are documented here.
 
+## [0.11.6] - 2026-04-17
+
+### Fixed
+
+- **Postgres schema migration crash on startup.** `PostgresStore::migrate()` split
+  the embedded `SCHEMA` string by `;` and executed each fragment as SQL. A semicolon
+  inside an SQL line comment (`-- Idempotent across startups; fresh installs pick
+  the column up from the…`) produced a phantom fragment starting with naked prose,
+  and Postgres rejected it with `syntax error at or near "fresh"` — which crashed
+  `assay serve` on every boot against a Postgres backend, regardless of whether the
+  target database was fresh or already populated. Affects v0.11.3 through v0.11.5.
+
+  Fix: extract the split into a `sanitise_schema` helper that drops pure-comment
+  lines (leading whitespace then `--`) before splitting on `;`. Inline `--`-after-code
+  and string-literal contents are left untouched, so the filter is conservative enough
+  to stay correct as the SCHEMA grows more prose.
+
+### Changed
+
+- **`assay-workflow` crate** bumped to `0.1.4` (from `0.1.3`). No public API
+  changes. Downstream consumers on `version = "0.1"` continue to work.
+
+### Tests
+
+- Added five pure-Rust unit tests for `sanitise_schema` under `src/store/postgres.rs`
+  that run on all platforms — no Docker required. Includes a regression test
+  (`sanitise_schema_real_constant_produces_only_ddl`) that asserts the live `SCHEMA`
+  constant never produces a statement whose first token isn't a recognised SQL
+  keyword. This would have caught the v0.11.3 bug at CI time; the existing
+  integration tests under `tests/postgres_store.rs` skip when Docker is unavailable
+  (macOS default), which is why this class of bug slipped through.
+
 ## [0.11.5] - 2026-04-17
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,7 @@ checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "assay-lua"
-version = "0.11.5"
+version = "0.11.6"
 dependencies = [
  "anyhow",
  "assay-workflow",
@@ -128,7 +128,7 @@ dependencies = [
 
 [[package]]
 name = "assay-workflow"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "aws-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "crates/assay-workflow"]
 
 [package]
 name = "assay-lua"
-version = "0.11.5"
+version = "0.11.6"
 categories = ["command-line-utilities", "development-tools::testing"]
 edition = "2024"
 homepage = "https://assay.rs"

--- a/crates/assay-workflow/Cargo.toml
+++ b/crates/assay-workflow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-workflow"
-version = "0.1.3"
+version = "0.1.4"
 categories = ["asynchronous", "database"]
 edition = "2024"
 keywords = ["workflow", "durable-execution", "orchestration", "task-queue"]

--- a/crates/assay-workflow/src/store/postgres.rs
+++ b/crates/assay-workflow/src/store/postgres.rs
@@ -153,6 +153,31 @@ CREATE INDEX IF NOT EXISTS idx_api_keys_prefix ON api_keys(prefix);
 -- source of truth through v0.11.3.
 "#;
 
+/// Split a Postgres DDL script into individual statements ready for `sqlx::query`.
+///
+/// Drops pure-comment lines (those starting with `--` after optional whitespace)
+/// *before* splitting on `;`. Without this step, a semicolon inside a line comment
+/// (e.g. `-- Idempotent across startups; fresh installs pick the column up`) would
+/// split the surrounding comment into fragments — one of which is naked prose that
+/// Postgres tries to parse as SQL and rejects with `syntax error at or near "<word>"`.
+///
+/// The filter only drops *pure-comment* lines (leading whitespace then `--`), leaving
+/// `--`-after-code untouched. That keeps string literals safe (could legally contain
+/// `--`) and is conservative enough to remain correct if the SCHEMA grows more prose.
+fn sanitise_schema(schema: &str) -> Vec<String> {
+    let without_comments: String = schema
+        .lines()
+        .filter(|line| !line.trim_start().starts_with("--"))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    without_comments
+        .split(';')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
 pub struct PostgresStore {
     pool: PgPool,
 }
@@ -166,12 +191,8 @@ impl PostgresStore {
     }
 
     async fn migrate(&self) -> Result<()> {
-        // Execute each statement separately — Postgres handles CREATE IF NOT EXISTS
-        for statement in SCHEMA.split(';') {
-            let trimmed = statement.trim();
-            if !trimmed.is_empty() {
-                sqlx::query(trimmed).execute(&self.pool).await?;
-            }
+        for statement in sanitise_schema(SCHEMA) {
+            sqlx::query(&statement).execute(&self.pool).await?;
         }
         Ok(())
     }
@@ -1437,6 +1458,78 @@ impl From<PgWorkerRow> for WorkflowWorker {
             active_tasks: r.active_tasks,
             last_heartbeat: r.last_heartbeat,
             registered_at: r.registered_at,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitise_schema_keeps_statements_intact() {
+        let input = "CREATE TABLE foo (x INT);\nCREATE INDEX idx_foo ON foo(x);\n";
+        let out = sanitise_schema(input);
+        assert_eq!(out.len(), 2);
+        assert!(out[0].starts_with("CREATE TABLE foo"));
+        assert!(out[1].starts_with("CREATE INDEX idx_foo"));
+    }
+
+    #[test]
+    fn sanitise_schema_drops_pure_comment_lines() {
+        let input = "-- header comment\nCREATE TABLE foo (x INT);\n-- trailing comment\n";
+        let out = sanitise_schema(input);
+        assert_eq!(out.len(), 1);
+        assert!(out[0].starts_with("CREATE TABLE foo"));
+    }
+
+    #[test]
+    fn sanitise_schema_ignores_semicolons_inside_comment_prose() {
+        // Regression: the exact shape that broke v0.11.3–v0.11.5 in production.
+        // `-- foo; bar` used to split into "foo" and " bar" fragments, the second
+        // of which was executed as SQL and rejected with `syntax error at or near "bar"`.
+        let input = "\
+CREATE TABLE foo (x INT);
+-- Idempotent across startups; fresh installs pick the column up from the
+-- CREATE TABLE above so the ADD is a no-op.
+";
+        let out = sanitise_schema(input);
+        assert_eq!(
+            out.len(),
+            1,
+            "expected 1 real statement, got {}: {:?}",
+            out.len(),
+            out
+        );
+        assert!(out[0].starts_with("CREATE TABLE foo"));
+    }
+
+    #[test]
+    fn sanitise_schema_drops_indented_comment_lines() {
+        let input = "  -- indented comment\n\tCREATE TABLE foo (x INT);\n";
+        let out = sanitise_schema(input);
+        assert_eq!(out.len(), 1);
+        assert!(out[0].contains("CREATE TABLE foo"));
+    }
+
+    #[test]
+    fn sanitise_schema_real_constant_produces_only_ddl() {
+        // The real SCHEMA constant must not produce any statement whose first
+        // token isn't a recognised SQL keyword. A prose fragment leaking in
+        // (e.g. "fresh installs...") means the filter regressed.
+        for stmt in sanitise_schema(SCHEMA) {
+            let first_word = stmt
+                .split_whitespace()
+                .next()
+                .expect("non-empty statement")
+                .to_uppercase();
+            assert!(
+                matches!(
+                    first_word.as_str(),
+                    "CREATE" | "INSERT" | "UPDATE" | "DROP" | "ALTER" | "WITH"
+                ),
+                "SCHEMA produced non-DDL statement starting with {first_word:?}: {stmt:?}"
+            );
         }
     }
 }

--- a/site/pages/index.html
+++ b/site/pages/index.html
@@ -12,10 +12,10 @@
 
 
   <main>
-    <!-- v0.11.5 release banner -->
+    <!-- v0.11.6 release banner -->
     <a href="changelog.html" class="release-banner">
-      <span class="release-banner-tag">v0.11.5</span>
-      <span class="release-banner-text">Combined JWT + API-key authentication for <code>assay serve</code> — run both auth modes on the same server; middleware dispatches on token shape</span>
+      <span class="release-banner-tag">v0.11.6</span>
+      <span class="release-banner-text">Fix Postgres schema-migration crash on startup — semicolon inside a SQL line comment no longer produces phantom SQL fragments</span>
       <span class="release-banner-arrow">&rarr;</span>
     </a>
 
@@ -147,7 +147,7 @@
     <h2>Core Capabilities</h2>
     <section style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1.5rem; margin-bottom: 2rem;">
       <div class="card card-highlight">
-        <h3 style="margin-top: 0;">Workflow Engine <span style="color: var(--accent); font-size: 0.7rem; font-weight: 700; vertical-align: middle; padding: 2px 6px; border: 1px solid var(--accent); border-radius: 4px;">v0.11.5</span></h3>
+        <h3 style="margin-top: 0;">Workflow Engine <span style="color: var(--accent); font-size: 0.7rem; font-weight: 700; vertical-align: middle; padding: 2px 6px; border: 1px solid var(--accent); border-radius: 4px;">v0.11.6</span></h3>
         <p class="text-muted">Native durable workflow engine with deterministic-replay runtime. Activities (sequential + parallel), signals, durable timers, child workflows, side effects, live state via <code>ctx:register_query</code>, search attributes, optional S3 archival. Crash-safe by replay — workers can die mid-flight without losing work or duplicating side effects.</p>
         <pre style="margin-bottom: 0;"><code>workflow.define("Deploy", function(ctx, in)
   local img = ctx:execute_activity("build", in)
@@ -299,7 +299,7 @@ cargo install assay-lua
 
     <h3>mise</h3>
     <pre><code># .mise.toml
-"github:developerinlondon/assay" = "v0.11.5"</code></pre>
+"github:developerinlondon/assay" = "v0.11.6"</code></pre>
 
   </main>
 


### PR DESCRIPTION
## Summary

v0.11.6 fixes a Postgres schema-migration crash that affected v0.11.3 through v0.11.5: `assay serve` exited on startup with `syntax error at or near \"fresh\"` against every Postgres backend, fresh or already-populated.

## Root cause

`PostgresStore::migrate()` in `crates/assay-workflow/src/store/postgres.rs` split the embedded `SCHEMA` string by `;` and ran each fragment as SQL. A semicolon inside a SQL line comment — specifically the v0.11.3-added trailing block:

```sql
-- Idempotent across startups; fresh installs pick the column up from the
-- CREATE TABLE above so the ADD is a no-op. …
```

— produced a phantom fragment whose first line was `fresh installs pick the column up from the`. Postgres parses that as SQL and rejects it. Earlier CREATE TABLE statements all succeeded before the crash, which is why logs show every table migrating cleanly and then a crash on the final "statement."

## Fix

Extract the split into a `sanitise_schema(schema)` helper that filters pure-comment lines (leading whitespace then `--`) *before* splitting on `;`. Inline `--`-after-code and string-literal contents are left untouched (SCHEMA has no such cases today, but the filter is conservative for future additions).

`migrate()` becomes a two-liner that calls the helper and runs each statement.

## Tests

Five pure-Rust unit tests under `store::postgres::tests`:

- `sanitise_schema_keeps_statements_intact` — baseline: two statements split cleanly
- `sanitise_schema_drops_pure_comment_lines` — header/footer comments removed
- `sanitise_schema_ignores_semicolons_inside_comment_prose` — the exact regression case
- `sanitise_schema_drops_indented_comment_lines` — indented `--` handled
- `sanitise_schema_real_constant_produces_only_ddl` — walks the live `SCHEMA` and asserts every statement starts with `CREATE` / `INSERT` / `UPDATE` / `DROP` / `ALTER` / `WITH`

**These tests run on all platforms with no Docker** — they'd have caught the v0.11.3 regression at CI time. The existing `tests/postgres_store.rs` integration tests skip when Docker is unavailable (macOS default), which is why this class of bug slipped through previously.

Future follow-up: instructions in AGENTS.md for running Docker-dependent tests on macOS (colima / orbstack / docker-desktop) — so the integration suite is reachable locally too.

## Versions

- `assay-workflow`: `0.1.3` → `0.1.4` (patch; no public API changes)
- `assay-lua`: `0.11.5` → `0.11.6`

Per the pre-1.0 patch-bumps-by-default policy in `AGENTS.md`.

## Test plan

- [x] `cargo test -p assay-workflow --lib store::postgres` — 5 new tests pass
- [x] `cargo build --workspace` clean
- [ ] CI green via `gh pr checks <this> --watch`, then squash-merge
- [ ] Tag `v0.11.6`, watch release GHA — especially crates-io (now unstuck on both crate bumps) and docker (pushes `ghcr.io/developerinlondon/assay:v0.11.6`)
- [ ] Downstream: bump gitops `apps/shared-infra/cc-workflows/base/deployment.yaml` image tag to `v0.11.6`; assay-serve pods on the dev cluster finally roll to Ready.