### PR TITLE
fix(release): idempotent docker push + .mise.toml as rust SSoT + Node-24 actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
     timeout-minutes: 25
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # moon's affected detection compares against the base ref,
           # which needs full history. Without this, every PR appears
@@ -89,7 +89,7 @@ jobs:
       # the e2e project's package.json so a Playwright bump
       # invalidates the cache and forces a fresh install.
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cache/ms-playwright
@@ -151,7 +151,7 @@ jobs:
       # upload without colliding.
       - name: Upload Playwright artifacts on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report-${{ matrix.os }}
           path: |
@@ -175,7 +175,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,13 +36,25 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+
+      # Pin rust to whatever .mise.toml says (single source of truth
+      # for the workspace toolchain) so the site build uses the same
+      # compiler the rest of CI does.
+      - id: rust
+        name: Read rust version from .mise.toml
+        run: |
+          set -euo pipefail
+          v=$(grep -oP '^rust\s*=\s*"\K[0-9]+\.[0-9]+(\.[0-9]+)?' .mise.toml)
+          echo "version=$v" >> "$GITHUB_OUTPUT"
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.rust.outputs.version }}
 
       - name: Cache cargo build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,15 @@ name: Release
 
 # Version-driven release pipeline. Trigger: any push to main (including the
 # merge commit of a feature PR). The `detect` job compares each workspace
-# crate's Cargo.toml version against crates.io; downstream jobs only run for
-# crates that bumped. Idempotent on re-run: if a version is already
-# published, its job is a no-op.
+# crate's Cargo.toml version against crates.io and exposes per-crate
+# `bumped` flags; the library-publish steps key off those flags. The
+# product (binaries + release-assay-engine + release-assay-lua) jobs
+# now always run after their predecessors succeed — every individual
+# step is independently idempotent (200-check on crates.io, `git
+# rev-parse` on tags, `gh release view` on GH releases, and
+# `docker buildx imagetools inspect` on ghcr images) so a re-run can
+# fill in a missed publish/push without bumping versions just to
+# clear an `if:` gate. Re-running on an already-shipped main is safe.
 #
 # Tagging policy (plan 12 rev 3): product crates get git tags on every
 # publish — `assay-lua-v<ver>` and `assay-engine-v<ver>`. Library crates
@@ -40,7 +46,9 @@ jobs:
       # Per-crate: `bumped` is "true" when the local manifest version is
       # ahead of crates.io; `version` is always the local manifest version
       # (downstream jobs use it for tag/release names regardless of whether
-      # we're publishing this run).
+      # we're publishing this run). The bumped flags drive *what* publish
+      # steps may push artifacts; downstream jobs themselves no longer
+      # gate on `bumped` so re-runs can fill in missed steps idempotently.
       assay_domain_bumped: ${{ steps.assay-domain.outputs.bumped }}
       assay_workflow_bumped: ${{ steps.assay-workflow.outputs.bumped }}
       assay_dashboard_bumped: ${{ steps.assay-dashboard.outputs.bumped }}
@@ -52,13 +60,32 @@ jobs:
       extension_bumped: ${{ steps.extension.outputs.bumped }}
       extension_version: ${{ steps.extension.outputs.version }}
       any_product_bumped: ${{ steps.any.outputs.any }}
+      # Workspace toolchain version — single source of truth lives in
+      # .mise.toml. Downstream jobs that need rust read this output
+      # instead of pinning their own version (or relying on @stable
+      # which silently rolls forward independently).
+      rust_version: ${{ steps.rust.outputs.version }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 2 # needed for `git show HEAD~1:...` diffing below
 
-      - uses: dtolnay/rust-toolchain@stable
+      - id: rust
+        name: Read rust version from .mise.toml
+        run: |
+          set -euo pipefail
+          v=$(grep -oP '^rust\s*=\s*"\K[0-9]+\.[0-9]+(\.[0-9]+)?' .mise.toml)
+          if [ -z "$v" ]; then
+            echo "could not extract rust version from .mise.toml" >&2
+            exit 1
+          fi
+          echo "rust pinned in .mise.toml: $v"
+          echo "version=$v" >> "$GITHUB_OUTPUT"
+
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.rust.outputs.version }}
 
       - id: assay-domain
         run: .github/release/check-bumped.sh assay-domain
@@ -124,9 +151,11 @@ jobs:
       needs.detect.outputs.assay_auth_bumped      == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ needs.detect.outputs.rust_version }}
 
       # Inline the helper so editing release.yml is one file, not two —
       # the detection path is already factored out, this is just the
@@ -183,13 +212,14 @@ jobs:
   #    product release jobs so we don't pay the cross-compile cost twice.
   binaries:
     needs: [detect, libraries]
-    # `libraries` uses `if:` to skip when nothing bumped, which in GH
-    # Actions makes it "skipped" not "success" — downstream `needs` would
-    # normally refuse to run. Use `always()` + explicit status check to
-    # proceed as long as libraries didn't outright *fail*.
+    # Always run after libraries finishes (success OR skipped). The
+    # downstream release jobs are independently idempotent — they can
+    # see what's already on crates.io / ghcr / GitHub releases and skip
+    # only the steps that have nothing left to do. Keeping `binaries`
+    # always-on means a release re-run can fix a missed publish/push
+    # without bumping versions just to clear the gate.
     if: |
       always() &&
-      needs.detect.outputs.any_product_bumped == 'true' &&
       (needs.libraries.result == 'success' || needs.libraries.result == 'skipped')
     strategy:
       fail-fast: false
@@ -205,10 +235,11 @@ jobs:
             deps: ""
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ needs.detect.outputs.rust_version }}
           targets: ${{ matrix.target }}
 
       - uses: Swatinem/rust-cache@v2
@@ -220,51 +251,50 @@ jobs:
         run: ${{ matrix.deps }}
 
       - name: Build assay runtime
-        if: needs.detect.outputs.assay_lua_bumped == 'true'
         run: cargo build --release --target ${{ matrix.target }} -p assay-lua --bin assay
 
       - name: Build assay-engine
-        if: needs.detect.outputs.assay_engine_bumped == 'true'
         run: cargo build --release --target ${{ matrix.target }} -p assay-engine --bin assay-engine
 
       - name: Package artifacts
         run: |
           set -euo pipefail
           mkdir -p dist
-          if [ -f "target/${{ matrix.target }}/release/assay" ]; then
-            cp target/${{ matrix.target }}/release/assay dist/assay-${{ matrix.suffix }}
-          fi
-          if [ -f "target/${{ matrix.target }}/release/assay-engine" ]; then
-            cp target/${{ matrix.target }}/release/assay-engine dist/assay-engine-${{ matrix.suffix }}
-          fi
+          cp target/${{ matrix.target }}/release/assay         dist/assay-${{ matrix.suffix }}
+          cp target/${{ matrix.target }}/release/assay-engine  dist/assay-engine-${{ matrix.suffix }}
           ls -la dist/
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: binaries-${{ matrix.target }}
           path: dist/*
-          if-no-files-found: ignore
+          if-no-files-found: error
 
   # ─────────────────────────────────────────────────────────────────────
   # 4. Product release: assay-engine. Publish the crate, push the
   #    `assay-engine-v<ver>` tag, create a GH release with the engine
   #    binaries + checksums + CHANGELOG section, and push the Docker
-  #    image. Runs only if assay-engine bumped.
+  #    image to ghcr.io. Always runs after `binaries` succeeds — every
+  #    step below is independently idempotent (crates.io 200-check, git
+  #    tag existence check, gh release existence check, ghcr image
+  #    existence check) so a re-run can fill in missed artifacts
+  #    without re-bumping the version.
   release-assay-engine:
     needs: [detect, libraries, binaries]
     if: |
       always() &&
-      needs.detect.outputs.assay_engine_bumped == 'true' &&
       (needs.libraries.result == 'success' || needs.libraries.result == 'skipped') &&
       needs.binaries.result == 'success'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ needs.detect.outputs.rust_version }}
 
       - name: Publish assay-engine to crates.io
         env:
@@ -280,7 +310,7 @@ jobs:
             cargo publish --allow-dirty -p assay-engine
           fi
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           pattern: binaries-*
           path: artifacts
@@ -294,6 +324,10 @@ jobs:
           sha256sum assay-engine-* > ../engine-checksums.txt
           cd ..
           cat engine-checksums.txt
+          # Co-locate the Dockerfile with the artifact so the docker
+          # build step's `context: artifacts` can find both. buildx
+          # resolves `file:` relative to the context directory.
+          cp Dockerfile.assay-engine artifacts/Dockerfile.assay-engine
 
       - name: Tag assay-engine-v${{ needs.detect.outputs.assay_engine_version }}
         env:
@@ -346,17 +380,44 @@ jobs:
             assay-engine-darwin-aarch64 \
             ../engine-checksums.txt
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/build-push-action@v6
+      # Idempotency check — `imagetools inspect` resolves the manifest
+      # via the registry API. Returns 0 when the tag exists, non-zero
+      # otherwise (404, network error, etc.). We treat any non-zero as
+      # "needs push" — false negatives just push redundantly, which is
+      # harmless when the destination tag is unchanged.
+      - name: Check if assay-engine docker image already exists
+        id: docker-check
+        env:
+          VERSION: ${{ needs.detect.outputs.assay_engine_version }}
+        run: |
+          set -uo pipefail
+          if docker buildx imagetools inspect "ghcr.io/developerinlondon/assay-engine:${VERSION}" >/dev/null 2>&1; then
+            echo "ghcr.io/developerinlondon/assay-engine:${VERSION} already published — skipping docker push"
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ghcr.io/developerinlondon/assay-engine:${VERSION} not found — will push"
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: docker/build-push-action@v7
+        if: steps.docker-check.outputs.exists != 'true'
         with:
-          context: .
+          # `context: artifacts` so the artifact-mode Dockerfile.assay-engine
+          # COPYs the linux-musl binary that the `binaries` job uploaded.
+          # Avoids re-running the cargo cross-compile inside Docker, which
+          # used to take ~6 min and tripped the openssl-src-needs-perl
+          # failure on rust:slim images.
+          context: artifacts
           file: Dockerfile.assay-engine
           push: true
+          build-args: |
+            RUST_VERSION=${{ needs.detect.outputs.rust_version }}
           tags: |
             ghcr.io/developerinlondon/assay-engine:${{ needs.detect.outputs.assay_engine_version }}
             ghcr.io/developerinlondon/assay-engine:latest
@@ -364,21 +425,25 @@ jobs:
   # ─────────────────────────────────────────────────────────────────────
   # 5. Product release: assay-lua. Same shape as assay-engine — separate
   #    job so the two can run in parallel after libraries+binaries finish.
+  #    Always runs after `binaries` succeeds; per-step idempotency
+  #    handles re-runs without version bumps (see release-assay-engine
+  #    above for the same pattern).
   release-assay-lua:
     needs: [detect, libraries, binaries]
     if: |
       always() &&
-      needs.detect.outputs.assay_lua_bumped == 'true' &&
       (needs.libraries.result == 'success' || needs.libraries.result == 'skipped') &&
       needs.binaries.result == 'success'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ needs.detect.outputs.rust_version }}
 
       - name: Publish assay-lua to crates.io
         env:
@@ -394,7 +459,7 @@ jobs:
             cargo publish --allow-dirty -p assay-lua
           fi
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           pattern: binaries-*
           path: artifacts
@@ -408,6 +473,9 @@ jobs:
           sha256sum assay-linux-x86_64 assay-darwin-aarch64 > ../lua-checksums.txt
           cd ..
           cat lua-checksums.txt
+          # Co-locate the Dockerfile with the artifact so the docker
+          # build step's `context: artifacts` can find both.
+          cp Dockerfile artifacts/Dockerfile
 
       - name: Tag assay-lua-v${{ needs.detect.outputs.assay_lua_version }}
         env:
@@ -452,17 +520,36 @@ jobs:
             assay-darwin-aarch64 \
             ../lua-checksums.txt
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/build-push-action@v6
+      - name: Check if assay docker image already exists
+        id: docker-check
+        env:
+          VERSION: ${{ needs.detect.outputs.assay_lua_version }}
+        run: |
+          set -uo pipefail
+          if docker buildx imagetools inspect "ghcr.io/developerinlondon/assay:${VERSION}" >/dev/null 2>&1; then
+            echo "ghcr.io/developerinlondon/assay:${VERSION} already published — skipping docker push"
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ghcr.io/developerinlondon/assay:${VERSION} not found — will push"
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: docker/build-push-action@v7
+        if: steps.docker-check.outputs.exists != 'true'
         with:
-          context: .
+          # `context: artifacts` so the artifact-mode Dockerfile COPYs
+          # the linux-musl assay binary the `binaries` job uploaded.
+          context: artifacts
           file: Dockerfile
           push: true
+          build-args: |
+            RUST_VERSION=${{ needs.detect.outputs.rust_version }}
           tags: |
             ghcr.io/developerinlondon/assay:${{ needs.detect.outputs.assay_lua_version }}
             ghcr.io/developerinlondon/assay:latest
@@ -479,9 +566,9 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "22"
           registry-url: "https://npm.pkg.github.com"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -324,10 +324,6 @@ jobs:
           sha256sum assay-engine-* > ../engine-checksums.txt
           cd ..
           cat engine-checksums.txt
-          # Co-locate the Dockerfile with the artifact so the docker
-          # build step's `context: artifacts` can find both. buildx
-          # resolves `file:` relative to the context directory.
-          cp Dockerfile.assay-engine artifacts/Dockerfile.assay-engine
 
       - name: Tag assay-engine-v${{ needs.detect.outputs.assay_engine_version }}
         env:
@@ -412,9 +408,11 @@ jobs:
           # COPYs the linux-musl binary that the `binaries` job uploaded.
           # Avoids re-running the cargo cross-compile inside Docker, which
           # used to take ~6 min and tripped the openssl-src-needs-perl
-          # failure on rust:slim images.
+          # failure on rust:slim images. The Dockerfile lives at the
+          # workspace root so the `file:` path is workspace-absolute —
+          # buildx accepts that explicitly even with a smaller `context:`.
           context: artifacts
-          file: Dockerfile.assay-engine
+          file: ${{ github.workspace }}/Dockerfile.assay-engine
           push: true
           build-args: |
             RUST_VERSION=${{ needs.detect.outputs.rust_version }}
@@ -473,9 +471,6 @@ jobs:
           sha256sum assay-linux-x86_64 assay-darwin-aarch64 > ../lua-checksums.txt
           cd ..
           cat lua-checksums.txt
-          # Co-locate the Dockerfile with the artifact so the docker
-          # build step's `context: artifacts` can find both.
-          cp Dockerfile artifacts/Dockerfile
 
       - name: Tag assay-lua-v${{ needs.detect.outputs.assay_lua_version }}
         env:
@@ -545,8 +540,10 @@ jobs:
         with:
           # `context: artifacts` so the artifact-mode Dockerfile COPYs
           # the linux-musl assay binary the `binaries` job uploaded.
+          # `file:` is workspace-absolute so buildx finds the Dockerfile
+          # outside the slimmer build context.
           context: artifacts
-          file: Dockerfile
+          file: ${{ github.workspace }}/Dockerfile
           push: true
           build-args: |
             RUST_VERSION=${{ needs.detect.outputs.rust_version }}

--- a/.gitignore
+++ b/.gitignore
@@ -32,5 +32,12 @@ assay-workflow.db-*
 /crates/assay-workflow/tests-e2e/playwright-report/
 /crates/assay-workflow/tests-e2e/.last-run.json
 
+# E2E SQLite scratch dirs created when local runs use a CWD-relative
+# data_dir. CI fixtures explicitly point at /tmp, but a developer
+# launching the engine binary directly from these directories will
+# land here (auth.db / engine.db / workflow.db).
+/crates/assay-engine/tests-e2e/data/
+/crates/assay-workflow/tests-e2e/data/
+
 # OMC session state in nested dirs
 **/.omc/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,76 @@
-# Builder — runtime binary (`assay`) for the pure Lua runtime crate.
+# assay container image — published as `ghcr.io/developerinlondon/assay`.
+# Pure Lua runtime; for the engine server image see `Dockerfile.assay-engine`.
 #
 # Post-0.13.0 the root-level `src/` and `stdlib/` moved under
 # `crates/assay/`, so `COPY crates/ crates/` alone covers every source
-# file the build needs. Building just the one package + bin keeps this
-# image focused and avoids compiling assay-engine (which has its own
-# Dockerfile) into the assay runtime image.
-FROM rust:1.92-slim AS builder
-RUN apt-get update && apt-get install -y musl-tools cmake make g++ protobuf-compiler && rm -rf /var/lib/apt/lists/*
+# file the source-mode build needs.
+#
+# Two build modes selected via the `BUILD_MODE` build arg:
+#
+#   BUILD_MODE=artifact (default)
+#     Consumes a pre-built linux-musl binary from the build context.
+#     The binary must be present at `assay-linux-x86_64`. Used by the
+#     release pipeline after the `binaries` GH Actions job downloads
+#     the matching cross-compiled artifact.
+#
+#     For local use, produce the binary first:
+#       cargo build --release --target x86_64-unknown-linux-musl \
+#         -p assay-lua --bin assay
+#       cp target/x86_64-unknown-linux-musl/release/assay \
+#         ./assay-linux-x86_64
+#       docker build -t assay .
+#
+#   BUILD_MODE=source
+#     Cross-compiles inside Docker. Slow (~5 min). Useful only when no
+#     local Rust toolchain is available.
+#
+#       docker build --build-arg BUILD_MODE=source -t assay .
+#
+# `RUST_VERSION` defaults to the pin in `.mise.toml` (the single source
+# of truth for the workspace toolchain). The release workflow extracts
+# it from .mise.toml and passes it as a build arg.
+
+ARG BUILD_MODE=artifact
+ARG RUST_VERSION=1.95
+
+# ──────────────────────────────────────────────────────────────────────
+# artifact branch — copy pre-built musl binary from build context
+# ──────────────────────────────────────────────────────────────────────
+FROM scratch AS artifact
+COPY assay-linux-x86_64 /assay
+
+# ──────────────────────────────────────────────────────────────────────
+# source branch — full cross-compile (rare, local-dev only)
+# ──────────────────────────────────────────────────────────────────────
+# `perl` is included for symmetry with Dockerfile.assay-engine — assay-lua
+# itself doesn't currently pull openssl-src, but adding a future dep
+# that does shouldn't silently start failing.
+FROM rust:${RUST_VERSION}-slim AS source-builder
+RUN apt-get update && apt-get install -y \
+      musl-tools cmake make g++ protobuf-compiler perl \
+    && rm -rf /var/lib/apt/lists/*
 RUN rustup target add x86_64-unknown-linux-musl
 WORKDIR /app
 COPY Cargo.toml Cargo.lock ./
 COPY crates/ crates/
-RUN cargo build --release --target x86_64-unknown-linux-musl -p assay-lua --bin assay
+RUN cargo build --release --target x86_64-unknown-linux-musl -p assay-lua --bin assay \
+    && cp /app/target/x86_64-unknown-linux-musl/release/assay /assay
 
-# Runtime — FROM scratch so the published image is the assay binary
-# plus a CA bundle, nothing else (~10 MB instead of ~25 MB with
-# alpine, and no transitive busybox/apk/musl CVE surface).
+# Normalise the source-builder output to a stage exposing /assay,
+# matching the artifact stage's layout.
+FROM source-builder AS source
+
+# ──────────────────────────────────────────────────────────────────────
+# Picker — Docker allows ARG interpolation in `FROM` but not in
+# `COPY --from=…`, so this small stage resolves BUILD_MODE; the runtime
+# stage then does a fixed `COPY --from=picked`.
+# ──────────────────────────────────────────────────────────────────────
+FROM ${BUILD_MODE} AS picked
+
+# ──────────────────────────────────────────────────────────────────────
+# CA certificate bundle — alpine is used only as a vendored cert source.
+# Files COPYed into FROM scratch; alpine itself never ships.
+# ──────────────────────────────────────────────────────────────────────
 #
 # History: commit 5c43c83 (Feb 2026) flipped this to alpine:3.21 to
 # accommodate one downstream Deployment that used `command: ["/bin/sh",
@@ -27,7 +82,15 @@ RUN cargo build --release --target x86_64-unknown-linux-musl -p assay-lua --bin 
 # (reqwest, sqlx TLS, WebSockets) verifies the server cert against
 # roots read from /etc/ssl/certs/ca-certificates.crt. Without this
 # file on scratch, every TLS connection fails immediately.
+FROM alpine:3 AS certs
+RUN apk add --no-cache ca-certificates
+
+# ──────────────────────────────────────────────────────────────────────
+# Runtime — FROM scratch so the published image is just the assay binary
+# plus a CA bundle, nothing else (~12 MB instead of ~25 MB with alpine,
+# and no transitive busybox/apk/musl CVE surface).
+# ──────────────────────────────────────────────────────────────────────
 FROM scratch
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=builder /app/target/x86_64-unknown-linux-musl/release/assay /assay
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=picked /assay /assay
 ENTRYPOINT ["/assay"]

--- a/Dockerfile.assay-engine
+++ b/Dockerfile.assay-engine
@@ -1,26 +1,93 @@
-# Builder — standalone HTTP server binary (`assay-engine`) that
-# composes assay-workflow, assay-dashboard, and (in v0.14.0) assay-auth
-# behind one port. Published as `ghcr.io/developerinlondon/assay-engine`
-# — distinct from the runtime image (`ghcr.io/developerinlondon/assay`)
-# because operators who deploy the server need a different set of
-# features, ports, and expectations than devs running one-off scripts.
-FROM rust:1.92-slim AS builder
-RUN apt-get update && apt-get install -y musl-tools cmake make g++ protobuf-compiler && rm -rf /var/lib/apt/lists/*
+# assay-engine container image — published as
+# `ghcr.io/developerinlondon/assay-engine`. Distinct from the assay
+# runtime image because operators who deploy the server need a different
+# set of features, ports, and expectations than devs running one-off
+# scripts.
+#
+# Two build modes selected via the `BUILD_MODE` build arg:
+#
+#   BUILD_MODE=artifact (default)
+#     Consumes a pre-built linux-musl binary from the build context.
+#     The binary must be present at `assay-engine-linux-x86_64`. Used by
+#     the release pipeline after the `binaries` GH Actions job downloads
+#     the matching cross-compiled artifact. Build context: ~20 MB.
+#     Build time: ~10s.
+#
+#     For local use, produce the binary first:
+#       cargo build --release --target x86_64-unknown-linux-musl \
+#         -p assay-engine --bin assay-engine
+#       cp target/x86_64-unknown-linux-musl/release/assay-engine \
+#         ./assay-engine-linux-x86_64
+#       docker build -f Dockerfile.assay-engine -t assay-engine .
+#
+#   BUILD_MODE=source
+#     Cross-compiles inside Docker. Slow (~6 min, plus ~30s for the
+#     vendored OpenSSL static compile that webauthn-rs needs). Useful
+#     only when no local Rust toolchain is available.
+#
+#       docker build --build-arg BUILD_MODE=source \
+#         -f Dockerfile.assay-engine -t assay-engine .
+#
+# `RUST_VERSION` defaults to the version pinned in `.mise.toml` (the
+# single source of truth for the workspace toolchain). The release
+# workflow extracts it from .mise.toml and passes it as a build arg so
+# the Dockerfile default never goes stale; bump both together if you
+# bump rust manually.
+
+ARG BUILD_MODE=artifact
+ARG RUST_VERSION=1.95
+
+# ──────────────────────────────────────────────────────────────────────
+# artifact branch — copy pre-built musl binary from build context
+# ──────────────────────────────────────────────────────────────────────
+FROM scratch AS artifact
+COPY assay-engine-linux-x86_64 /assay-engine
+
+# ──────────────────────────────────────────────────────────────────────
+# source branch — full cross-compile (rare, local-dev only)
+# ──────────────────────────────────────────────────────────────────────
+# `perl` (full distribution, not just `perl-base`) is required by
+# `openssl-src`'s ./Configure script — the slim Debian image only ships
+# perl-base which is missing FindBin.pm. Without `perl` here the vendored
+# OpenSSL build fails with "Can't locate FindBin.pm in @INC".
+FROM rust:${RUST_VERSION}-slim AS source-builder
+RUN apt-get update && apt-get install -y \
+      musl-tools cmake make g++ protobuf-compiler perl \
+    && rm -rf /var/lib/apt/lists/*
 RUN rustup target add x86_64-unknown-linux-musl
 WORKDIR /app
 COPY Cargo.toml Cargo.lock ./
 COPY crates/ crates/
-RUN cargo build --release --target x86_64-unknown-linux-musl -p assay-engine --bin assay-engine
+RUN cargo build --release --target x86_64-unknown-linux-musl -p assay-engine --bin assay-engine \
+    && cp /app/target/x86_64-unknown-linux-musl/release/assay-engine /assay-engine
 
-# Runtime — FROM scratch mirrors the policy of the runtime image: no
-# shell, no busybox, no alpine CVE surface. Just the static musl binary
-# + a CA bundle so HTTPS (reqwest, sqlx TLS) can verify server certs.
-#
-# Default port follows assay-engine's `EngineConfig.server.bind_addr`
-# conventional default of 0.0.0.0:8080. Operators override via config
-# or CLI flag; the EXPOSE is informational for orchestration tooling.
+# Normalise the source-builder output to a stage with the binary at
+# /assay-engine, matching the artifact stage's layout. Both branches
+# now expose `/assay-engine` so the picker below can select either.
+FROM source-builder AS source
+
+# ──────────────────────────────────────────────────────────────────────
+# Picker — Docker allows ARG interpolation inside `FROM` but NOT inside
+# `COPY --from=…`, so we use a small picker stage that resolves the
+# build mode here, then the runtime stage does a fixed
+# `COPY --from=picked` regardless of which branch was selected.
+# ──────────────────────────────────────────────────────────────────────
+FROM ${BUILD_MODE} AS picked
+
+# ──────────────────────────────────────────────────────────────────────
+# CA certificate bundle — alpine is used only as a vendored cert source.
+# Its files end up COPIED into FROM scratch; alpine itself never ships.
+# ──────────────────────────────────────────────────────────────────────
+FROM alpine:3 AS certs
+RUN apk add --no-cache ca-certificates
+
+# ──────────────────────────────────────────────────────────────────────
+# Runtime — FROM scratch + binary + cert bundle. No shell, no busybox,
+# no apk surface. Default port mirrors EngineConfig.server.bind_addr's
+# 0.0.0.0:8080 default; operators override via config or CLI flag.
+# ──────────────────────────────────────────────────────────────────────
 FROM scratch
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=builder /app/target/x86_64-unknown-linux-musl/release/assay-engine /assay-engine
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=picked /assay-engine /assay-engine
 EXPOSE 8080
 ENTRYPOINT ["/assay-engine"]


### PR DESCRIPTION
## Summary

- Stops the docker build inside Docker — both Dockerfiles now consume the prebuilt linux-musl binary that the `binaries` job already produces, eliminating the openssl-src perl/FindBin failure that blocked v0.2.0's Docker push
- Makes the release pipeline truly idempotent — `release-assay-engine` and `release-assay-lua` no longer gate on `*_bumped == 'true'`, and the docker push now does a `docker buildx imagetools inspect` skip-if-present check (matching what crates publish, git tag, and gh release already had)
- Bumps every Node-20-deprecated GitHub Action to its current Node-24 major (checkout v6, upload-artifact v7, download-artifact v8, cache v5, setup-node v6, docker/login v4, docker/build-push v7)
- Bumps both Dockerfiles' rust base from 1.92-slim → 1.95-slim and adds `perl` to source-mode apt deps (so future openssl-src consumers work)
- Makes `.mise.toml` the single source of truth for the workspace rust version — release.yml + deploy.yml now read it inline and pass to `dtolnay/rust-toolchain@master` instead of pinning independently or rolling on `@stable`

## Why

- **No new release version needed.** v0.2.0 already shipped to crates.io + tagged + GH released; only the assay-engine Docker image is missing. After this merges, release.yml will idempotently no-op every other step and only push the missing `ghcr.io/developerinlondon/assay-engine:0.2.0` + `:latest`.
- **No more cross-compile inside Docker.** Image build drops from ~6 min to ~10s; vendored OpenSSL no longer compiled twice (once on the runner for the binary artifact, once inside Docker for nothing).
- **Defensive against future re-runs.** Re-running release.yml on already-shipped main is now safe — every artifact-creating step has an existence check, every gate is gone, the workflow does only what's missing.

## What changed

| File | Change |
|---|---|
| `Dockerfile.assay-engine` | Dual-mode (`BUILD_MODE=artifact` default, `=source` for local dev), rust 1.95-slim, perl added to source-mode deps |
| `Dockerfile` (assay-lua) | Same dual-mode shape, rust 1.95-slim |
| `.github/workflows/release.yml` | Detect job exposes `rust_version` from `.mise.toml`; binaries + release jobs run unconditionally after their predecessors succeed; docker push gated on `imagetools inspect` skip-if-present; `context: artifacts` consumes the prebuilt binary; build-arg passes RUST_VERSION through; all action versions bumped to Node-24 majors |
| `.github/workflows/ci.yml` | Action version bumps only |
| `.github/workflows/deploy.yml` | Action version bumps + read rust version from `.mise.toml` |

## Closes

- Resolves the failed docker push from release run [`24954145848`](https://github.com/developerinlondon/assay/actions/runs/24954145848)
- Eliminates every "Node 20 actions are deprecated" CI warning

## Test plan

- [x] YAML syntax-checked locally for all three workflow files
- [x] `Dockerfile.assay-engine` artifact-mode build succeeds locally with a staged binary
- [ ] On merge: release.yml re-fires, library/crate/tag/GH-release steps all skip via existing idempotency checks, only `ghcr.io/developerinlondon/assay-engine:0.2.0` + `:latest` get pushed
- [ ] Confirm zero `Node 20 actions are deprecated` annotations on the next workflow run