### PR TITLE
ci: restrict push trigger to main only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,17 @@
 name: CI
 
 on:
-  push:
-    branches: ['**']
-    tags-ignore: ['v*']
+  # Cover every PR commit via `pull_request` (fires on open + every
+  # new commit via the `synchronize` event, tested against the
+  # merge commit with the base branch). Restrict `push` to `main`
+  # only so feat-branch pushes don't double-run with pull_request,
+  # and so merges into `main` don't re-run the exact commit that
+  # pull_request just validated. `tags-ignore: ['v*']` keeps the
+  # release tag from triggering CI — that belongs to release.yml.
   pull_request:
+  push:
+    branches: [main]
+    tags-ignore: ['v*']
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- Removes redundant CI re-runs across a PR's lifecycle.
- `pull_request` already covers every commit on PR branches (via the `synchronize` event, tested against the merge commit with `main`), so the `push: branches: ['**']` trigger was re-running CI on:
  - every feat-branch push (duplicate with `pull_request`)
  - the merge commit hitting `main` (same commit `pull_request` just validated)
- After this change:
  - PR open + every new commit → CI runs once (via `pull_request`)
  - feat-branch push without an open PR → no CI (open a PR to test)
  - PR merge → no re-run on `main` (same commit was just tested)
  - direct push to `main` (rare, branch-protection exempt) → CI as a safety net
  - tag push (`v*`) → unchanged, ignored by CI (belongs to `release.yml`)

## Test plan
- [ ] This PR itself: `pull_request` event should fire CI once with the three required checks (`check (ubuntu-latest, x86_64-unknown-linux-gnu)`, `check (macos-14, aarch64-apple-darwin)`, `extension-tests`).
- [ ] After merge: confirm no CI run fires on `main` for the merge commit.
- [ ] Next PR opened: confirm only one CI run per commit pushed.