### PR TITLE
ci: drop push trigger — pull_request covers everything

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,17 +1,14 @@
 name: CI
 
 on:
-  # Cover every PR commit via `pull_request` (fires on open + every
-  # new commit via the `synchronize` event, tested against the
-  # merge commit with the base branch). Restrict `push` to `main`
-  # only so feat-branch pushes don't double-run with pull_request,
-  # and so merges into `main` don't re-run the exact commit that
-  # pull_request just validated. `tags-ignore: ['v*']` keeps the
-  # release tag from triggering CI — that belongs to release.yml.
+  # `pull_request` fires on open + every new commit (the
+  # `synchronize` event), and tests against the merge commit with
+  # the base branch. Because branch protection blocks direct pushes
+  # to `main`, the merge commit that pull_request validates IS the
+  # commit that lands on `main` after merge — so a push trigger on
+  # `main` would just re-run CI on identical code. Skip it; rely on
+  # pull_request alone. Tag pushes (`v*`) are handled by release.yml.
   pull_request:
-  push:
-    branches: [main]
-    tags-ignore: ['v*']
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
Follow-up to #61. That PR restricted `push: branches: ['**']` to `[main]`, which eliminated feat-branch double-runs but still fired a redundant CI run on `main` after every merge.

The merge commit `pull_request` validates IS the exact commit that lands on `main` when the PR merges, so the push trigger on `main` only re-ran CI on identical code. Branch protection already blocks direct pushes to `main`, so the `push` trigger was only catching admin-override emergency pushes.

Drop it entirely. `pull_request` covers:
- every commit pushed to an open PR branch (synchronize event)
- each PR against the merge commit with the base branch

Tag pushes (`v*`) stay unaffected (handled by `release.yml`).

## Test plan
- [ ] This PR: `pull_request` event fires CI once — all three required checks (ubuntu/macos matrix + extension-tests) pass.
- [ ] After merge: **no** CI run fires on `main` for the merge commit (unlike after #61 merge).
- [ ] Next PR opened: CI runs once per commit via `pull_request`.