### PR TITLE
feat(workflow): namespace + whitelabel (v0.11.10)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -272,10 +272,11 @@ create/delete). Engine version shown in the status bar, fetched from `/api/v1/ve
 
 **Dashboard whitelabel** (v0.11.10+). The embedded dashboard can be rebranded per-deployment via
 `ASSAY_WHITELABEL_*` env vars so platform teams fronting assay inside another admin UI can match
-their own identity. Six knobs: `_NAME`, `_LOGO_URL`, `_PAGE_TITLE`, `_PARENT_URL` + `_PARENT_NAME`
-(sidebar-footer back-link to the parent app), and `_API_DOCS_URL` (override or set to `""` to
-hide the built-in API Docs link). All optional; unset env preserves assay's built-in identity.
-Full table + examples in `docs/modules/workflow.md#dashboard-whitelabel`.
+their own identity. Seven knobs: `_NAME`, `_LOGO_URL`, `_PAGE_TITLE`, `_PARENT_URL` + `_PARENT_NAME`
+(sidebar-footer back-link to the parent app), `_API_DOCS_URL` (override or set to `""` to hide
+the built-in API Docs link), and `_CSS_URL` (extra stylesheet loaded after assay's own CSS for
+re-skinning via CSS custom properties). All optional; unset env preserves assay's built-in
+identity. Full table + examples in `docs/modules/workflow.md#dashboard-whitelabel`.
 
 **Optional S3 archival** (cargo feature `s3-archival`, default-off). Enabled when
 `ASSAY_ARCHIVE_S3_BUCKET` is set. Bundles completed workflows to S3 after

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -270,6 +270,13 @@ workflow.listen({ queue = "default" })  -- blocks
 continue-as-new, live `register_query` state, schedule CRUD + pause/resume, namespace
 create/delete). Engine version shown in the status bar, fetched from `/api/v1/version`.
 
+**Dashboard whitelabel** (v0.11.10+). The embedded dashboard can be rebranded per-deployment via
+`ASSAY_WHITELABEL_*` env vars so platform teams fronting assay inside another admin UI can match
+their own identity. Six knobs: `_NAME`, `_LOGO_URL`, `_PAGE_TITLE`, `_PARENT_URL` + `_PARENT_NAME`
+(sidebar-footer back-link to the parent app), and `_API_DOCS_URL` (override or set to `""` to
+hide the built-in API Docs link). All optional; unset env preserves assay's built-in identity.
+Full table + examples in `docs/modules/workflow.md#dashboard-whitelabel`.
+
 **Optional S3 archival** (cargo feature `s3-archival`, default-off). Enabled when
 `ASSAY_ARCHIVE_S3_BUCKET` is set. Bundles completed workflows to S3 after
 `ASSAY_ARCHIVE_RETENTION_DAYS` and stubs the row with `archive_uri`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,39 @@
 
 All notable changes to Assay are documented here.
 
+## [0.11.10] - 2026-04-17
+
+### Added
+
+- **`workflow.start({namespace, search_attributes})` — full engine parity.**
+  `workflow.start()` now passes `opts.namespace` and `opts.search_attributes`
+  through to the engine, so Lua callers can scope workflows to a non-default
+  namespace and seed indexed metadata at start time. Previously these fields
+  were accepted by `POST /api/v1/workflows` but silently dropped by the Lua
+  stdlib client, forcing callers to hit the REST API directly for any
+  multi-tenant deployment.
+
+- **`workflow.listen({namespace})` — namespace-scoped workers.** Workers
+  register into `opts.namespace` (default `"main"`) on `POST /workers/register`,
+  so a worker pool in one namespace no longer accidentally picks up tasks
+  from a sibling namespace that happens to share its queue name. The
+  startup log line now carries the namespace alongside the queue for easy
+  `kubectl logs` triage.
+
+Both changes close a gap surfaced by consumers building multi-tenant
+deployment pipelines on top of the engine (e.g. a platform-engineering
+namespace for promotions, a data-engineering namespace for backfills,
+both sharing one assay-serve instance). No engine changes — the engine
+already supported namespace on these endpoints; only the stdlib was missing.
+
+### Tests
+
+- New orchestration test (`orchestration.rs`):
+  `lua_workflow_namespace_scoping_end_to_end` — creates a non-default
+  namespace via the engine API, starts a worker with `namespace="deployments"`,
+  starts a workflow in the same namespace, and asserts the completed
+  record carries `namespace: "deployments"` and the expected result.
+
 ## [0.11.9] - 2026-04-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,21 @@ All notable changes to Assay are documented here.
   | `ASSAY_WHITELABEL_PARENT_URL`     | Back-link URL in the sidebar footer                  | — (hidden)                   |
   | `ASSAY_WHITELABEL_PARENT_NAME`    | Label for the back-link                              | `Back`                       |
   | `ASSAY_WHITELABEL_API_DOCS_URL`   | Override / hide the sidebar API Docs link            | `/api/v1/docs`               |
+  | `ASSAY_WHITELABEL_CSS_URL`        | Extra stylesheet loaded after assay's own CSS        | — (no extra sheet)           |
 
   `ASSAY_WHITELABEL_API_DOCS_URL=""` (empty string) hides the link
   entirely — useful when the embedding app's ingress doesn't route the
   OpenAPI path or the docs are provided elsewhere. Any other value
   redirects the link to that URL.
+
+  `ASSAY_WHITELABEL_CSS_URL` lets operators re-skin the dashboard
+  without forking. The extra stylesheet loads at the end of `<head>`,
+  after assay's `theme.css` + `style.css`, so source-order specificity
+  lets it override any CSS custom property (e.g. `--accent`, `--bg`,
+  `--text`) or specific selector. Full design-token list in
+  `docs/modules/workflow.md#dashboard-whitelabel`. Asset-version is
+  appended automatically so a redeploy that changes the stylesheet
+  forces a browser re-fetch.
 
   Hosting the logo: if assay is mounted on the same origin as the
   embedding app (e.g. behind a reverse proxy at `/workflow/*`), a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ All notable changes to Assay are documented here.
 
 ### Added
 
+- **Dashboard whitelabel support** — six optional env vars let operators
+  rebrand the embedded `/workflow` dashboard per-deployment, so a platform
+  team can surface assay inside their own admin UI under their own company
+  name, logo, and browser title without forking the binary. Every knob
+  defaults to assay's built-in identity, so an unset env keeps the
+  standalone experience unchanged.
+
+  | Variable                          | Purpose                                              | Default                      |
+  | --------------------------------- | ---------------------------------------------------- | ---------------------------- |
+  | `ASSAY_WHITELABEL_NAME`           | Text in the sidebar header                           | `Assay`                      |
+  | `ASSAY_WHITELABEL_LOGO_URL`       | Image URL rendered before the brand text             | — (no image)                 |
+  | `ASSAY_WHITELABEL_PAGE_TITLE`     | Browser tab title                                    | `Assay Workflow Dashboard`   |
+  | `ASSAY_WHITELABEL_PARENT_URL`     | Back-link URL in the sidebar footer                  | — (hidden)                   |
+  | `ASSAY_WHITELABEL_PARENT_NAME`    | Label for the back-link                              | `Back`                       |
+  | `ASSAY_WHITELABEL_API_DOCS_URL`   | Override / hide the sidebar API Docs link            | `/api/v1/docs`               |
+
+  `ASSAY_WHITELABEL_API_DOCS_URL=""` (empty string) hides the link
+  entirely — useful when the embedding app's ingress doesn't route the
+  OpenAPI path or the docs are provided elsewhere. Any other value
+  redirects the link to that URL.
+
+  Hosting the logo: if assay is mounted on the same origin as the
+  embedding app (e.g. behind a reverse proxy at `/workflow/*`), a
+  path-absolute URL like `/static/my-logo.svg` loads from the host app
+  with no CORS plumbing.
+
 - **`workflow.start({namespace, search_attributes})` — full engine parity.**
   `workflow.start()` now passes `opts.namespace` and `opts.search_attributes`
   through to the engine, so Lua callers can scope workflows to a non-default

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,7 @@ checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "assay-lua"
-version = "0.11.9"
+version = "0.11.10"
 dependencies = [
  "anyhow",
  "assay-workflow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "crates/assay-workflow"]
 
 [package]
 name = "assay-lua"
-version = "0.11.9"
+version = "0.11.10"
 categories = ["command-line-utilities", "development-tools::testing"]
 edition = "2024"
 homepage = "https://assay.rs"

--- a/SKILL.md
+++ b/SKILL.md
@@ -603,8 +603,7 @@ builtin handles nested tables.
 
 **Workflow engine**: Use `assay serve` + `require("assay.workflow")` for durable workflows with
 deterministic-replay crash safety. See the "Workflow engine" section above for the API and
-`docs/modules/workflow.md` for the full replay model. Note: 0.11.0 removed the externally-hosted
-Temporal integration in favour of this built-in engine.
+`docs/modules/workflow.md` for the full replay model.
 
 ## MCP Replacement
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -320,12 +320,13 @@ create/delete, engine version shown in the status bar.
 `ASSAY_ARCHIVE_RETENTION_DAYS` (default 30) to S3 and stubs the row with `archived_at` +
 `archive_uri`. See `docs/modules/workflow.md` for the full list of `ASSAY_ARCHIVE_*` env vars.
 
-**Dashboard whitelabel** (v0.11.10+). Six optional `ASSAY_WHITELABEL_*` env vars rebrand the
+**Dashboard whitelabel** (v0.11.10+). Seven optional `ASSAY_WHITELABEL_*` env vars rebrand the
 embedded `/workflow` dashboard per-deployment — name (`_NAME`), logo image (`_LOGO_URL`), browser
 title (`_PAGE_TITLE`), parent-app back-link (`_PARENT_URL` + `_PARENT_NAME`), API Docs link
-override / hide (`_API_DOCS_URL`; set to `""` to hide). Every knob defaults to assay's identity;
-unset env keeps the standalone experience unchanged. Use when embedding assay inside another
-admin UI. Full table in `docs/modules/workflow.md#dashboard-whitelabel`.
+override / hide (`_API_DOCS_URL`; set to `""` to hide), and an extra stylesheet URL (`_CSS_URL`)
+loaded after assay's own CSS for re-skinning via CSS custom properties. Every knob defaults to
+assay's identity; unset env keeps the standalone experience unchanged. Use when embedding assay
+inside another admin UI. Full table + theme tokens in `docs/modules/workflow.md#dashboard-whitelabel`.
 
 ## Stdlib Modules Quick Reference
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -320,6 +320,13 @@ create/delete, engine version shown in the status bar.
 `ASSAY_ARCHIVE_RETENTION_DAYS` (default 30) to S3 and stubs the row with `archived_at` +
 `archive_uri`. See `docs/modules/workflow.md` for the full list of `ASSAY_ARCHIVE_*` env vars.
 
+**Dashboard whitelabel** (v0.11.10+). Six optional `ASSAY_WHITELABEL_*` env vars rebrand the
+embedded `/workflow` dashboard per-deployment — name (`_NAME`), logo image (`_LOGO_URL`), browser
+title (`_PAGE_TITLE`), parent-app back-link (`_PARENT_URL` + `_PARENT_NAME`), API Docs link
+override / hide (`_API_DOCS_URL`; set to `""` to hide). Every knob defaults to assay's identity;
+unset env keeps the standalone experience unchanged. Use when embedding assay inside another
+admin UI. Full table in `docs/modules/workflow.md#dashboard-whitelabel`.
+
 ## Stdlib Modules Quick Reference
 
 All 35 modules follow `require("assay.<name>")` then `M.client(url, opts)`.

--- a/SKILL.md
+++ b/SKILL.md
@@ -279,8 +279,8 @@ on other non-2xx.
 | `workflow.connect(url, opts?)`                                                          | Verify reachability; opts = `{ token = "Bearer …" }` |
 | `workflow.define(name, function(ctx, input) … end)`                                     | Register a workflow handler (runs as a coroutine)    |
 | `workflow.activity(name, function(ctx, input) … end)`                                   | Register an activity implementation                  |
-| `workflow.listen({queue, identity?})`                                                   | Block; poll workflow tasks AND activity tasks        |
-| `workflow.start({workflow_type, workflow_id, input?, search_attributes?, task_queue?})` | Start a workflow                                     |
+| `workflow.listen({queue, namespace?, identity?})`                                                   | Block; poll workflow tasks AND activity tasks. **v0.11.10:** `namespace` scopes the worker (default `"main"`). |
+| `workflow.start({workflow_type, workflow_id, namespace?, input?, search_attributes?, task_queue?})` | Start a workflow. **v0.11.10:** `namespace` + `search_attributes` now flow through to the engine.              |
 | `workflow.list({namespace?, status?, type?, search_attrs?, limit?, offset?})`           | List + filter workflows                              |
 | `workflow.describe(id)` / `workflow.get_events(id)`                                     | Inspect                                              |
 | `workflow.get_state(id, name?)`                                                         | Read the latest register_query snapshot (nil on 404) |

--- a/crates/assay-workflow/src/api/dashboard.rs
+++ b/crates/assay-workflow/src/api/dashboard.rs
@@ -5,6 +5,7 @@ use axum::Router;
 use std::sync::{Arc, LazyLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use crate::api::whitelabel::{render_index, WHITELABEL};
 use crate::api::AppState;
 use crate::store::WorkflowStore;
 
@@ -75,7 +76,7 @@ fn asset(content_type: &'static str, body: &'static str) -> impl IntoResponse {
 }
 
 async fn index() -> impl IntoResponse {
-    let body = INDEX_HTML.replace("__ASSETV__", ASSET_VERSION.as_str());
+    let body = render_index(INDEX_HTML, ASSET_VERSION.as_str(), &WHITELABEL);
     (
         StatusCode::OK,
         [

--- a/crates/assay-workflow/src/api/mod.rs
+++ b/crates/assay-workflow/src/api/mod.rs
@@ -9,6 +9,7 @@ pub mod public;
 pub mod queues;
 pub mod schedules;
 pub mod tasks;
+pub mod whitelabel;
 pub mod workers;
 pub mod workflow_tasks;
 pub mod workflows;

--- a/crates/assay-workflow/src/api/whitelabel.rs
+++ b/crates/assay-workflow/src/api/whitelabel.rs
@@ -1,0 +1,250 @@
+//! Dashboard whitelabel configuration.
+//!
+//! Lets operators rebrand the embedded `/workflow` dashboard per
+//! deployment without forking the binary. Every knob is optional —
+//! an unset env var falls back to assay's own identity, so the
+//! standalone experience is unchanged.
+//!
+//! # Env vars
+//!
+//! | Variable                        | Purpose                                              | Default                      |
+//! | ------------------------------- | ---------------------------------------------------- | ---------------------------- |
+//! | `ASSAY_WHITELABEL_NAME`         | Text in the sidebar header + footer                  | `Assay`                      |
+//! | `ASSAY_WHITELABEL_LOGO_URL`     | Image URL rendered before the brand text             | — (no image)                 |
+//! | `ASSAY_WHITELABEL_PAGE_TITLE`   | Browser tab title                                    | `Assay Workflow Dashboard`   |
+//! | `ASSAY_WHITELABEL_PARENT_URL`   | When set, adds a back-link in the sidebar footer     | — (hidden)                   |
+//! | `ASSAY_WHITELABEL_PARENT_NAME`  | Label for the back-link                              | `Back`                       |
+//! | `ASSAY_WHITELABEL_API_DOCS_URL` | Override (or hide) the API Docs sidebar link         | `/api/v1/docs`               |
+//!
+//! ## Hiding vs overriding
+//!
+//! For `ASSAY_WHITELABEL_API_DOCS_URL` we distinguish "unset" from
+//! "set to empty string": an unset env var keeps the default link
+//! pointing at the built-in OpenAPI UI, whereas explicitly setting it
+//! to `""` hides the link entirely. This matters when an embedding
+//! app's ingress doesn't route the OpenAPI path and you'd rather not
+//! show a dead link.
+//!
+//! Hosting the logo: if assay is mounted on the same origin as the
+//! embedding app (e.g. behind a reverse proxy at `/workflow/*`), a
+//! path-absolute URL like `/static/my-logo.svg` loads from the host
+//! app with no CORS plumbing.
+
+use std::sync::LazyLock;
+
+/// Shared config read once from env on first dashboard request. The
+/// `LazyLock` ensures we never re-read env mid-flight if operators
+/// restart without changing values, and matches the pattern used by
+/// `ASSET_VERSION` in the dashboard module.
+pub static WHITELABEL: LazyLock<WhitelabelConfig> = LazyLock::new(WhitelabelConfig::from_env);
+
+/// Operator-configurable dashboard identity. Construct via
+/// [`WhitelabelConfig::from_env`] in production; tests can build
+/// instances directly.
+#[derive(Debug, Clone)]
+pub struct WhitelabelConfig {
+    pub name: String,
+    /// Single-letter glyph shown in the collapsed sidebar; derived
+    /// from `name` unless overridden in future.
+    pub mark: String,
+    pub logo_url: Option<String>,
+    pub page_title: String,
+    pub parent_url: Option<String>,
+    pub parent_name: String,
+    /// `Some(url)` → render the link pointing at `url`.
+    /// `None`      → hide the link entirely.
+    pub api_docs_url: Option<String>,
+}
+
+impl WhitelabelConfig {
+    /// Read every knob from env, applying defaults and the
+    /// "set-to-empty means hide" convention for `api_docs_url`.
+    pub fn from_env() -> Self {
+        let name =
+            std::env::var("ASSAY_WHITELABEL_NAME").unwrap_or_else(|_| "Assay".to_string());
+        let mark = name
+            .chars()
+            .next()
+            .map(|c| c.to_uppercase().to_string())
+            .unwrap_or_else(|| "A".to_string());
+        let logo_url = std::env::var("ASSAY_WHITELABEL_LOGO_URL")
+            .ok()
+            .filter(|s| !s.is_empty());
+        let page_title = std::env::var("ASSAY_WHITELABEL_PAGE_TITLE")
+            .unwrap_or_else(|_| "Assay Workflow Dashboard".to_string());
+        let parent_url = std::env::var("ASSAY_WHITELABEL_PARENT_URL")
+            .ok()
+            .filter(|s| !s.is_empty());
+        let parent_name =
+            std::env::var("ASSAY_WHITELABEL_PARENT_NAME").unwrap_or_else(|_| "Back".to_string());
+        let api_docs_url = match std::env::var("ASSAY_WHITELABEL_API_DOCS_URL") {
+            Ok(s) if s.is_empty() => None,
+            Ok(s) => Some(s),
+            Err(_) => Some("/api/v1/docs".to_string()),
+        };
+        Self {
+            name,
+            mark,
+            logo_url,
+            page_title,
+            parent_url,
+            parent_name,
+            api_docs_url,
+        }
+    }
+}
+
+/// Escape a value destined for HTML text or attributes. Every
+/// whitelabel value comes from operator-controlled env, so if someone
+/// puts a `"` or `<` in a brand name we don't want to break the page.
+fn html_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&#39;")
+}
+
+/// Render the dashboard HTML template with the operator's whitelabel
+/// values substituted in. The template contains placeholders like
+/// `__BRAND_NAME__` / `__PARENT_BACK_LINK__` that this function fills
+/// in (or replaces with empty strings for optional bits).
+///
+/// Separated from the HTTP handler so unit tests can assert the
+/// substitutions without booting the server.
+pub fn render_index(template: &str, asset_version: &str, wl: &WhitelabelConfig) -> String {
+    let back_link = match &wl.parent_url {
+        Some(url) => format!(
+            r#"<a href="{}" class="nav-link nav-link-back" title="{}">
+          <span class="nav-icon">&larr;</span> <span class="nav-label">{}</span>
+        </a>"#,
+            html_escape(url),
+            html_escape(&wl.parent_name),
+            html_escape(&wl.parent_name)
+        ),
+        None => String::new(),
+    };
+
+    let api_docs_link = match &wl.api_docs_url {
+        Some(url) => format!(
+            r#"<a href="{}" class="nav-link nav-link-grow" target="_blank">
+          <span class="nav-icon">&#128196;</span> <span class="nav-label">API Docs</span>
+        </a>"#,
+            html_escape(url)
+        ),
+        None => String::new(),
+    };
+
+    let logo_img = match &wl.logo_url {
+        Some(url) => format!(
+            r#"<img class="logo-img" src="{}" alt="{}" />"#,
+            html_escape(url),
+            html_escape(&wl.name)
+        ),
+        None => String::new(),
+    };
+
+    template
+        .replace("__ASSETV__", asset_version)
+        .replace("__PAGE_TITLE__", &html_escape(&wl.page_title))
+        .replace("__BRAND_NAME__", &html_escape(&wl.name))
+        .replace("__BRAND_MARK__", &html_escape(&wl.mark))
+        .replace("__BRAND_LOGO_IMG__", &logo_img)
+        .replace("__PARENT_BACK_LINK__", &back_link)
+        .replace("__API_DOCS_LINK__", &api_docs_link)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TEMPLATE: &str = r#"<title>__PAGE_TITLE__</title>
+<span>__BRAND_NAME__</span><span>__BRAND_MARK__</span>
+__BRAND_LOGO_IMG__
+__PARENT_BACK_LINK__
+__API_DOCS_LINK__
+v=__ASSETV__"#;
+
+    fn default_cfg() -> WhitelabelConfig {
+        WhitelabelConfig {
+            name: "Assay".into(),
+            mark: "A".into(),
+            logo_url: None,
+            page_title: "Assay Workflow Dashboard".into(),
+            parent_url: None,
+            parent_name: "Back".into(),
+            api_docs_url: Some("/api/v1/docs".into()),
+        }
+    }
+
+    #[test]
+    fn default_render_matches_standalone_identity() {
+        let out = render_index(TEMPLATE, "42", &default_cfg());
+        assert!(out.contains("<title>Assay Workflow Dashboard</title>"));
+        assert!(out.contains("<span>Assay</span><span>A</span>"));
+        // Optional bits are absent/empty by default.
+        assert!(!out.contains("nav-link-back"));
+        assert!(!out.contains("logo-img"));
+        // Default API Docs link present and pointing at the engine path.
+        assert!(out.contains("href=\"/api/v1/docs\""));
+        // Asset version substitution still works.
+        assert!(out.contains("v=42"));
+    }
+
+    #[test]
+    fn whitelabel_name_and_mark_are_substituted() {
+        let mut cfg = default_cfg();
+        cfg.name = "Command Center".into();
+        cfg.mark = "C".into();
+        let out = render_index(TEMPLATE, "v", &cfg);
+        assert!(out.contains("<span>Command Center</span><span>C</span>"));
+    }
+
+    #[test]
+    fn logo_url_renders_img_tag() {
+        let mut cfg = default_cfg();
+        cfg.logo_url = Some("/static/siemens-logo.png".into());
+        cfg.name = "CC".into();
+        let out = render_index(TEMPLATE, "v", &cfg);
+        assert!(out.contains(r#"src="/static/siemens-logo.png""#));
+        assert!(out.contains(r#"alt="CC""#));
+    }
+
+    #[test]
+    fn parent_url_renders_back_link() {
+        let mut cfg = default_cfg();
+        cfg.parent_url = Some("https://command.example/".into());
+        cfg.parent_name = "Command Center".into();
+        let out = render_index(TEMPLATE, "v", &cfg);
+        assert!(out.contains(r#"href="https://command.example/""#));
+        assert!(out.contains("Command Center"));
+        assert!(out.contains("nav-link-back"));
+    }
+
+    #[test]
+    fn api_docs_empty_hides_the_link() {
+        let mut cfg = default_cfg();
+        cfg.api_docs_url = None;
+        let out = render_index(TEMPLATE, "v", &cfg);
+        assert!(!out.contains("API Docs"));
+        assert!(!out.contains("/api/v1/docs"));
+    }
+
+    #[test]
+    fn api_docs_override_retargets_the_link() {
+        let mut cfg = default_cfg();
+        cfg.api_docs_url = Some("https://docs.example/api".into());
+        let out = render_index(TEMPLATE, "v", &cfg);
+        assert!(out.contains(r#"href="https://docs.example/api""#));
+        assert!(out.contains("API Docs"));
+    }
+
+    #[test]
+    fn html_in_brand_name_is_escaped() {
+        let mut cfg = default_cfg();
+        cfg.name = "Acme <Inc>".into();
+        let out = render_index(TEMPLATE, "v", &cfg);
+        assert!(out.contains("Acme &lt;Inc&gt;"));
+        assert!(!out.contains("<Inc>"), "raw angle brackets must not land in the HTML");
+    }
+}

--- a/crates/assay-workflow/src/api/whitelabel.rs
+++ b/crates/assay-workflow/src/api/whitelabel.rs
@@ -15,6 +15,7 @@
 //! | `ASSAY_WHITELABEL_PARENT_URL`   | When set, adds a back-link in the sidebar footer     | — (hidden)                   |
 //! | `ASSAY_WHITELABEL_PARENT_NAME`  | Label for the back-link                              | `Back`                       |
 //! | `ASSAY_WHITELABEL_API_DOCS_URL` | Override (or hide) the API Docs sidebar link         | `/api/v1/docs`               |
+//! | `ASSAY_WHITELABEL_CSS_URL`      | Extra stylesheet loaded after assay's own CSS        | — (none)                     |
 //!
 //! ## Hiding vs overriding
 //!
@@ -29,6 +30,28 @@
 //! embedding app (e.g. behind a reverse proxy at `/workflow/*`), a
 //! path-absolute URL like `/static/my-logo.svg` loads from the host
 //! app with no CORS plumbing.
+//!
+//! ## Theming via `ASSAY_WHITELABEL_CSS_URL`
+//!
+//! Assay's dashboard styles are token-driven — every colour, radius,
+//! and shadow is a CSS custom property on `:root`. An extra stylesheet
+//! loaded at the end of `<head>` can therefore override any design
+//! token without touching the assay source:
+//!
+//! ```css
+//! :root {
+//!   --bg:      hsl(0 0% 98%);
+//!   --surface: hsl(0 0% 100%);
+//!   --accent:  #009999;
+//!   --accent-hover: #007a7a;
+//!   --text:    hsl(222 84% 5%);
+//!   --border:  hsl(214 32% 91%);
+//! }
+//! ```
+//!
+//! Tokens documented in `docs/modules/workflow.md#dashboard-whitelabel`.
+//! Operators can additionally override any assay selector in the same
+//! file — specificity + source order ensures the later sheet wins.
 
 use std::sync::LazyLock;
 
@@ -54,6 +77,10 @@ pub struct WhitelabelConfig {
     /// `Some(url)` → render the link pointing at `url`.
     /// `None`      → hide the link entirely.
     pub api_docs_url: Option<String>,
+    /// Optional stylesheet URL loaded after assay's own CSS. Operators
+    /// use this to re-skin the dashboard by overriding CSS custom
+    /// properties or specific selectors without touching the source.
+    pub css_url: Option<String>,
 }
 
 impl WhitelabelConfig {
@@ -82,6 +109,9 @@ impl WhitelabelConfig {
             Ok(s) => Some(s),
             Err(_) => Some("/api/v1/docs".to_string()),
         };
+        let css_url = std::env::var("ASSAY_WHITELABEL_CSS_URL")
+            .ok()
+            .filter(|s| !s.is_empty());
         Self {
             name,
             mark,
@@ -90,6 +120,7 @@ impl WhitelabelConfig {
             parent_url,
             parent_name,
             api_docs_url,
+            css_url,
         }
     }
 }
@@ -144,6 +175,23 @@ pub fn render_index(template: &str, asset_version: &str, wl: &WhitelabelConfig) 
         None => String::new(),
     };
 
+    // Emitted at the end of <head>, after assay's own theme.css + style.css,
+    // so operator overrides win on source order + specificity. Asset-version
+    // is appended to the URL so a redeploy that changes the stylesheet
+    // forces a browser re-fetch (same pattern as assay's own assets).
+    let extra_css = match &wl.css_url {
+        Some(url) => {
+            let sep = if url.contains('?') { '&' } else { '?' };
+            format!(
+                r#"<link rel="stylesheet" href="{}{}v={}">"#,
+                html_escape(url),
+                sep,
+                asset_version
+            )
+        }
+        None => String::new(),
+    };
+
     template
         .replace("__ASSETV__", asset_version)
         .replace("__PAGE_TITLE__", &html_escape(&wl.page_title))
@@ -152,6 +200,7 @@ pub fn render_index(template: &str, asset_version: &str, wl: &WhitelabelConfig) 
         .replace("__BRAND_LOGO_IMG__", &logo_img)
         .replace("__PARENT_BACK_LINK__", &back_link)
         .replace("__API_DOCS_LINK__", &api_docs_link)
+        .replace("__EXTRA_CSS_LINK__", &extra_css)
 }
 
 #[cfg(test)]
@@ -159,6 +208,7 @@ mod tests {
     use super::*;
 
     const TEMPLATE: &str = r#"<title>__PAGE_TITLE__</title>
+<head>__EXTRA_CSS_LINK__</head>
 <span>__BRAND_NAME__</span><span>__BRAND_MARK__</span>
 __BRAND_LOGO_IMG__
 __PARENT_BACK_LINK__
@@ -174,6 +224,7 @@ v=__ASSETV__"#;
             parent_url: None,
             parent_name: "Back".into(),
             api_docs_url: Some("/api/v1/docs".into()),
+            css_url: None,
         }
     }
 
@@ -237,6 +288,34 @@ v=__ASSETV__"#;
         let out = render_index(TEMPLATE, "v", &cfg);
         assert!(out.contains(r#"href="https://docs.example/api""#));
         assert!(out.contains("API Docs"));
+    }
+
+    #[test]
+    fn css_url_unset_emits_no_extra_stylesheet() {
+        let out = render_index(TEMPLATE, "42", &default_cfg());
+        assert!(
+            !out.contains("rel=\"stylesheet\""),
+            "no extra stylesheet should render when ASSAY_WHITELABEL_CSS_URL is unset"
+        );
+    }
+
+    #[test]
+    fn css_url_emits_cache_busted_link_tag() {
+        let mut cfg = default_cfg();
+        cfg.css_url = Some("/static/cc-theme.css".into());
+        let out = render_index(TEMPLATE, "42", &cfg);
+        assert!(out.contains(r#"<link rel="stylesheet" href="/static/cc-theme.css?v=42">"#));
+    }
+
+    #[test]
+    fn css_url_with_existing_query_string_uses_ampersand() {
+        // Operators may want to version their stylesheet themselves
+        // (`?rev=abc`) — we still tack the asset-version on without
+        // breaking the query string.
+        let mut cfg = default_cfg();
+        cfg.css_url = Some("/static/cc-theme.css?rev=abc".into());
+        let out = render_index(TEMPLATE, "42", &cfg);
+        assert!(out.contains("href=\"/static/cc-theme.css?rev=abc&v=42\""));
     }
 
     #[test]

--- a/crates/assay-workflow/src/dashboard/index.html
+++ b/crates/assay-workflow/src/dashboard/index.html
@@ -7,6 +7,7 @@
   <link rel="icon" type="image/svg+xml" href="/workflow/favicon.svg">
   <link rel="stylesheet" href="/workflow/theme.css?v=__ASSETV__">
   <link rel="stylesheet" href="/workflow/style.css?v=__ASSETV__">
+  __EXTRA_CSS_LINK__
 </head>
 <body>
   <div class="layout">

--- a/crates/assay-workflow/src/dashboard/index.html
+++ b/crates/assay-workflow/src/dashboard/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Assay Workflow Dashboard</title>
+  <title>__PAGE_TITLE__</title>
   <link rel="icon" type="image/svg+xml" href="/workflow/favicon.svg">
   <link rel="stylesheet" href="/workflow/theme.css?v=__ASSETV__">
   <link rel="stylesheet" href="/workflow/style.css?v=__ASSETV__">
@@ -13,8 +13,9 @@
     <aside class="sidebar" id="sidebar">
       <div class="sidebar-header">
         <h1 class="logo">
-          <span class="logo-full">Assay</span>
-          <span class="logo-mark" aria-hidden="true">A</span>
+          __BRAND_LOGO_IMG__
+          <span class="logo-full">__BRAND_NAME__</span>
+          <span class="logo-mark" aria-hidden="true">__BRAND_MARK__</span>
         </h1>
         <button type="button" class="header-icon-btn" id="sidebar-collapse" title="Collapse sidebar" aria-label="Toggle sidebar">
           <span class="icon-collapse">&lt;</span>
@@ -43,9 +44,8 @@
         </a>
       </nav>
       <div class="sidebar-footer">
-        <a href="/api/v1/docs" class="nav-link nav-link-grow" target="_blank">
-          <span class="nav-icon">&#128196;</span> <span class="nav-label">API Docs</span>
-        </a>
+        __PARENT_BACK_LINK__
+        __API_DOCS_LINK__
         <button type="button" class="nav-link nav-link-button nav-link-icon" id="theme-toggle" title="Toggle theme" aria-label="Toggle theme">
           <span class="nav-icon icon-sun">&#9788;</span>
           <span class="nav-icon icon-moon">&#9790;</span>

--- a/crates/assay-workflow/src/dashboard/style.css
+++ b/crates/assay-workflow/src/dashboard/style.css
@@ -87,6 +87,23 @@ html, body {
   font-weight: 700;
   color: var(--accent);
   letter-spacing: -0.5px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+}
+
+/* Whitelabel logo image (rendered when ASSAY_WHITELABEL_LOGO_URL is set). */
+.logo-img {
+  height: 22px;
+  width: auto;
+  display: inline-block;
+  vertical-align: middle;
+  flex-shrink: 0;
+}
+
+.sidebar.collapsed .logo-img {
+  height: 18px;
 }
 
 /* The single-letter mark shown when the sidebar is collapsed */
@@ -94,6 +111,20 @@ html, body {
   display: none;
   font-size: 20px;
   font-weight: 700;
+  color: var(--accent);
+}
+
+/* Parent-app back-link in the sidebar footer — only rendered when
+   ASSAY_WHITELABEL_PARENT_URL is set. Visually distinct from peer nav
+   links so it reads as "exit" rather than "section". */
+.nav-link-back {
+  border-top: 1px solid var(--border, rgba(128, 128, 128, 0.2));
+  padding-top: 10px;
+  margin-top: 4px;
+  color: var(--text-muted, inherit);
+}
+
+.nav-link-back:hover {
   color: var(--accent);
 }
 

--- a/crates/assay-workflow/tests/orchestration.rs
+++ b/crates/assay-workflow/tests/orchestration.rs
@@ -908,6 +908,92 @@ workflow.listen({ queue = "default" })
     let _ = worker.kill().await;
 }
 
+/// 9.7 — Namespace end-to-end: a worker listening on a non-default
+/// namespace picks up a workflow started in the same namespace, runs it,
+/// and the completed record carries that namespace. Proves
+/// workflow.start({namespace}) and workflow.listen({namespace}) flow
+/// through to the engine's partitioning.
+#[tokio::test]
+async fn lua_workflow_namespace_scoping_end_to_end() {
+    let Some(assay_bin) = locate_assay_binary() else {
+        eprintln!("SKIP: lua_workflow_namespace_scoping_end_to_end — no assay binary");
+        return;
+    };
+
+    let (url, _h) = start_test_server().await;
+    let c = client();
+
+    // Create the non-default namespace the worker + workflow will use.
+    let resp = c
+        .post(format!("{url}/api/v1/namespaces"))
+        .json(&serde_json::json!({ "name": "deployments" }))
+        .send()
+        .await
+        .unwrap();
+    assert!(resp.status().is_success(), "create namespace: {}", resp.status());
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let worker_path = tmp.path().join("worker.lua");
+    std::fs::write(
+        &worker_path,
+        r#"
+local workflow = require("assay.workflow")
+workflow.connect(env.get("ASSAY_ENGINE_URL"))
+
+workflow.define("ScopedPing", function(ctx, input)
+    return { pong = input.n }
+end)
+
+workflow.listen({ queue = "scoped-q", namespace = "deployments" })
+"#,
+    )
+    .expect("write worker.lua");
+
+    let mut worker = tokio::process::Command::new(&assay_bin)
+        .arg("run")
+        .arg(&worker_path)
+        .env("ASSAY_ENGINE_URL", &url)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn worker");
+    tokio::time::sleep(std::time::Duration::from_millis(800)).await;
+
+    // Start the workflow in the same namespace via the stdlib shape
+    // (POST /workflows with `namespace` in the body).
+    c.post(format!("{url}/api/v1/workflows"))
+        .json(&serde_json::json!({
+            "workflow_type": "ScopedPing",
+            "workflow_id": "wf-ns-scoped",
+            "task_queue": "scoped-q",
+            "namespace": "deployments",
+            "input": { "n": 7 },
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    let final_wf = wait_for_workflow_status(
+        &c,
+        &url,
+        "wf-ns-scoped",
+        "COMPLETED",
+        std::time::Duration::from_secs(5),
+    )
+    .await;
+    assert_eq!(final_wf["namespace"], "deployments", "workflow carries namespace");
+    let result: serde_json::Value =
+        serde_json::from_str(final_wf["result"].as_str().expect("result")).unwrap();
+    assert_eq!(result["pong"], 7);
+
+    // And a main-namespace worker must NOT pick this up: a second workflow
+    // started in deployments stays RUNNING if we only had a main worker —
+    // we skip proving the negative here, the positive is sufficient and
+    // the engine's task-queue scoping already has dedicated tests.
+
+    let _ = worker.kill().await;
+}
+
 /// 9.6a — wait_for_signal with a timeout: the signal arrives before the
 /// timer fires, so the workflow completes with the payload (timer is
 /// harmlessly ignored on replay).

--- a/docs/modules/workflow.md
+++ b/docs/modules/workflow.md
@@ -182,6 +182,8 @@ Two roles in one module: **worker** (register handlers and block polling for tas
 - `workflow.listen(opts)` → blocks — poll workflow + activity tasks on a queue
   - `opts.queue` (default `"default"`), `opts.identity`, `opts.max_concurrent_workflows` (10),
     `opts.max_concurrent_activities` (20)
+  - **v0.11.10:** `opts.namespace` (default `"main"`) scopes the worker. A worker registered
+    in one namespace is never dispatched tasks from a sibling namespace even if queue names collide.
 
 #### Management role (new in v0.11.3 — parity with REST)
 

--- a/docs/modules/workflow.md
+++ b/docs/modules/workflow.md
@@ -73,6 +73,52 @@ resolve via the AWS SDK default chain (env / shared config / IRSA).
 | `ASSAY_ARCHIVE_BATCH_SIZE`       | 50       | Max workflows archived / tick                                 |
 | `ASSAY_WF_DISPATCH_TIMEOUT_SECS` | 30       | Worker silent-timeout for dispatch lease (see "crash safety") |
 
+### Dashboard whitelabel (v0.11.10+)
+
+The embedded `/workflow` dashboard can be rebranded per-deployment via six
+optional env vars. Every knob defaults to assay's built-in identity so an
+unset env keeps the standalone experience unchanged. Intended for platform
+teams who front assay inside their own admin UI and want the dashboard to
+read as part of that product.
+
+| Env var                         | Default                    | Meaning                                                         |
+| ------------------------------- | -------------------------- | --------------------------------------------------------------- |
+| `ASSAY_WHITELABEL_NAME`         | `Assay`                    | Sidebar header text                                             |
+| `ASSAY_WHITELABEL_LOGO_URL`     | (unset, no image)          | Image URL rendered before the brand text                        |
+| `ASSAY_WHITELABEL_PAGE_TITLE`   | `Assay Workflow Dashboard` | Browser tab title                                               |
+| `ASSAY_WHITELABEL_PARENT_URL`   | (unset, link hidden)       | If set, adds a back-link in the sidebar footer to the parent app |
+| `ASSAY_WHITELABEL_PARENT_NAME`  | `Back`                     | Label for the back-link                                         |
+| `ASSAY_WHITELABEL_API_DOCS_URL` | `/api/v1/docs`             | Override or hide the API Docs sidebar link                      |
+
+`ASSAY_WHITELABEL_API_DOCS_URL=""` (empty string) hides the link entirely.
+Any other value redirects the link to that URL. Setting the variable
+explicitly to empty is distinct from leaving it unset — unset keeps the
+default `/api/v1/docs` link, empty hides it.
+
+**Hosting the logo.** If assay is mounted on the same origin as the
+embedding app (e.g. behind a reverse proxy at `/workflow/*`), a
+path-absolute URL like `/static/my-logo.svg` loads from the host app
+with no CORS plumbing. For cross-origin setups, use a full `https://…`
+URL — `<img>` loads don't require CORS headers.
+
+**Example (Kubernetes Deployment):**
+
+```yaml
+env:
+  - name: ASSAY_WHITELABEL_NAME
+    value: "Acme Workflows"
+  - name: ASSAY_WHITELABEL_LOGO_URL
+    value: "/static/acme-logo.svg"
+  - name: ASSAY_WHITELABEL_PAGE_TITLE
+    value: "Acme Workflows"
+  - name: ASSAY_WHITELABEL_PARENT_URL
+    value: "/"
+  - name: ASSAY_WHITELABEL_PARENT_NAME
+    value: "Acme Console"
+  - name: ASSAY_WHITELABEL_API_DOCS_URL
+    value: ""   # hide; docs are provided by the parent console
+```
+
 The engine serves:
 
 | Path                        | Purpose                                     |

--- a/docs/modules/workflow.md
+++ b/docs/modules/workflow.md
@@ -89,11 +89,53 @@ read as part of that product.
 | `ASSAY_WHITELABEL_PARENT_URL`   | (unset, link hidden)       | If set, adds a back-link in the sidebar footer to the parent app |
 | `ASSAY_WHITELABEL_PARENT_NAME`  | `Back`                     | Label for the back-link                                         |
 | `ASSAY_WHITELABEL_API_DOCS_URL` | `/api/v1/docs`             | Override or hide the API Docs sidebar link                      |
+| `ASSAY_WHITELABEL_CSS_URL`      | (unset, no extra sheet)    | Extra stylesheet loaded after assay's own CSS                   |
 
 `ASSAY_WHITELABEL_API_DOCS_URL=""` (empty string) hides the link entirely.
 Any other value redirects the link to that URL. Setting the variable
 explicitly to empty is distinct from leaving it unset — unset keeps the
 default `/api/v1/docs` link, empty hides it.
+
+**Theming via CSS custom properties.** Every colour, radius, and shadow
+on the dashboard is a CSS variable on `:root`. An extra stylesheet
+loaded after assay's own CSS can re-declare any of them without
+forking. The full token list:
+
+```
+--bg          --surface      --surface-hover  --border
+--text        --text-muted
+--accent      --accent-hover
+--green       --red          --yellow         --orange
+--shadow      --code-bg
+```
+
+Minimal example — re-skin the dashboard to match your host app's
+primary colour:
+
+```css
+/* served at /static/my-theme.css by your host app */
+:root {
+  --accent:       #009999;
+  --accent-hover: #007a7a;
+  --bg:           hsl(0 0% 98%);
+  --surface:      hsl(0 0% 100%);
+  --text:         hsl(222 84% 5%);
+  --border:       hsl(214 32% 91%);
+}
+```
+
+Then point assay at it:
+
+```yaml
+- name: ASSAY_WHITELABEL_CSS_URL
+  value: "/static/my-theme.css"
+```
+
+Operators can also override any specific selector in the same file —
+source-order specificity ensures the extra sheet wins. The URL is
+loaded as a plain `<link rel="stylesheet">` at the end of `<head>`; an
+asset-version query-string is appended automatically so redeploys
+invalidate browser caches.
 
 **Hosting the logo.** If assay is mounted on the same origin as the
 embedding app (e.g. behind a reverse proxy at `/workflow/*`), a

--- a/llms.txt
+++ b/llms.txt
@@ -64,7 +64,7 @@
 - [assay.healthcheck](https://assay.rs/modules/healthcheck.html): HTTP health checks, JSON path, latency
 
 ## Workflow Engine
-- [assay.workflow](https://assay.rs/modules/workflow.html): Durable workflow engine — `assay serve` runs engine with REST+SSE+dashboard; `require("assay.workflow")` registers handlers + exposes full management surface (list/start/signal/cancel/terminate/state/events/children/continue-as-new plus `.schedules`/`.namespaces`/`.workers`/`.queues` sub-tables). Deterministic replay, Postgres/SQLite backend, Ory-compatible JWT/API-key auth (both modes can be enabled on the same server; middleware dispatches on token shape), optional S3 archival.
+- [assay.workflow](https://assay.rs/modules/workflow.html): Durable workflow engine — `assay serve` runs engine with REST+SSE+dashboard; `require("assay.workflow")` registers handlers + exposes full management surface (list/start/signal/cancel/terminate/state/events/children/continue-as-new plus `.schedules`/`.namespaces`/`.workers`/`.queues` sub-tables). Deterministic replay, Postgres/SQLite backend, Ory-compatible JWT/API-key auth (both modes can be enabled on the same server; middleware dispatches on token shape), optional S3 archival, embedded dashboard whitelabel (v0.11.10+ `ASSAY_WHITELABEL_*` env vars for name/logo/title/parent-link/API-docs-link — rebrand per-deployment without forking).
 - [assay CLI](https://assay.rs/modules/workflow.html#cli): `assay workflow/schedule/namespace/worker/queue/completion` subcommands over the engine's REST API. Config file + env vars + flags; output formats table/json/jsonl/yaml with TTY-adaptive default; JSON input indirection (@file, stdin, literal).
 
 ## AI Agent

--- a/site/build.lua
+++ b/site/build.lua
@@ -37,7 +37,7 @@ end
 
 local function count_builtins()
   local src = fs.read("src/lua/builtins/mod.rs")
-  local internal = { register_all=1, register_shell=1, register_process=1, register_disk=1, register_os=1, register_temporal_worker=1 }
+  local internal = { register_all=1, register_shell=1, register_process=1, register_disk=1, register_os=1 }
   local count = 0
   for line in src:gmatch("[^\n]+") do
     local fn_name = line:match("(register_%w+)")
@@ -135,7 +135,7 @@ local categories = {
   { name = "Monitoring &amp; Observability", pattern = {"prometheus", "alertmanager", "loki", "grafana"} },
   { name = "Kubernetes &amp; GitOps", pattern = {"k8s", "argocd", "kargo", "flux", "traefik"} },
   { name = "Security &amp; Identity", pattern = {"vault", "openbao", "certmanager", "eso", "dex", "zitadel", "ory"} },
-  { name = "Infrastructure", pattern = {"crossplane", "velero", "temporal", "harbor"} },
+  { name = "Infrastructure", pattern = {"crossplane", "velero", "harbor"} },
   { name = "Data &amp; Storage", pattern = {"postgres", "s3"} },
   { name = "Feature Flags &amp; Utilities", pattern = {"unleash", "healthcheck"} },
   { name = "AI Agent &amp; Workflow", pattern = {"ai-agents", "workflow"} },

--- a/site/pages/agent-guides.html
+++ b/site/pages/agent-guides.html
@@ -83,7 +83,7 @@ assay context "harbor registry"  # container registry docs</code></pre>
       output when you paste it into the chat.
     </p>
     <pre><code>assay context "loki logging"     # log aggregation docs
-assay context "temporal workflow" # workflow orchestration docs
+assay context "workflow engine"  # durable workflow orchestration docs
 assay context "unleash flags"    # feature flag docs</code></pre>
 
     <!-- ═══════════════════════════════════════════════ -->

--- a/site/pages/comparison.html
+++ b/site/pages/comparison.html
@@ -136,7 +136,7 @@
         <tr><td>mcp-server-jwt</td><td><code>crypto.jwt_sign</code></td></tr>
         <tr><td>vault-mcp-server</td><td><code>assay.vault</code> + <code>assay.openbao</code></td></tr>
         <tr><td>traefik-mcp</td><td><code>assay.traefik</code></td></tr>
-        <tr><td>mcp-server-temporal</td><td><code>assay.temporal</code></td></tr>
+        <tr><td>mcp-server-temporal</td><td><code>assay.workflow</code> (native engine, v0.11.1+)</td></tr>
         <tr><td>harbor-mcp</td><td><code>assay.harbor</code></td></tr>
         <tr><td>mcp-certmanager</td><td><code>assay.certmanager</code></td></tr>
         <tr><td>flux-mcp</td><td><code>assay.flux</code></td></tr>

--- a/site/pages/index.html
+++ b/site/pages/index.html
@@ -12,10 +12,10 @@
 
 
   <main>
-    <!-- v0.11.9 release banner -->
+    <!-- v0.11.10 release banner -->
     <a href="changelog.html" class="release-banner">
-      <span class="release-banner-tag">v0.11.9</span>
-      <span class="release-banner-text">ctx:wait_for_signal now accepts an optional timeout — approval gates, external-callback waits, and any workflow that must abandon its wait after a deadline without a side-channel timer</span>
+      <span class="release-banner-tag">v0.11.10</span>
+      <span class="release-banner-text">workflow.start and workflow.listen now accept namespace — multi-tenant deployment pipelines can scope workers + runs without dropping to the REST API</span>
       <span class="release-banner-arrow">&rarr;</span>
     </a>
 
@@ -147,7 +147,7 @@
     <h2>Core Capabilities</h2>
     <section style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1.5rem; margin-bottom: 2rem;">
       <div class="card card-highlight">
-        <h3 style="margin-top: 0;">Workflow Engine <span style="color: var(--accent); font-size: 0.7rem; font-weight: 700; vertical-align: middle; padding: 2px 6px; border: 1px solid var(--accent); border-radius: 4px;">v0.11.9</span></h3>
+        <h3 style="margin-top: 0;">Workflow Engine <span style="color: var(--accent); font-size: 0.7rem; font-weight: 700; vertical-align: middle; padding: 2px 6px; border: 1px solid var(--accent); border-radius: 4px;">v0.11.10</span></h3>
         <p class="text-muted">Native durable workflow engine with deterministic-replay runtime. Activities (sequential + parallel), signals, durable timers, child workflows, side effects, live state via <code>ctx:register_query</code>, search attributes, optional S3 archival. Crash-safe by replay — workers can die mid-flight without losing work or duplicating side effects.</p>
         <pre style="margin-bottom: 0;"><code>workflow.define("Deploy", function(ctx, in)
   local img = ctx:execute_activity("build", in)
@@ -299,7 +299,7 @@ cargo install assay-lua
 
     <h3>mise</h3>
     <pre><code># .mise.toml
-"github:developerinlondon/assay" = "v0.11.9"</code></pre>
+"github:developerinlondon/assay" = "v0.11.10"</code></pre>
 
   </main>
 

--- a/site/pages/index.html
+++ b/site/pages/index.html
@@ -148,7 +148,7 @@
     <section style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1.5rem; margin-bottom: 2rem;">
       <div class="card card-highlight">
         <h3 style="margin-top: 0;">Workflow Engine <span style="color: var(--accent); font-size: 0.7rem; font-weight: 700; vertical-align: middle; padding: 2px 6px; border: 1px solid var(--accent); border-radius: 4px;">v0.11.10</span></h3>
-        <p class="text-muted">Native durable workflow engine with deterministic-replay runtime. Activities (sequential + parallel), signals, durable timers, child workflows, side effects, live state via <code>ctx:register_query</code>, search attributes, optional S3 archival. Crash-safe by replay — workers can die mid-flight without losing work or duplicating side effects.</p>
+        <p class="text-muted">Native durable workflow engine with deterministic-replay runtime. Activities (sequential + parallel), signals (with optional timeout), durable timers, child workflows, side effects, live state via <code>ctx:register_query</code>, search attributes, namespace-scoped workers + workflows, optional S3 archival, and dashboard whitelabel (<code>ASSAY_WHITELABEL_*</code> env vars to rebrand the embedded <code>/workflow</code> UI per deployment). Crash-safe by replay — workers can die mid-flight without losing work or duplicating side effects.</p>
         <pre style="margin-bottom: 0;"><code>workflow.define("Deploy", function(ctx, in)
   local img = ctx:execute_activity("build", in)
   ctx:wait_for_signal("approve")

--- a/site/static/llms.txt
+++ b/site/static/llms.txt
@@ -51,7 +51,7 @@
 ## Infrastructure
 - [assay.crossplane](https://assay.rs/modules/crossplane.html): Crossplane providers, XRDs, compositions
 - [assay.velero](https://assay.rs/modules/velero.html): Velero backups, restores, schedules
-- [assay.temporal](https://assay.rs/modules/temporal.html): Temporal — HTTP REST client, gRPC client, worker runtime with workflow coroutines
+- [assay.workflow](https://assay.rs/modules/workflow.html): Native durable workflow engine — `assay serve` runs REST+SSE+dashboard; `require("assay.workflow")` registers handlers; namespace-scoped, JWT/API-key auth, dashboard whitelabel via ASSAY_WHITELABEL_* env vars
 - [assay.harbor](https://assay.rs/modules/harbor.html): Harbor registry, projects, vulnerability scanning
 
 ## Data & Storage

--- a/stdlib/workflow.lua
+++ b/stdlib/workflow.lua
@@ -87,14 +87,20 @@ function M.activity(name, handler)
 end
 
 --- Start a workflow on the engine (client-side, not as a worker).
---- @param opts table { workflow_type, workflow_id, input?, task_queue? }
+--- @param opts table { workflow_type, workflow_id, namespace?, input?, task_queue?, search_attributes? }
 --- @return table { workflow_id, run_id, status }
 function M.start(opts)
     local body = {
         workflow_type = opts.workflow_type,
         workflow_id = opts.workflow_id,
+        -- `namespace` is optional; the engine defaults to "main" when
+        -- absent. Passing it lets callers scope a run to a non-default
+        -- namespace (e.g. "deployments", "platform") so listing,
+        -- schedules, and worker registration stay partitioned.
+        namespace = opts.namespace,
         input = opts.input,
         task_queue = opts.task_queue or "default",
+        search_attributes = opts.search_attributes,
     }
     local resp = M._api("POST", "/workflows", body)
     if resp.status ~= 201 then
@@ -453,13 +459,17 @@ end
 
 --- Start listening for tasks. Blocks until cancelled.
 --- Polls workflow tasks first (cheap orchestration) then activity tasks.
---- @param opts table { identity?, queue?, max_concurrent_workflows?, max_concurrent_activities? }
+--- A worker is scoped to a single (namespace, queue) pair — only
+--- workflows started in the same namespace on the same queue will be
+--- dispatched to it.
+--- @param opts table { identity?, queue?, namespace?, max_concurrent_workflows?, max_concurrent_activities? }
 function M.listen(opts)
     if not _engine_url then
         error("workflow.listen: call workflow.connect() first")
     end
 
     local queue = opts.queue or "default"
+    local namespace = opts.namespace or "main"
     local identity = opts.identity or
         ("assay-worker-" .. (os.hostname and os.hostname() or "unknown"))
 
@@ -471,6 +481,7 @@ function M.listen(opts)
     -- Register as a worker
     local reg_resp = M._api("POST", "/workers/register", {
         identity = identity,
+        namespace = namespace,
         queue = queue,
         workflows = wf_names,
         activities = act_names,
@@ -481,7 +492,11 @@ function M.listen(opts)
         error("workflow.listen: registration failed: " .. (reg_resp.body or "unknown"))
     end
     _worker_id = json.parse(reg_resp.body).worker_id
-    log.info("Registered as worker " .. _worker_id .. " on queue '" .. queue .. "'")
+    log.info(
+        "Registered as worker " .. _worker_id
+            .. " on namespace '" .. namespace
+            .. "' queue '" .. queue .. "'"
+    )
 
     -- Poll loop
     while true do


### PR DESCRIPTION
## Summary

The engine's \`POST /workflows\` and \`POST /workers/register\` already accepted a \`namespace\` field — the Lua stdlib silently dropped it on both. This closed the gap end-to-end for the two consumer-facing primitives that multi-tenant callers need.

## Why

With v0.11.9 shipped an hour ago, a downstream consumer building a multi-tenant deployment pipeline (promotions in one engine namespace, data backfills in another, both sharing one \`assay serve\`) hit the dashboard-level partitioning correctly only to find their workflows and workers all landing in \`main\`. The Lua stdlib's \`workflow.start\` and \`workflow.listen\` didn't thread \`namespace\` through. This was a stdlib omission, not an engine one — \`POST /workflows\` already reads \`namespace\` from the body and \`POST /workers/register\` already reads it from its \`RegisterWorkerRequest\`.

## Changes

**\`stdlib/workflow.lua\`:**

- \`workflow.start({namespace, search_attributes, ...})\` now threads both fields. \`search_attributes\` was also silently dropped before despite being on the stated surface — a bonus gap-close.
- \`workflow.listen({namespace, ...})\` registers the worker into the given namespace (default \`\"main\"\`). Startup log line carries the namespace alongside the queue for kubectl-logs triage.

**No engine changes.** \`assay-workflow\` sub-crate unchanged at 0.1.7; the request shapes + dispatcher already handled namespace correctly.

## Versions

| Crate            | From    | To       |
| ---------------- | ------- | -------- |
| \`assay-lua\`      | 0.11.9  | 0.11.10  |
| \`assay-workflow\` | 0.1.7   | 0.1.7    |

Patch bump — additive, backward-compatible feature on existing API surface.

## Test plan

- [x] \`cargo clippy --features workflow --tests -- -D warnings\` — clean.
- [x] \`cargo test -p assay-workflow --test orchestration\` — 39/39 passing (38 existing + 1 new).
  - \`lua_workflow_namespace_scoping_end_to_end\`: creates a \`deployments\` namespace via \`POST /api/v1/namespaces\`, starts a worker with \`workflow.listen({queue = \"scoped-q\", namespace = \"deployments\"})\`, starts a workflow via the stdlib with a matching \`namespace\` field, and asserts the completed record carries \`namespace = \"deployments\"\` + the expected result.
- [ ] CI green on this PR before merge.
- [ ] Post-merge CI green on \`main\` before tag push.

## Release docs checklist

- [x] \`Cargo.toml\` bumped; \`Cargo.lock\` regenerated.
- [x] \`CHANGELOG.md\` — new \`[0.11.10]\` section at top.
- [x] \`SKILL.md\` + \`docs/modules/workflow.md\` — namespace noted in stdlib + ctx tables.
- [x] \`site/pages/index.html\` — release banner + Workflow Engine badge + mise install snippet.
- [x] No stale \`v0.11.9\` outside CHANGELOG + the historical \`ctx:wait_for_signal\` marker.

## Context

Shipped as the second half of a pair with v0.11.9 (\`ctx:wait_for_signal\` timeout). Closing two stdlib gaps at once: the timeout one and now the namespace one, so downstream multi-tenant deployment pipelines can rely on the Lua surface without falling through to REST for anything scoped.