### PR TITLE
fix(release): vendor openssl so musl cross-build links statically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,6 +269,7 @@ dependencies = [
  "assay-workflow",
  "axum",
  "clap",
+ "openssl",
  "reqwest 0.13.2",
  "serde",
  "serde_json",
@@ -3385,6 +3386,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "openssl-src"
+version = "300.5.5+3.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f1787d533e03597a7934fd0a765f0d28e94ecc5fb7789f8053b1e699a56f709"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3392,6 +3402,7 @@ checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
 dependencies = [
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/crates/assay-engine/Cargo.toml
+++ b/crates/assay-engine/Cargo.toml
@@ -79,6 +79,18 @@ toml = "0.9"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 
+# Direct dep just to flip on the `vendored` feature for the openssl-sys
+# transitive (pulled in by webauthn-rs via assay-auth's auth-passkey
+# feature). Without this, the release-pipeline cross-build to
+# x86_64-unknown-linux-musl can't find a musl-compatible libssl on the
+# Ubuntu runner and openssl-sys aborts with "Could not find directory
+# of OpenSSL installation". `vendored` makes openssl-sys statically
+# compile OpenSSL from bundled source — adds ~30s to musl builds but
+# removes the cross-compile sysroot dependency entirely. Cargo feature
+# unification spreads the flag to every openssl/openssl-sys consumer
+# in the graph, so no other crate has to change.
+openssl = { version = "0.10", features = ["vendored"] }
+
 [dev-dependencies]
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
 tempfile = "3"


### PR DESCRIPTION
## Summary

- Add `openssl = { features = ["vendored"] }` to `crates/assay-engine/Cargo.toml` so `openssl-sys` statically compiles OpenSSL from bundled C source for the musl cross-build target
- Unblocks the v0.2.0 release pipeline — the `binaries (linux-x86_64-musl)` job in run [24944723161](https://github.com/developerinlondon/assay/actions/runs/24944723161) failed because the GitHub runner doesn't ship a musl-compatible libssl
- Adds ~4.7 MB to the release binary (14.8 MB → 19.5 MB) — accepted as a temporary cost; the proper fix is tracked in #75

## Why this and not a real OpenSSL removal

`webauthn-rs` (pulled in via `assay-auth`'s `auth-passkey` feature) is the only crate in our graph that depends on OpenSSL. Replacing it with a RustCrypto-backed equivalent that preserves full FIDO MDS attestation chain validation is ~10–11 hours of focused work — too large for an unplanned release-unblock. Vendoring OpenSSL is a one-line change that ships today.

See **#75** for the proper fix proposal: fork `webauthn-rs-core` to replace OpenSSL with `p256` / `p384` / `rsa` / `sha2` / `x509-cert` / `webpki`, keeping every attestation format we currently support.

## Test plan

- [x] `cargo build --release -p assay-engine --bin assay-engine` succeeds locally with the vendored feature on (verified, 1m 19s build time including OpenSSL static compile)
- [x] `ldd target/release/assay-engine` shows no openssl shared deps — binary is fully self-contained
- [ ] On merge: `release.yml` re-fires; `libraries` job is idempotent (skips already-published crates.io rows from run 24944723161); `binaries` job rebuilds musl Linux successfully; `release-assay-engine` + `release-assay-lua` jobs publish to crates.io, push tags `assay-engine-v0.2.0` + `assay-lua-v0.14.0`, create GH releases with binaries, push Docker images to ghcr.io

Closes the v0.2.0 release; #75 tracks the follow-up.