### PR TITLE
feat: v0.12.1 — fs.lines + fs.sub_in_file + string.split + scratch image

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,32 @@ This applies to all files in the repo: `stdlib/`, `src/`, `tests/`, `*.md`, `*.h
 `CHANGELOG.md`, and any commit/PR text. The only legitimate exception is the copyright holder's name
 in `LICENSE`/`NOTICE`/`CLA.md`.
 
+## Failing tests: never rewrite, always escalate
+
+**If a test is failing, the default is to fix the code under test — NOT the test.** Modifying a
+failing test (relaxing an assertion, changing an expected value, loosening a regex, adding
+`#[ignore]`, deleting the test, or narrowing its scope) requires **explicit approval from the human
+operator** before committing. No exceptions — not "while debugging", not "just to unblock CI", not
+"the test was wrong anyway". Ask, wait for a clear yes, then change.
+
+Why this rule exists: AI agents have a known failure mode where a failing assertion gets "solved"
+by weakening the check until it passes, masking the real regression behind green CI. The test is a
+specification the code is supposed to meet; weakening it silently changes the specification without
+the human realising the behavioural guarantee has shrunk.
+
+When a test fails, the expected agent workflow is:
+
+1. Report the failure verbatim (test name + failure message + relevant file:line).
+2. Explain what the test is checking and what the code actually did.
+3. Propose a fix — which is usually in the code under test, occasionally in the test (if the test
+   itself has a real bug), but never "just delete the assertion".
+4. Wait for approval before editing anything test-related.
+
+If the test genuinely has a bug (e.g. wrong assertion, stale fixture, pre-existing flake), that's
+also a conversation, not a silent rewrite. Flag it, describe the bug, propose the correction,
+wait for confirmation. Tests are the repo's behavioural contract; changes to them need the same
+care as changes to published API surface.
+
 ## Release docs checklist
 
 Every release (patch, minor, or major) must update **all** of the following before the PR merges —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,55 @@
 
 All notable changes to Assay are documented here.
 
+## [0.12.1] - 2026-04-19
+
+Text-processing stdlib primitives + scratch-based image, so assay
+scripts don't need a shell in the container and the published image
+goes from ~25 MB back to ~10 MB.
+
+### Added
+
+- **`fs.lines(path)`** — streaming line iterator. Designed for
+  `for line in fs.lines(path) do … end`; reads from a buffered
+  reader so multi-GB files don't land in memory. Each line is
+  returned with the trailing `\n` (or `\r\n`) stripped. Equivalent
+  to `while read line; do …; done < file` in bash.
+- **`fs.sub_in_file(path, pattern, repl)`** — `sed -i`
+  equivalent, but portable (no BSD-vs-GNU `sed -i` dance) and
+  without the quoting traps of shell. Uses Lua patterns (same
+  engine as `string.gsub`); `repl` accepts a replacement string
+  with `%0`-`%9` backreferences OR a function. Writes only when
+  the substitution count is > 0, so repeated calls on an
+  already-substituted file are no-ops on disk.
+- **`string.split(s, sep?)`** — awk-style field split, extending
+  Lua's built-in `string` library. With no `sep`, splits on any run
+  of whitespace and drops leading/trailing empty fields (matches
+  awk default FS and Python `str.split()`). With a literal `sep`,
+  splits on that substring (not a Lua pattern — use
+  `string.gmatch` if you need pattern semantics). Pairs with
+  `fs.lines` so `awk '{print $2}'`-style pipelines become three
+  lines of Lua.
+
+### Changed
+
+- **Docker image runtime stage back to `FROM scratch`** (reverts the
+  Feb-2026 regression to alpine:3.21). The published
+  `ghcr.io/developerinlondon/assay` image is now the assay binary
+  plus `/etc/ssl/certs/ca-certificates.crt`, nothing else. About
+  40% smaller (~10 MB vs ~25 MB with Alpine), zero Alpine CVE
+  surface. Downstream images (anyone `FROM ghcr.io/developerinlondon/assay`)
+  inherit the slimming automatically on next rebuild. The
+  `command: ["/bin/sh", "-c", …]` wrapper that originally forced
+  Alpine has been removed from every usage in the gitops repo;
+  the new text-processing primitives above cover the shell-out
+  cases that used to need sed/awk.
+- **Regression guards on the Dockerfile** (`tests/dockerfile.rs`):
+  asserts the runtime stage is `FROM scratch`, that the CA bundle
+  is copied in, and that the ENTRYPOINT uses an absolute path
+  (`/assay`, not bare `assay` — scratch has no `$PATH`). These
+  fail CI loudly if anyone tries to flip the runtime back to
+  Alpine without justification.
+
 ## [0.12.0] - 2026-04-18
 
 This release combines a major dashboard upgrade (Steps tab + step-

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,7 +84,7 @@ checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
 
 [[package]]
 name = "assay-lua"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "anyhow",
  "assay-workflow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "crates/assay-workflow"]
 
 [package]
 name = "assay-lua"
-version = "0.12.0"
+version = "0.12.1"
 categories = ["command-line-utilities", "development-tools::testing"]
 edition = "2024"
 homepage = "https://assay.rs"

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,21 @@ COPY stdlib/ stdlib/
 COPY crates/ crates/
 RUN cargo build --release --target x86_64-unknown-linux-musl
 
-# Runtime
-FROM alpine:3.21
-COPY --from=builder /app/target/x86_64-unknown-linux-musl/release/assay /usr/local/bin/assay
-ENTRYPOINT ["assay"]
+# Runtime — FROM scratch so the published image is the assay binary
+# plus a CA bundle, nothing else (~10 MB instead of ~25 MB with
+# alpine, and no transitive busybox/apk/musl CVE surface).
+#
+# History: commit 5c43c83 (Feb 2026) flipped this to alpine:3.21 to
+# accommodate one downstream Deployment that used `command: ["/bin/sh",
+# "-c", …]` wrappers for env-var setup. That wrapper has since been
+# removed and assay's stdlib covers the sed/awk use cases that once
+# required a shell. `tests/dockerfile.rs` guards against the regression.
+#
+# The CA bundle COPY is load-bearing: any HTTPS call made by assay
+# (reqwest, sqlx TLS, WebSockets) verifies the server cert against
+# roots read from /etc/ssl/certs/ca-certificates.crt. Without this
+# file on scratch, every TLS connection fails immediately.
+FROM scratch
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=builder /app/target/x86_64-unknown-linux-musl/release/assay /assay
+ENTRYPOINT ["/assay"]

--- a/docs/modules/fs.md
+++ b/docs/modules/fs.md
@@ -26,6 +26,34 @@ Filesystem operations. No `require()` needed.
 - `fs.glob(pattern)` → `[path]` — Glob pattern matching, returns array of path strings
 - `fs.tempdir()` → path — Create a temporary directory
 
+### Line Iteration & In-Place Editing
+
+- `fs.lines(path)` → iterator — Streaming line reader. Designed for
+  `for line in fs.lines(path) do … end`. Reads from a buffered reader
+  so multi-GB files never land in memory; each line is returned with
+  the trailing `\n` (or `\r\n`) stripped. Equivalent to `while read
+  line; do …; done < file` in bash.
+- `fs.sub_in_file(path, pattern, repl)` → count — In-place
+  search-and-replace; equivalent to `sed -i 's/pattern/repl/g' path`
+  but portable (no BSD-vs-GNU `sed -i` split). `pattern` uses Lua
+  patterns (same as `string.gsub`); `repl` can be a replacement
+  string with `%0`-`%9` backreferences OR a function per
+  `string.gsub`. Writes only when at least one match is found, so
+  repeated calls on an already-substituted file are no-ops on disk.
+
+```lua
+-- grep-equivalent: count lines matching a pattern
+local n = 0
+for line in fs.lines("/var/log/app.log") do
+  if line:match("ERROR") then n = n + 1 end
+end
+
+-- sed -i equivalent: bump a version string across every file
+for _, p in ipairs(fs.glob("apps/**/values.yaml")) do
+  fs.sub_in_file(p, "image: foo:v%d+%.%d+%.%d+", "image: foo:v1.2.3")
+end
+```
+
 ### Metadata
 
 - `fs.stat(path)` → `{size, type, modified, created, permissions}` — File metadata

--- a/docs/modules/utilities.md
+++ b/docs/modules/utilities.md
@@ -23,3 +23,30 @@ Sleep utility. No `require()` needed.
 Timestamp utility. No `require()` needed.
 
 - `time()` → number — Unix timestamp in seconds (with fractional milliseconds)
+
+## string
+
+Lua's built-in `string` library (see [the Lua 5.4 reference](https://www.lua.org/manual/5.4/manual.html#6.4))
+is available as always — `string.format`, `string.gsub`, `string.match`, `string.gmatch`, etc.
+Assay extends it with one awk-style helper:
+
+- `string.split(s, sep?)` → `{parts}` — Split a string into an array of parts.
+  When `sep` is `nil` (or empty), splits on any run of whitespace and skips
+  leading/trailing empty fields (matches awk's default FS and Python's
+  `str.split()` with no arg). When `sep` is provided, splits on the literal
+  string (NOT a Lua pattern — use `string.gmatch` if you need pattern
+  semantics). Pairs well with `fs.lines` for awk-style field processing:
+
+```lua
+-- awk '{ print $2 }' users.tsv
+for line in fs.lines("users.tsv") do
+  print(string.split(line)[2])
+end
+
+-- awk -F, '{ sum[$1] += $2 }' stats.csv
+local sum = {}
+for line in fs.lines("stats.csv") do
+  local f = string.split(line, ",")
+  sum[f[1]] = (sum[f[1]] or 0) + tonumber(f[2])
+end
+```

--- a/llms.txt
+++ b/llms.txt
@@ -18,7 +18,7 @@
 ## Builtins (no require needed)
 - [http](https://assay.rs/modules/http.html): HTTP client, server, SSE streaming — http.get/post/put/patch/delete/serve
 - [json, yaml, toml](https://assay.rs/modules/serialization.html): JSON/YAML/TOML parse and encode
-- [fs](https://assay.rs/modules/fs.html): Filesystem — fs.read/write
+- [fs](https://assay.rs/modules/fs.html): Filesystem — fs.read/write, fs.lines (streaming line iterator), fs.sub_in_file (sed -i equivalent using Lua patterns)
 - [crypto, base64](https://assay.rs/modules/crypto.html): JWT signing/decoding, HMAC, hashing, random, base64
 - [regex](https://assay.rs/modules/regex.html): Regex match, find, replace
 - [db](https://assay.rs/modules/db.html): SQL database — Postgres, MySQL, SQLite — db.connect/query/execute
@@ -26,7 +26,7 @@
 - [template](https://assay.rs/modules/template.html): Jinja2-compatible template rendering
 - [async](https://assay.rs/modules/async.html): Async task spawn and await
 - [assert](https://assay.rs/modules/assert.html): Assertions — assert.eq/ne/gt/lt/contains/not_nil/matches
-- [log, env, sleep, time](https://assay.rs/modules/utilities.html): Logging, environment variables, sleep, timestamps
+- [log, env, sleep, time, string.split](https://assay.rs/modules/utilities.html): Logging, environment variables, sleep, timestamps, awk-style field split
 
 ## Monitoring & Observability
 - [assay.prometheus](https://assay.rs/modules/prometheus.html): PromQL queries, alerts, targets, rules
@@ -72,6 +72,6 @@
 
 ## Optional
 - [Crates.io](https://crates.io/crates/assay-lua): Use Assay as a Rust crate in your own projects
-- [Docker](https://github.com/developerinlondon/assay/pkgs/container/assay): ghcr.io/developerinlondon/assay:latest (~9MB compressed)
+- [Docker](https://github.com/developerinlondon/assay/pkgs/container/assay): ghcr.io/developerinlondon/assay:latest — FROM scratch, ~10MB (binary + CA bundle, no Alpine/busybox/shell)
 - [Agent Guides](https://assay.rs/agent-guides.html): Integration guides for Claude Code, Cursor, Windsurf, Cline, OpenCode
 - [Changelog](https://github.com/developerinlondon/assay/releases): Release history

--- a/site/pages/index.html
+++ b/site/pages/index.html
@@ -12,10 +12,10 @@
 
 
   <main>
-    <!-- v0.12.0 release banner -->
+    <!-- v0.12.1 release banner -->
     <a href="changelog.html" class="release-banner">
-      <span class="release-banner-tag">v0.12.0</span>
-      <span class="release-banner-text">Steps tab + step actions + live tail + auto-advance focus + cancel-replay state preservation; CI/CD overhaul (mise + moon + Playwright e2e); modal system; cross-linked detail panels; new <code>process.spawn</code> Lua builtin</span>
+      <span class="release-banner-tag">v0.12.1</span>
+      <span class="release-banner-text">Image back to <code>FROM scratch</code> (~40% smaller, zero Alpine CVE surface); new <code>fs.lines</code> + <code>fs.sub_in_file</code> + <code>string.split</code> primitives so <code>sed</code> / <code>awk</code> / <code>grep</code> pipelines move into Lua</span>
       <span class="release-banner-arrow">&rarr;</span>
     </a>
 
@@ -147,7 +147,7 @@
     <h2>Core Capabilities</h2>
     <section style="display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1.5rem; margin-bottom: 2rem;">
       <div class="card card-highlight">
-        <h3 style="margin-top: 0;">Workflow Engine <span style="color: var(--accent); font-size: 0.7rem; font-weight: 700; vertical-align: middle; padding: 2px 6px; border: 1px solid var(--accent); border-radius: 4px;">v0.12.0</span></h3>
+        <h3 style="margin-top: 0;">Workflow Engine <span style="color: var(--accent); font-size: 0.7rem; font-weight: 700; vertical-align: middle; padding: 2px 6px; border: 1px solid var(--accent); border-radius: 4px;">v0.12.1</span></h3>
         <p class="text-muted">Native durable workflow engine with deterministic-replay runtime. Activities (sequential + parallel), signals (with optional timeout), durable timers, child workflows, side effects, live state via <code>ctx:register_query</code>, self-initiated cancel via <code>ctx:cancel</code>, search attributes, namespace-scoped workers + workflows, optional S3 archival, and dashboard whitelabel (<code>ASSAY_WHITELABEL_*</code> env vars to rebrand the embedded <code>/workflow</code> UI per deployment — including brand mark, subtitle, and a "Powered by" attribution when customised). Crash-safe by replay — workers can die mid-flight without losing work or duplicating side effects.</p>
         <pre style="margin-bottom: 0;"><code>workflow.define("Deploy", function(ctx, in)
   local img = ctx:execute_activity("build", in)
@@ -299,7 +299,7 @@ cargo install assay-lua
 
     <h3>mise</h3>
     <pre><code># .mise.toml
-"github:developerinlondon/assay" = "v0.12.0"</code></pre>
+"github:developerinlondon/assay" = "v0.12.1"</code></pre>
 
   </main>
 

--- a/src/lua/builtins/core.rs
+++ b/src/lua/builtins/core.rs
@@ -365,7 +365,100 @@ pub fn register_fs(lua: &Lua) -> mlua::Result<()> {
     })?;
     fs_table.set("readdir", readdir_fn)?;
 
+    // fs.lines(path) — stateful iterator yielding one line per call.
+    // Designed for `for line in fs.lines(path) do ... end`. Streams via
+    // BufReader so multi-GB files don't land in memory. Lines are
+    // stripped of their trailing `\n` (and `\r\n` on Windows files).
+    // Returns an iterator function; Lua's for-loop calls it until nil.
+    let lines_fn = lua.create_function(|lua, path: String| {
+        use std::io::BufRead;
+        let file = std::fs::File::open(&path).map_err(|e| {
+            mlua::Error::runtime(format!("fs.lines: failed to open {path:?}: {e}"))
+        })?;
+        let iter = std::sync::Arc::new(std::sync::Mutex::new(
+            std::io::BufReader::new(file).lines(),
+        ));
+        lua.create_function(move |_, ()| {
+            let mut it = iter
+                .lock()
+                .map_err(|e| mlua::Error::runtime(format!("fs.lines: lock poisoned: {e}")))?;
+            match it.next() {
+                Some(Ok(line)) => Ok(Some(line)),
+                Some(Err(e)) => Err(mlua::Error::runtime(format!("fs.lines: read error: {e}"))),
+                None => Ok(None),
+            }
+        })
+    })?;
+    fs_table.set("lines", lines_fn)?;
+
+    // fs.sub_in_file(path, pattern, repl) — `sed -i` equivalent.
+    // In-place search-and-replace using Lua's native pattern engine
+    // (same semantics as string.gsub, including %0-%9 backreferences
+    // and function replacements). Reads the file, substitutes, and
+    // only writes back if at least one match was made — so repeated
+    // calls on an already-substituted file are a no-op on disk.
+    // Returns the count of substitutions.
+    let sub_in_file_fn =
+        lua.create_function(|lua, (path, pattern, repl): (String, String, mlua::Value)| {
+            let content = std::fs::read_to_string(&path).map_err(|e| {
+                mlua::Error::runtime(format!(
+                    "fs.sub_in_file: failed to read {path:?}: {e}"
+                ))
+            })?;
+            let string_table: mlua::Table = lua.globals().get("string")?;
+            let gsub: mlua::Function = string_table.get("gsub")?;
+            let (new_content, count): (String, u64) = gsub.call((content, pattern, repl))?;
+            if count > 0 {
+                std::fs::write(&path, &new_content).map_err(|e| {
+                    mlua::Error::runtime(format!(
+                        "fs.sub_in_file: failed to write {path:?}: {e}"
+                    ))
+                })?;
+            }
+            Ok(count)
+        })?;
+    fs_table.set("sub_in_file", sub_in_file_fn)?;
+
     lua.globals().set("fs", fs_table)?;
+    Ok(())
+}
+
+pub fn register_string_helpers(lua: &Lua) -> mlua::Result<()> {
+    let string_table: mlua::Table = lua.globals().get("string")?;
+
+    // string.split(s, sep?) — awk-style field split.
+    // When `sep` is nil or empty: splits on any run of whitespace and
+    // skips leading/trailing empty fields (matches awk default FS and
+    // Python's str.split() with no arg). When `sep` is provided: splits
+    // on the literal string (not a Lua pattern — use string.gmatch if
+    // you need pattern semantics). Returns a 1-indexed array table.
+    let split_fn = lua.create_function(|lua, args: mlua::MultiValue| {
+        let mut args_iter = args.into_iter();
+        let s: String = args_iter
+            .next()
+            .ok_or_else(|| mlua::Error::runtime("string.split: string required"))
+            .and_then(|v| lua.unpack(v))?;
+        let sep: Option<String> = match args_iter.next() {
+            Some(mlua::Value::Nil) | None => None,
+            Some(v) => Some(lua.unpack(v)?),
+        };
+        let results = lua.create_table()?;
+        match sep {
+            Some(ref sep_str) if !sep_str.is_empty() => {
+                for (i, part) in (1..).zip(s.split(sep_str.as_str())) {
+                    results.set(i, part)?;
+                }
+            }
+            _ => {
+                for (i, part) in (1..).zip(s.split_whitespace()) {
+                    results.set(i, part)?;
+                }
+            }
+        }
+        Ok(results)
+    })?;
+    string_table.set("split", split_fn)?;
+
     Ok(())
 }
 

--- a/src/lua/builtins/mod.rs
+++ b/src/lua/builtins/mod.rs
@@ -25,6 +25,7 @@ pub fn register_all(lua: &mlua::Lua, client: reqwest::Client) -> mlua::Result<()
     core::register_sleep(lua)?;
     core::register_time(lua)?;
     core::register_fs(lua)?;
+    core::register_string_helpers(lua)?;
     core::register_base64(lua)?;
     crypto::register_crypto(lua)?;
     core::register_regex(lua)?;

--- a/tests/dockerfile.rs
+++ b/tests/dockerfile.rs
@@ -20,11 +20,13 @@ fn dockerfile_runtime_stage_is_from_scratch() {
 
     // The runtime stage is the last `FROM` line in a multi-stage
     // build (earlier FROMs are builder/intermediate stages with `AS`).
+    // `next_back()` on the DoubleEndedIterator grabs it directly
+    // without walking the whole line stream (`Iterator::last` would).
     let last_from = content
         .lines()
         .map(str::trim_start)
         .filter(|l| l.starts_with("FROM "))
-        .last()
+        .next_back()
         .expect("Dockerfile must contain at least one FROM line");
 
     assert_eq!(

--- a/tests/dockerfile.rs
+++ b/tests/dockerfile.rs
@@ -20,13 +20,14 @@ fn dockerfile_runtime_stage_is_from_scratch() {
 
     // The runtime stage is the last `FROM` line in a multi-stage
     // build (earlier FROMs are builder/intermediate stages with `AS`).
-    // `next_back()` on the DoubleEndedIterator grabs it directly
-    // without walking the whole line stream (`Iterator::last` would).
+    // `rfind` on the DoubleEndedIterator is a one-pass reverse
+    // search — cheaper than `filter(..).next_back()` (clippy 1.95
+    // surfaces this via `clippy::filter_next`) and `Iterator::last`
+    // would walk the whole stream forwards.
     let last_from = content
         .lines()
         .map(str::trim_start)
-        .filter(|l| l.starts_with("FROM "))
-        .next_back()
+        .rfind(|l| l.starts_with("FROM "))
         .expect("Dockerfile must contain at least one FROM line");
 
     assert_eq!(

--- a/tests/dockerfile.rs
+++ b/tests/dockerfile.rs
@@ -1,0 +1,71 @@
+//! Regression guards on the root `Dockerfile`.
+//!
+//! The published `ghcr.io/developerinlondon/assay` image is meant to
+//! be a scratch image containing only the assay binary and a CA bundle.
+//! That keeps it ~10 MB (vs ~25 MB on Alpine), reduces the CVE surface
+//! to assay's own supply chain, and makes every downstream image that
+//! `FROM`'s assay inherit the same minimal footprint.
+//!
+//! In Feb 2026 (commit 5c43c83) the runtime stage was briefly flipped
+//! to `FROM alpine:3.21` to accommodate a single downstream Deployment
+//! that wrapped assay in `command: ["/bin/sh", "-c", …]`. That wrapper
+//! has since been removed and assay's stdlib covers the sed/awk use
+//! cases that once required a shell. These tests prevent silently
+//! reintroducing the regression.
+
+#[test]
+fn dockerfile_runtime_stage_is_from_scratch() {
+    let content =
+        std::fs::read_to_string("Dockerfile").expect("Dockerfile must exist at repo root");
+
+    // The runtime stage is the last `FROM` line in a multi-stage
+    // build (earlier FROMs are builder/intermediate stages with `AS`).
+    let last_from = content
+        .lines()
+        .map(str::trim_start)
+        .filter(|l| l.starts_with("FROM "))
+        .last()
+        .expect("Dockerfile must contain at least one FROM line");
+
+    assert_eq!(
+        last_from.trim(),
+        "FROM scratch",
+        "Dockerfile runtime stage must be `FROM scratch` — got `{last_from}`.\n\
+         This guard exists because commit 5c43c83 (Feb 2026) once flipped \
+         the runtime to alpine:3.21 and nobody noticed for weeks. Keeping \
+         the runtime scratch preserves the ~10 MB image size and excludes \
+         the entire Alpine CVE feed from assay's supply chain."
+    );
+}
+
+#[test]
+fn dockerfile_copies_ca_bundle() {
+    let content =
+        std::fs::read_to_string("Dockerfile").expect("Dockerfile must exist at repo root");
+
+    assert!(
+        content.contains("ca-certificates.crt"),
+        "Dockerfile must COPY a CA bundle into the scratch image at \
+         /etc/ssl/certs/ca-certificates.crt — without it, every HTTPS \
+         call from assay (reqwest, sqlx TLS, WebSockets) fails with \
+         'certificate verify failed: unable to get local issuer \
+         certificate'. The pre-Feb-2026 Dockerfile had this line; \
+         the Alpine regression silently dropped it."
+    );
+}
+
+#[test]
+fn dockerfile_entrypoint_uses_absolute_path() {
+    let content =
+        std::fs::read_to_string("Dockerfile").expect("Dockerfile must exist at repo root");
+
+    // On a scratch image there is no $PATH resolution (no shell, no
+    // system PATH). The ENTRYPOINT must be an absolute filesystem
+    // path — `/assay`, not bare `assay`.
+    assert!(
+        content.contains(r#"ENTRYPOINT ["/assay"]"#),
+        "Dockerfile ENTRYPOINT must be an absolute path (`/assay`) \
+         because scratch images have no $PATH resolution. Found content \
+         did not include the absolute-path ENTRYPOINT."
+    );
+}

--- a/tests/fs.rs
+++ b/tests/fs.rs
@@ -429,3 +429,186 @@ async fn test_fs_readdir_nonexistent() {
     let result = run_lua(r#"fs.readdir("/nonexistent/path")"#).await;
     assert!(result.is_err());
 }
+
+// ──────────────────────── fs.lines ────────────────────────
+
+#[tokio::test]
+async fn test_fs_lines_basic() {
+    let dir = std::env::temp_dir().join("assay_test_lines_basic");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("three.txt");
+    std::fs::write(&path, "alpha\nbeta\ngamma\n").unwrap();
+
+    let script = format!(
+        r#"
+            local out = {{}}
+            for line in fs.lines("{}") do
+                table.insert(out, line)
+            end
+            assert.eq(#out, 3)
+            assert.eq(out[1], "alpha")
+            assert.eq(out[2], "beta")
+            assert.eq(out[3], "gamma")
+        "#,
+        path.display().to_string().replace('\\', "\\\\")
+    );
+    run_lua(&script).await.unwrap();
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[tokio::test]
+async fn test_fs_lines_empty_file() {
+    let dir = std::env::temp_dir().join("assay_test_lines_empty");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("empty.txt");
+    std::fs::write(&path, "").unwrap();
+
+    let script = format!(
+        r#"
+            local count = 0
+            for _ in fs.lines("{}") do count = count + 1 end
+            assert.eq(count, 0, "empty file yields zero lines")
+        "#,
+        path.display().to_string().replace('\\', "\\\\")
+    );
+    run_lua(&script).await.unwrap();
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[tokio::test]
+async fn test_fs_lines_no_trailing_newline() {
+    let dir = std::env::temp_dir().join("assay_test_lines_no_trailing");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("no_trail.txt");
+    std::fs::write(&path, "one\ntwo").unwrap(); // no final \n
+
+    let script = format!(
+        r#"
+            local out = {{}}
+            for line in fs.lines("{}") do table.insert(out, line) end
+            assert.eq(#out, 2, "final line without trailing \\n still yielded")
+            assert.eq(out[1], "one")
+            assert.eq(out[2], "two")
+        "#,
+        path.display().to_string().replace('\\', "\\\\")
+    );
+    run_lua(&script).await.unwrap();
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[tokio::test]
+async fn test_fs_lines_nonexistent() {
+    let result = run_lua(r#"
+        for _ in fs.lines("/nonexistent/file.txt") do end
+    "#)
+    .await;
+    assert!(result.is_err());
+}
+
+// ──────────────────────── fs.sub_in_file ────────────────────────
+
+#[tokio::test]
+async fn test_fs_sub_in_file_basic() {
+    let dir = std::env::temp_dir().join("assay_test_sub_basic");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("conf.yaml");
+    std::fs::write(&path, "image: assay:v0.10.1\nother: unchanged\n").unwrap();
+
+    let script = format!(
+        r#"
+            local n = fs.sub_in_file("{}", "v0%.10%.1", "v0.12.1")
+            assert.eq(n, 1, "one substitution")
+            local after = fs.read("{}")
+            assert.contains(after, "assay:v0.12.1")
+            assert.contains(after, "other: unchanged")
+        "#,
+        path.display().to_string().replace('\\', "\\\\"),
+        path.display().to_string().replace('\\', "\\\\")
+    );
+    run_lua(&script).await.unwrap();
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[tokio::test]
+async fn test_fs_sub_in_file_no_match() {
+    let dir = std::env::temp_dir().join("assay_test_sub_no_match");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("conf.yaml");
+    std::fs::write(&path, "nothing to see\n").unwrap();
+    let original_mtime = std::fs::metadata(&path).unwrap().modified().unwrap();
+    // tiny sleep so mtime comparison is meaningful on fast filesystems
+    std::thread::sleep(std::time::Duration::from_millis(50));
+
+    let script = format!(
+        r#"
+            local n = fs.sub_in_file("{}", "v0%.11%.x", "v0.12.1")
+            assert.eq(n, 0, "no match = no substitution")
+        "#,
+        path.display().to_string().replace('\\', "\\\\")
+    );
+    run_lua(&script).await.unwrap();
+
+    // Verify the file wasn't rewritten (mtime unchanged when count==0).
+    let new_mtime = std::fs::metadata(&path).unwrap().modified().unwrap();
+    assert_eq!(
+        original_mtime, new_mtime,
+        "file should not be rewritten when no match"
+    );
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[tokio::test]
+async fn test_fs_sub_in_file_multiple_occurrences() {
+    let dir = std::env::temp_dir().join("assay_test_sub_multi");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("conf.yaml");
+    std::fs::write(&path, "a: v0.10.1\nb: v0.10.1\nc: v0.10.1\n").unwrap();
+
+    let script = format!(
+        r#"
+            local n = fs.sub_in_file("{}", "v0%.10%.1", "v0.12.1")
+            assert.eq(n, 3, "three substitutions")
+        "#,
+        path.display().to_string().replace('\\', "\\\\")
+    );
+    run_lua(&script).await.unwrap();
+
+    let after = std::fs::read_to_string(&path).unwrap();
+    assert_eq!(after, "a: v0.12.1\nb: v0.12.1\nc: v0.12.1\n");
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[tokio::test]
+async fn test_fs_sub_in_file_backref() {
+    let dir = std::env::temp_dir().join("assay_test_sub_backref");
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("conf.yaml");
+    std::fs::write(&path, "image: assay:v0.10.1\n").unwrap();
+
+    // Lua pattern: wrap the match in brackets via a capture group.
+    let script = format!(
+        r#"
+            local n = fs.sub_in_file("{}", "(v%d+%.%d+%.%d+)", "[%1]")
+            assert.eq(n, 1)
+            local after = fs.read("{}")
+            assert.contains(after, "[v0.10.1]")
+        "#,
+        path.display().to_string().replace('\\', "\\\\"),
+        path.display().to_string().replace('\\', "\\\\")
+    );
+    run_lua(&script).await.unwrap();
+    let _ = std::fs::remove_dir_all(&dir);
+}
+
+#[tokio::test]
+async fn test_fs_sub_in_file_nonexistent() {
+    let result = run_lua(r#"fs.sub_in_file("/nonexistent/file", "x", "y")"#).await;
+    assert!(result.is_err());
+}

--- a/tests/string_helpers.rs
+++ b/tests/string_helpers.rs
@@ -1,0 +1,109 @@
+mod common;
+
+use common::run_lua;
+
+// ──────────────────────── string.split ────────────────────────
+
+#[tokio::test]
+async fn test_string_split_default_whitespace() {
+    let script = r#"
+        local parts = string.split("alpha  beta\tgamma\n")
+        assert.eq(#parts, 3)
+        assert.eq(parts[1], "alpha")
+        assert.eq(parts[2], "beta")
+        assert.eq(parts[3], "gamma")
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_string_split_leading_trailing_whitespace() {
+    let script = r#"
+        local parts = string.split("   a b c   ")
+        assert.eq(#parts, 3)
+        assert.eq(parts[1], "a")
+        assert.eq(parts[3], "c")
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_string_split_custom_separator() {
+    let script = r#"
+        local parts = string.split("a,b,c,d", ",")
+        assert.eq(#parts, 4)
+        assert.eq(parts[1], "a")
+        assert.eq(parts[4], "d")
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_string_split_literal_sep_not_pattern() {
+    // '.' is a Lua pattern "any char" — but string.split treats
+    // the separator as a literal string, not a pattern.
+    let script = r#"
+        local parts = string.split("a.b.c", ".")
+        assert.eq(#parts, 3)
+        assert.eq(parts[1], "a")
+        assert.eq(parts[2], "b")
+        assert.eq(parts[3], "c")
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_string_split_multichar_separator() {
+    let script = r#"
+        local parts = string.split("foo::bar::baz", "::")
+        assert.eq(#parts, 3)
+        assert.eq(parts[1], "foo")
+        assert.eq(parts[2], "bar")
+        assert.eq(parts[3], "baz")
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_string_split_single_element() {
+    let script = r#"
+        local parts = string.split("lonely")
+        assert.eq(#parts, 1)
+        assert.eq(parts[1], "lonely")
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_string_split_empty_string_whitespace() {
+    let script = r#"
+        local parts = string.split("")
+        assert.eq(#parts, 0, "empty string yields empty array under whitespace split")
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_string_split_empty_string_custom_sep() {
+    // With a literal separator, an empty string still counts as a
+    // single empty field (matches Rust str::split / Python str.split).
+    let script = r#"
+        local parts = string.split("", ",")
+        assert.eq(#parts, 1)
+        assert.eq(parts[1], "")
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_string_split_trailing_separator() {
+    // "a,b," splits into {"a", "b", ""}.
+    let script = r#"
+        local parts = string.split("a,b,", ",")
+        assert.eq(#parts, 3)
+        assert.eq(parts[1], "a")
+        assert.eq(parts[2], "b")
+        assert.eq(parts[3], "")
+    "#;
+    run_lua(script).await.unwrap();
+}


### PR DESCRIPTION
## Summary

Text-processing stdlib primitives so `sed` / `awk` / `grep` pipelines move into Lua, plus revert of the Docker runtime stage to `FROM scratch` so the published image is ~10 MB instead of ~25 MB and the entire Alpine CVE feed drops out of the supply chain.

## What's new

**Stdlib (`src/lua/builtins/core.rs`):**

- `fs.lines(path)` — streaming line iterator. `for line in fs.lines(path) do … end`. Buffered reader; multi-GB files never land in memory.
- `fs.sub_in_file(path, pattern, repl)` → count — `sed -i` equivalent using Lua patterns. Idempotent on no-match (skips the write).
- `string.split(s, sep?)` — awk-style field split. Default: whitespace + drop empty leading/trailing. Literal sep otherwise (not a pattern).

**Image (`Dockerfile`):**

- Runtime stage: `FROM alpine:3.21` → `FROM scratch`.
- Adds back the CA bundle COPY that was silently dropped in commit `5c43c83` (Feb 2026).
- ENTRYPOINT back to absolute `/assay` (scratch has no `$PATH`).
- Net image size: ~25 MB → ~10 MB. Downstream images inherit on rebuild.

**Regression guards (`tests/dockerfile.rs`):**

Three tests that fail CI if anyone flips the runtime back to Alpine/Debian without justification:

1. Runtime FROM must be `scratch`.
2. CA bundle must be COPY'd (TLS fails silently without it).
3. ENTRYPOINT must use absolute path.

**Agent discipline (`AGENTS.md`):**

New section: *"Failing tests: never rewrite, always escalate."* Modifying a failing test requires explicit operator approval; the default is to fix the code under test. Prevents AI-driven silent assertion-weakening.

## Why

Two threads converged here. First, the cc-workflows bump to v0.12.0 surfaced ~10 places in gitops where assay was pinned to older versions, each invoked directly (no `sh -c` wrappers anywhere). That killed the original justification for the Alpine switch. Second, to make scratch-image sustainable long-term we need the stdlib to cover the shell-text-processing toolkit — otherwise someone will eventually shell out to `sed` and the Alpine flip happens again.

The three primitives cover the common cases:

| Shell | Assay equivalent |
|---|---|
| `while read line; do … < file` | `for line in fs.lines(path) do … end` |
| `sed -i 's/a/b/g' file` | `fs.sub_in_file(path, "a", "b")` |
| `awk '{ print $2 }' file` | `print(string.split(line)[2])` |
| `grep pat file` | `for line in fs.lines … if line:match(pat) …` |

## Test plan

- [x] `cargo test`: 966 passed, 0 failed.
- [x] `cargo clippy --tests -- -D warnings`: clean.
- [x] `tests/dockerfile.rs`: all three guards pass on the new scratch Dockerfile.
- [x] `tests/fs.rs`: 9 new tests for fs.lines + fs.sub_in_file (basic, empty file, no-trailing-newline, nonexistent, no-match idempotency, multiple occurrences, backreferences).
- [x] `tests/string_helpers.rs`: 9 new tests for string.split (default whitespace, custom sep, literal-not-pattern, multichar sep, leading/trailing whitespace, single element, empty string, trailing separator).
- [ ] CI on this PR: three required checks green (pr-only trigger from #62).
- [ ] Post-merge: tag `v0.12.1`, release workflow produces scratch-based image on ghcr.io + mac/linux binaries.

## Breaking changes

None. All additions are purely additive at the stdlib level. The Dockerfile change affects the published image only — anyone pulling `ghcr.io/developerinlondon/assay` will see a smaller image with nothing else changed. Downstream Dockerfiles that `FROM ghcr.io/developerinlondon/assay` will lose access to `/bin/sh` and other Alpine-provided tools — a grep of the gitops repo confirms zero current usages relied on those.