### PR TITLE
feat(api): POST /api/v1/api-keys + bootstrap window + idempotent label (v0.11.7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,52 @@
 
 All notable changes to Assay are documented here.
 
+## [0.11.7] - 2026-04-17
+
+### Added
+
+- **`POST /api/v1/api-keys` endpoint** — REST alternative to the
+  `assay serve --generate-api-key` CLI subcommand. Accepts
+  `{ label?, idempotent? }`. With `idempotent=true` and a key matching
+  the label already exists, returns `200 OK` with the existing record's
+  metadata (no plaintext). Otherwise mints a fresh key and returns
+  `201 Created` with the plaintext.
+
+  **Bootstrap window:** when the `api_keys` table is empty, `POST
+  /api/v1/api-keys` is callable without authentication. This is the
+  only way a freshly deployed server running in API-key or combined
+  mode can receive its first credential without operator shell access.
+  The window closes the moment any key exists.
+
+- **`GET /api/v1/api-keys`** and **`DELETE /api/v1/api-keys/{prefix}`** —
+  list and revoke.
+
+- **`workflow.api_keys.{generate, list, delete}`** Lua stdlib helpers
+  wrapping the above endpoints. Example:
+
+  ```lua
+  local resp = workflow.api_keys.generate("cc_api_key", { idempotent = true })
+  if resp.plaintext then
+      -- fresh mint; persist plaintext somewhere (e.g. a k8s Secret)
+  else
+      -- already exists; plaintext was issued on first call
+  end
+  ```
+
+### Store
+
+- New `WorkflowStore` trait methods: `api_keys_empty()` (used by the
+  bootstrap-window gate) and `get_api_key_by_label(label)` (used by the
+  idempotent-mode lookup). Implemented for both SQLite and Postgres.
+
+- `ApiKeyRecord` now derives `utoipa::ToSchema` so the OpenAPI spec
+  includes it.
+
+### Changed
+
+- **`assay-workflow` crate** bumped to `0.1.5` (from `0.1.4`). Additive
+  API changes; downstream consumers on `version = "0.1"` continue to work.
+
 ## [0.11.6] - 2026-04-17
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,7 @@ checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "assay-lua"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "anyhow",
  "assay-workflow",
@@ -128,7 +128,7 @@ dependencies = [
 
 [[package]]
 name = "assay-workflow"
-version = "0.1.4"
+version = "0.1.5"
 dependencies = [
  "anyhow",
  "aws-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "crates/assay-workflow"]
 
 [package]
 name = "assay-lua"
-version = "0.11.6"
+version = "0.11.7"
 categories = ["command-line-utilities", "development-tools::testing"]
 edition = "2024"
 homepage = "https://assay.rs"

--- a/crates/assay-workflow/Cargo.toml
+++ b/crates/assay-workflow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-workflow"
-version = "0.1.4"
+version = "0.1.5"
 categories = ["asynchronous", "database"]
 edition = "2024"
 keywords = ["workflow", "durable-execution", "orchestration", "task-queue"]

--- a/crates/assay-workflow/src/api/api_keys.rs
+++ b/crates/assay-workflow/src/api/api_keys.rs
@@ -1,0 +1,151 @@
+//! API key management endpoints.
+//!
+//! Provides REST creation/listing/deletion of engine API keys as an
+//! alternative to the `assay serve --generate-api-key` CLI subcommand.
+//!
+//! `POST /api/v1/api-keys` supports a client-supplied `label` and an
+//! `idempotent` flag. When `idempotent = true` and a key with that label
+//! already exists, the handler returns the existing record's metadata
+//! *without* a plaintext — the plaintext was handed out at generation
+//! time and is never retrievable again.
+//!
+//! The POST endpoint is intentionally callable **without authentication**
+//! when the `api_keys` table is empty (see `api/auth.rs` middleware). This
+//! is the first-ever-key bootstrap window: without it, a freshly deployed
+//! server running in API-key or combined mode has no way to receive its
+//! first credential. The window closes as soon as any key exists.
+use std::sync::Arc;
+
+use axum::extract::State;
+use axum::routing::{delete, post};
+use axum::{Json, Router};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+use crate::api::auth::{generate_api_key, hash_api_key, key_prefix};
+use crate::api::workflows::AppError;
+use crate::api::AppState;
+use crate::store::{ApiKeyRecord, WorkflowStore};
+
+pub fn router<S: WorkflowStore + 'static>() -> Router<Arc<AppState<S>>> {
+    Router::new()
+        .route("/api-keys", post(create_api_key).get(list_api_keys))
+        .route("/api-keys/{prefix}", delete(revoke_api_key))
+}
+
+#[derive(Deserialize, ToSchema)]
+pub struct CreateApiKeyRequest {
+    /// Optional label to tag the key with. Labels can be arbitrary strings
+    /// but are most useful when unique — combined with `idempotent=true`
+    /// they let a caller provision a named key across reruns.
+    #[serde(default)]
+    pub label: Option<String>,
+
+    /// If true AND a key with this `label` already exists, the handler
+    /// returns `200 OK` with the existing record's metadata (no plaintext).
+    /// If false (default) or no label is supplied, the handler always
+    /// mints a fresh key and returns `201 Created` with the plaintext.
+    #[serde(default)]
+    pub idempotent: bool,
+}
+
+#[derive(Serialize, ToSchema)]
+pub struct CreateApiKeyResponse {
+    /// Plaintext API key. Only present on a fresh mint (`201 Created`).
+    /// Never included when an existing key is returned idempotently.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub plaintext: Option<String>,
+    pub prefix: String,
+    pub label: Option<String>,
+    pub created_at: f64,
+}
+
+#[utoipa::path(
+    post, path = "/api/v1/api-keys",
+    tag = "api-keys",
+    request_body = CreateApiKeyRequest,
+    responses(
+        (status = 201, description = "New API key minted", body = CreateApiKeyResponse),
+        (status = 200, description = "Idempotent: existing key with this label returned (no plaintext)", body = CreateApiKeyResponse),
+        (status = 500, description = "Internal error"),
+    ),
+)]
+pub async fn create_api_key<S: WorkflowStore>(
+    State(state): State<Arc<AppState<S>>>,
+    Json(req): Json<CreateApiKeyRequest>,
+) -> Result<(axum::http::StatusCode, Json<CreateApiKeyResponse>), AppError> {
+    if req.idempotent {
+        if let Some(label) = req.label.as_deref() {
+            if let Some(existing) = state.engine.store().get_api_key_by_label(label).await? {
+                return Ok((
+                    axum::http::StatusCode::OK,
+                    Json(CreateApiKeyResponse {
+                        plaintext: None,
+                        prefix: existing.prefix,
+                        label: existing.label,
+                        created_at: existing.created_at,
+                    }),
+                ));
+            }
+        }
+    }
+
+    let plaintext = generate_api_key();
+    let hash = hash_api_key(&plaintext);
+    let prefix = key_prefix(&plaintext);
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs_f64())
+        .unwrap_or(0.0);
+
+    state
+        .engine
+        .store()
+        .create_api_key(&hash, &prefix, req.label.as_deref(), now)
+        .await?;
+
+    Ok((
+        axum::http::StatusCode::CREATED,
+        Json(CreateApiKeyResponse {
+            plaintext: Some(plaintext),
+            prefix,
+            label: req.label,
+            created_at: now,
+        }),
+    ))
+}
+
+#[utoipa::path(
+    get, path = "/api/v1/api-keys",
+    tag = "api-keys",
+    responses(
+        (status = 200, description = "List of API key metadata (hashes never exposed)", body = Vec<ApiKeyRecord>),
+    ),
+)]
+pub async fn list_api_keys<S: WorkflowStore>(
+    State(state): State<Arc<AppState<S>>>,
+) -> Result<Json<Vec<ApiKeyRecord>>, AppError> {
+    let keys = state.engine.store().list_api_keys().await?;
+    Ok(Json(keys))
+}
+
+#[utoipa::path(
+    delete, path = "/api/v1/api-keys/{prefix}",
+    tag = "api-keys",
+    params(("prefix" = String, Path, description = "Key prefix (e.g. assay_abcd1234...)")),
+    responses(
+        (status = 204, description = "Key revoked"),
+        (status = 404, description = "No key with that prefix"),
+    ),
+)]
+pub async fn revoke_api_key<S: WorkflowStore>(
+    State(state): State<Arc<AppState<S>>>,
+    axum::extract::Path(prefix): axum::extract::Path<String>,
+) -> Result<axum::http::StatusCode, AppError> {
+    let removed = state.engine.store().revoke_api_key(&prefix).await?;
+    if removed {
+        Ok(axum::http::StatusCode::NO_CONTENT)
+    } else {
+        Ok(axum::http::StatusCode::NOT_FOUND)
+    }
+}

--- a/crates/assay-workflow/src/api/api_keys.rs
+++ b/crates/assay-workflow/src/api/api_keys.rs
@@ -74,20 +74,19 @@ pub async fn create_api_key<S: WorkflowStore>(
     State(state): State<Arc<AppState<S>>>,
     Json(req): Json<CreateApiKeyRequest>,
 ) -> Result<(axum::http::StatusCode, Json<CreateApiKeyResponse>), AppError> {
-    if req.idempotent {
-        if let Some(label) = req.label.as_deref() {
-            if let Some(existing) = state.engine.store().get_api_key_by_label(label).await? {
-                return Ok((
-                    axum::http::StatusCode::OK,
-                    Json(CreateApiKeyResponse {
-                        plaintext: None,
-                        prefix: existing.prefix,
-                        label: existing.label,
-                        created_at: existing.created_at,
-                    }),
-                ));
-            }
-        }
+    if req.idempotent
+        && let Some(label) = req.label.as_deref()
+        && let Some(existing) = state.engine.store().get_api_key_by_label(label).await?
+    {
+        return Ok((
+            axum::http::StatusCode::OK,
+            Json(CreateApiKeyResponse {
+                plaintext: None,
+                prefix: existing.prefix,
+                label: existing.label,
+                created_at: existing.created_at,
+            }),
+        ));
     }
 
     let plaintext = generate_api_key();

--- a/crates/assay-workflow/src/api/auth.rs
+++ b/crates/assay-workflow/src/api/auth.rs
@@ -259,6 +259,12 @@ fn find_key_in_set(jwks: &JwkSet, kid: &str) -> Option<DecodingKey> {
 /// the API-key path. A semantically-invalid JWT (expired, forged signature, wrong
 /// audience) is rejected and is *not* retried as an API key — a token that looks
 /// like a JWT is treated as a JWT.
+///
+/// **Bootstrap window:** `POST /api/v1/api-keys` is accepted without a Bearer
+/// token iff the `api_keys` table is empty. This is the only way a freshly
+/// deployed server running in API-key or combined mode can receive its first
+/// credential without operator shell access. The window closes the moment any
+/// key exists.
 pub async fn auth_middleware<S: WorkflowStore>(
     State(state): State<Arc<AppState<S>>>,
     request: Request,
@@ -268,6 +274,28 @@ pub async fn auth_middleware<S: WorkflowStore>(
 
     if !auth.is_enabled() {
         return next.run(request).await;
+    }
+
+    if is_bootstrap_request(&request) {
+        match state.engine.store().api_keys_empty().await {
+            Ok(true) => {
+                info!(
+                    "Allowing unauthenticated POST /api/v1/api-keys — api_keys table is empty (bootstrap window)"
+                );
+                return next.run(request).await;
+            }
+            Ok(false) => {
+                // Fall through to normal auth — bootstrap window is closed.
+            }
+            Err(e) => {
+                warn!("api_keys_empty check failed: {e}");
+                return (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(serde_json::json!({"error": "auth bootstrap check failed"})),
+                )
+                    .into_response();
+            }
+        }
     }
 
     let token = match extract_bearer(&request) {
@@ -391,6 +419,14 @@ fn extract_bearer(request: &Request) -> Option<&str> {
         .get("authorization")
         .and_then(|v| v.to_str().ok())
         .and_then(|v| v.strip_prefix("Bearer "))
+}
+
+/// True iff the request is the bootstrap-window endpoint
+/// (`POST /api/v1/api-keys`). The caller is still responsible for checking
+/// that the `api_keys` table is empty before actually allowing unauth access.
+fn is_bootstrap_request(request: &Request) -> bool {
+    request.method() == axum::http::Method::POST
+        && request.uri().path() == "/api/v1/api-keys"
 }
 
 fn auth_error(msg: &str) -> Response {

--- a/crates/assay-workflow/src/api/mod.rs
+++ b/crates/assay-workflow/src/api/mod.rs
@@ -1,4 +1,5 @@
 pub mod activities;
+pub mod api_keys;
 pub mod auth;
 pub mod dashboard;
 pub mod events;
@@ -71,6 +72,7 @@ fn api_v1_router<S: WorkflowStore + 'static>() -> Router<Arc<AppState<S>>> {
         .merge(workers::router())
         .merge(namespaces::router())
         .merge(queues::router())
+        .merge(api_keys::router())
         .merge(meta::router())
 }
 

--- a/crates/assay-workflow/src/store/mod.rs
+++ b/crates/assay-workflow/src/store/mod.rs
@@ -371,6 +371,21 @@ pub trait WorkflowStore: Send + Sync + 'static {
         prefix: &str,
     ) -> impl Future<Output = anyhow::Result<bool>> + Send;
 
+    /// Return true iff the `api_keys` table has no rows. Used by the HTTP layer
+    /// to identify the first-ever key-creation window (where the `POST
+    /// /api/v1/api-keys` endpoint is callable without authentication).
+    fn api_keys_empty(&self) -> impl Future<Output = anyhow::Result<bool>> + Send;
+
+    /// Find an existing API key by its label. Returns None if no key has this
+    /// label (or `label` is NULL). Used to implement idempotent key creation:
+    /// a second `POST /api/v1/api-keys { label, idempotent: true }` call hits
+    /// this method and returns the existing record's metadata (without a
+    /// plaintext, which is only ever retrievable at generation time).
+    fn get_api_key_by_label(
+        &self,
+        label: &str,
+    ) -> impl Future<Output = anyhow::Result<Option<ApiKeyRecord>>> + Send;
+
     // ── Child Workflows ─────────────────────────────────────
 
     fn list_child_workflows(
@@ -412,7 +427,7 @@ pub trait WorkflowStore: Send + Sync + 'static {
 }
 
 /// API key metadata (hash is never exposed).
-#[derive(Clone, Debug, serde::Serialize)]
+#[derive(Clone, Debug, serde::Serialize, utoipa::ToSchema)]
 pub struct ApiKeyRecord {
     pub prefix: String,
     pub label: Option<String>,

--- a/crates/assay-workflow/src/store/postgres.rs
+++ b/crates/assay-workflow/src/store/postgres.rs
@@ -1122,6 +1122,30 @@ impl WorkflowStore for PostgresStore {
         Ok(res.rows_affected() > 0)
     }
 
+    async fn api_keys_empty(&self) -> Result<bool> {
+        let row: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM api_keys")
+            .fetch_one(&self.pool)
+            .await?;
+        Ok(row.0 == 0)
+    }
+
+    async fn get_api_key_by_label(
+        &self,
+        label: &str,
+    ) -> Result<Option<crate::store::ApiKeyRecord>> {
+        let row: Option<(String, Option<String>, f64)> = sqlx::query_as(
+            "SELECT prefix, label, created_at FROM api_keys WHERE label = $1 LIMIT 1",
+        )
+        .bind(label)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row.map(|(prefix, label, created_at)| crate::store::ApiKeyRecord {
+            prefix,
+            label,
+            created_at,
+        }))
+    }
+
     // ── Child Workflows ─────────────────────────────────────
 
     async fn list_child_workflows(&self, parent_id: &str) -> Result<Vec<WorkflowRecord>> {

--- a/crates/assay-workflow/src/store/sqlite.rs
+++ b/crates/assay-workflow/src/store/sqlite.rs
@@ -1256,6 +1256,27 @@ impl WorkflowStore for SqliteStore {
         Ok(res.rows_affected() > 0)
     }
 
+    async fn api_keys_empty(&self) -> Result<bool> {
+        let row: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM api_keys")
+            .fetch_one(&self.pool)
+            .await?;
+        Ok(row.0 == 0)
+    }
+
+    async fn get_api_key_by_label(&self, label: &str) -> Result<Option<ApiKeyRecord>> {
+        let row: Option<(String, Option<String>, f64)> = sqlx::query_as(
+            "SELECT prefix, label, created_at FROM api_keys WHERE label = ? LIMIT 1",
+        )
+        .bind(label)
+        .fetch_optional(&self.pool)
+        .await?;
+        Ok(row.map(|(prefix, label, created_at)| ApiKeyRecord {
+            prefix,
+            label,
+            created_at,
+        }))
+    }
+
     // ── Child Workflows ─────────────────────────────────────
 
     async fn list_child_workflows(&self, parent_id: &str) -> Result<Vec<WorkflowRecord>> {

--- a/crates/assay-workflow/tests/auth_test.rs
+++ b/crates/assay-workflow/tests/auth_test.rs
@@ -505,3 +505,156 @@ fn is_enabled_reflects_state() {
     assert!(AuthMode::jwt("https://auth.example.com".to_string(), None).is_enabled());
     assert!(AuthMode::combined("https://auth.example.com".to_string(), None).is_enabled());
 }
+
+// ── POST /api/v1/api-keys — bootstrap window + idempotent mode ────
+
+#[tokio::test]
+async fn bootstrap_post_api_keys_allowed_without_auth_when_empty() {
+    // Fresh store, api_keys table is empty. In api-key auth mode, the only
+    // way to mint the first key is unauthenticated POST /api/v1/api-keys.
+    let (url, _h) = start_server(AuthMode::api_key()).await;
+
+    let resp = client()
+        .post(format!("{url}/api/v1/api-keys"))
+        .json(&serde_json::json!({ "label": "first-ever", "idempotent": true }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201, "bootstrap window should allow unauth");
+
+    let body: serde_json::Value = resp.json().await.unwrap();
+    assert!(
+        body.get("plaintext").and_then(|v| v.as_str()).is_some(),
+        "fresh mint must include plaintext"
+    );
+    assert_eq!(body["label"], "first-ever");
+    assert!(body["prefix"].as_str().unwrap().starts_with("assay_"));
+}
+
+#[tokio::test]
+async fn bootstrap_closes_after_first_key() {
+    // First call closes the window; second unauth call must be rejected.
+    let (url, _h) = start_server(AuthMode::api_key()).await;
+
+    let first = client()
+        .post(format!("{url}/api/v1/api-keys"))
+        .json(&serde_json::json!({ "label": "k1" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(first.status(), 201);
+
+    let second = client()
+        .post(format!("{url}/api/v1/api-keys"))
+        .json(&serde_json::json!({ "label": "k2" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        second.status(),
+        401,
+        "bootstrap window closes once any key exists"
+    );
+}
+
+#[tokio::test]
+async fn bootstrap_only_on_post_api_keys_path() {
+    // Other endpoints don't get the bootstrap pass — empty api_keys table
+    // doesn't imply free access to everything.
+    let (url, _h) = start_server(AuthMode::api_key()).await;
+
+    let resp = client()
+        .get(format!("{url}/api/v1/workflows"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        401,
+        "bootstrap window only covers POST /api/v1/api-keys"
+    );
+}
+
+#[tokio::test]
+async fn api_keys_idempotent_returns_existing_without_plaintext() {
+    // Bootstrap the first key; then call again with the same label and
+    // idempotent=true. The server should return 200 with metadata but
+    // NO plaintext (the plaintext was issued once and can't be re-emitted).
+    let (url, _h) = start_server(AuthMode::api_key()).await;
+
+    let first = client()
+        .post(format!("{url}/api/v1/api-keys"))
+        .json(&serde_json::json!({ "label": "cc_api_key", "idempotent": true }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(first.status(), 201);
+    let first_body: serde_json::Value = first.json().await.unwrap();
+    let key = first_body["plaintext"].as_str().unwrap().to_string();
+
+    // Second call with idempotent=true — authenticated via the key we just received.
+    let second = client()
+        .post(format!("{url}/api/v1/api-keys"))
+        .header("Authorization", format!("Bearer {key}"))
+        .json(&serde_json::json!({ "label": "cc_api_key", "idempotent": true }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(second.status(), 200);
+    let second_body: serde_json::Value = second.json().await.unwrap();
+    assert!(
+        second_body.get("plaintext").is_none()
+            || second_body["plaintext"].is_null(),
+        "idempotent hit must omit plaintext"
+    );
+    assert_eq!(second_body["label"], "cc_api_key");
+    assert_eq!(second_body["prefix"], first_body["prefix"]);
+}
+
+#[tokio::test]
+async fn api_keys_non_idempotent_mints_another_with_same_label() {
+    // Without idempotent=true (default), the server mints a NEW key even when
+    // another key with the same label exists. Labels aren't unique in the
+    // engine; idempotency is opt-in.
+    let (url, _h) = start_server(AuthMode::api_key()).await;
+
+    let first = client()
+        .post(format!("{url}/api/v1/api-keys"))
+        .json(&serde_json::json!({ "label": "shared-label" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(first.status(), 201);
+    let first_body: serde_json::Value = first.json().await.unwrap();
+    let key = first_body["plaintext"].as_str().unwrap().to_string();
+
+    let second = client()
+        .post(format!("{url}/api/v1/api-keys"))
+        .header("Authorization", format!("Bearer {key}"))
+        .json(&serde_json::json!({ "label": "shared-label" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(second.status(), 201);
+    let second_body: serde_json::Value = second.json().await.unwrap();
+    assert!(second_body["plaintext"].as_str().is_some());
+    assert_ne!(
+        first_body["prefix"], second_body["prefix"],
+        "non-idempotent must mint a fresh key, different prefix"
+    );
+}
+
+#[tokio::test]
+async fn bootstrap_window_closed_in_no_auth_mode_is_a_noop() {
+    // no-auth mode: the whole API is open, so the bootstrap gate is irrelevant.
+    // This test just confirms we don't trip over ourselves in that configuration.
+    let (url, _h) = start_server(AuthMode::no_auth()).await;
+
+    let resp = client()
+        .post(format!("{url}/api/v1/api-keys"))
+        .json(&serde_json::json!({ "label": "anything" }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 201);
+}

--- a/site/pages/index.html
+++ b/site/pages/index.html
@@ -12,10 +12,10 @@
 
 
   <main>
-    <!-- v0.11.6 release banner -->
+    <!-- v0.11.7 release banner -->
     <a href="changelog.html" class="release-banner">
-      <span class="release-banner-tag">v0.11.6</span>
-      <span class="release-banner-text">Fix Postgres schema-migration crash on startup — semicolon inside a SQL line comment no longer produces phantom SQL fragments</span>
+      <span class="release-banner-tag">v0.11.7</span>
+      <span class="release-banner-text">POST /api/v1/api-keys with idempotent label + first-ever-bootstrap window — mint API keys via REST, no CLI subprocess required</span>
       <span class="release-banner-arrow">&rarr;</span>
     </a>
 
@@ -147,7 +147,7 @@
     <h2>Core Capabilities</h2>
     <section style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1.5rem; margin-bottom: 2rem;">
       <div class="card card-highlight">
-        <h3 style="margin-top: 0;">Workflow Engine <span style="color: var(--accent); font-size: 0.7rem; font-weight: 700; vertical-align: middle; padding: 2px 6px; border: 1px solid var(--accent); border-radius: 4px;">v0.11.6</span></h3>
+        <h3 style="margin-top: 0;">Workflow Engine <span style="color: var(--accent); font-size: 0.7rem; font-weight: 700; vertical-align: middle; padding: 2px 6px; border: 1px solid var(--accent); border-radius: 4px;">v0.11.7</span></h3>
         <p class="text-muted">Native durable workflow engine with deterministic-replay runtime. Activities (sequential + parallel), signals, durable timers, child workflows, side effects, live state via <code>ctx:register_query</code>, search attributes, optional S3 archival. Crash-safe by replay — workers can die mid-flight without losing work or duplicating side effects.</p>
         <pre style="margin-bottom: 0;"><code>workflow.define("Deploy", function(ctx, in)
   local img = ctx:execute_activity("build", in)
@@ -299,7 +299,7 @@ cargo install assay-lua
 
     <h3>mise</h3>
     <pre><code># .mise.toml
-"github:developerinlondon/assay" = "v0.11.6"</code></pre>
+"github:developerinlondon/assay" = "v0.11.7"</code></pre>
 
   </main>
 

--- a/stdlib/workflow.lua
+++ b/stdlib/workflow.lua
@@ -372,6 +372,55 @@ function M.namespaces.delete(name)
     end
 end
 
+-- ── API Keys ────────────────────────────────────────────────
+
+M.api_keys = {}
+
+--- Generate (or idempotently retrieve) an API key.
+---
+--- @param label string|nil  Optional label to tag the key with.
+--- @param opts table|nil    `{ idempotent = bool }`. When true and a key
+---                          with this `label` already exists, the server
+---                          returns the existing record's metadata without
+---                          a plaintext (which is only ever retrievable at
+---                          generation time).
+--- @return table            `{ plaintext?, prefix, label, created_at }`.
+---                          `plaintext` is present only on a fresh mint.
+---
+--- Bootstrap window: this call works without authentication iff the
+--- server's `api_keys` table is empty (first-ever key). After that, a
+--- valid Bearer token is required.
+function M.api_keys.generate(label, opts)
+    opts = opts or {}
+    local body = { label = label }
+    if opts.idempotent ~= nil then
+        body.idempotent = opts.idempotent
+    end
+    local resp = M._api("POST", "/api-keys", body)
+    if resp.status ~= 200 and resp.status ~= 201 then
+        error("workflow.api_keys.generate failed: " .. (resp.body or "unknown error"))
+    end
+    return json.parse(resp.body)
+end
+
+--- List API key metadata (hashes never exposed). Returns prefix + label
+--- + created_at per key.
+function M.api_keys.list()
+    local resp = M._api("GET", "/api-keys")
+    if resp.status ~= 200 then
+        error("workflow.api_keys.list failed: " .. (resp.body or "unknown error"))
+    end
+    return json.parse(resp.body)
+end
+
+--- Revoke an API key by its prefix (e.g. "assay_abcd1234...").
+function M.api_keys.delete(prefix)
+    local resp = M._api("DELETE", "/api-keys/" .. url_encode(prefix))
+    if resp.status ~= 204 and resp.status ~= 404 then
+        error("workflow.api_keys.delete failed: " .. (resp.body or "unknown error"))
+    end
+end
+
 -- ── Workers ─────────────────────────────────────────────────
 
 M.workers = {}


### PR DESCRIPTION
## Summary

Adds a REST alternative to `assay serve --generate-api-key` so consumers (gitops operators, embedders) can mint API keys over HTTP instead of shelling out to the CLI. Fills the architectural gap that was forcing downstream code to either `shell.exec` the CLI or write directly to assay's internal `api_keys` table.

## What changes

- **`POST /api/v1/api-keys`** — body `{ label?: string, idempotent?: boolean }`.
  - `idempotent=true` + existing label → `200 OK` with `{ prefix, label, created_at }` (no plaintext).
  - Otherwise → `201 Created` with `{ plaintext, prefix, label, created_at }`.
- **Bootstrap window** — the endpoint is callable **without authentication** iff the `api_keys` table is empty. Once any key exists, auth is required. This is how a freshly deployed server in API-key or combined mode receives its first credential without operator shell access.
- **`GET /api/v1/api-keys`** and **`DELETE /api/v1/api-keys/{prefix}`** — list / revoke.
- **`workflow.api_keys.{generate, list, delete}`** Lua stdlib helpers.
- Store trait gets `api_keys_empty()` (middleware gate) and `get_api_key_by_label(label)` (idempotent lookup); both implemented for SQLite and Postgres.

## Motivating use case

Downstream bootstrapping looks like this (from CC's gitops repo):

```lua
local workflow = require("assay.workflow")
local k8s = require("k8s")

-- Client-side idempotency: skip if we already have the plaintext
local ok = pcall(function() k8s.secrets:get("infra", "cc-workflows-api-key") end)
if ok then return end

-- First-ever call: bootstrap window is open
workflow.connect(os.getenv("ASSAY_ENGINE_URL"))
local resp = workflow.api_keys.generate("cc_api_key", { idempotent = true })

k8s.resources:create("infra", "Secret", {
    apiVersion = "v1", kind = "Secret",
    metadata = { name = "cc-workflows-api-key" },
    stringData = { service_api_key = resp.plaintext },
})
```

No `shell.exec`, no direct SQL, no k8s-awareness in assay.

## Versions

- `assay-workflow`: `0.1.4` → `0.1.5` (additive; downstream consumers on `version = "0.1"` continue to work)
- `assay-lua`: `0.11.6` → `0.11.7`

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test -p assay-workflow --test auth_test` — **27 passed** (21 existing + 6 new):
  - `bootstrap_post_api_keys_allowed_without_auth_when_empty`
  - `bootstrap_closes_after_first_key`
  - `bootstrap_only_on_post_api_keys_path`
  - `api_keys_idempotent_returns_existing_without_plaintext`
  - `api_keys_non_idempotent_mints_another_with_same_label`
  - `bootstrap_window_closed_in_no_auth_mode_is_a_noop`
- [x] `cargo test --workspace --no-fail-fast` — green on re-run. One existing Lua orchestration test (`lua_workflow_with_signal`) flaked once under parallel load; stable on subsequent runs (3/3 green in isolation). Unrelated to this change.
- [ ] CI green via `gh pr checks <this> --watch`; then squash-merge.
- [ ] Tag `v0.11.7`, watch release GHA (crates-io should publish both crates on bumped versions).