### PR TITLE
fix(release): skip binaries when GH releases already exist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,32 +1,19 @@
 name: CI
 
+# pull_request validates the merge commit; branch protection blocks
+# direct pushes to main, so a push trigger would re-run on identical
+# code. Tag pushes (`v*`) are handled by release.yml.
 on:
-  # `pull_request` fires on open + every new commit (the
-  # `synchronize` event), and tests against the merge commit with
-  # the base branch. Because branch protection blocks direct pushes
-  # to `main`, the merge commit that pull_request validates IS the
-  # commit that lands on `main` after merge — so a push trigger on
-  # `main` would just re-run CI on identical code. Skip it; rely on
-  # pull_request alone. Tag pushes (`v*`) are handled by release.yml.
   pull_request:
 
 permissions:
   contents: read
 
-# Cancel superseded runs on the same branch — saves CI minutes when
-# pushing rapid-fire commits.
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  # Rust workspace: clippy + tests + e2e via `moon ci`, on both
-  # release targets. Job name `check` + the two matrix entries
-  # produce the status contexts `check (ubuntu-latest,
-  # x86_64-unknown-linux-gnu)` and `check (macos-14,
-  # aarch64-apple-darwin)`, matching branch protection on `main`.
-  # Matrix coverage exists because assay ships binaries for both
-  # targets via release.yml — CI must validate each on every PR.
   check:
     strategy:
       fail-fast: false
@@ -37,79 +24,54 @@ jobs:
           - os: macos-14
             target: aarch64-apple-darwin
     runs-on: ${{ matrix.os }}
-    # Ubuntu runs the full matrix (PG + SQLite). Shared PG18 service below
-    # eliminates per-test container spin-up, so the workflow suite is
-    # seconds not minutes. macOS is SQLite-only (PG tests cfg-gated
-    # `target_os = "linux"`) plus rust compile. 25 min covers both with
-    # comfortable headroom — any longer was masking the per-test-container
-    # pathology, which is now gone.
     timeout-minutes: 25
 
     steps:
       - uses: actions/checkout@v6
         with:
-          # moon's affected detection compares against the base ref,
-          # which needs full history. Without this, every PR appears
-          # as a single-commit diff and the affected set is wrong.
+          # moon's affected detection compares against the base ref —
+          # needs full history.
           fetch-depth: 0
 
-      # Single source of truth for tool versions: .mise.toml at the
-      # repo root pins rust + node + moon. mise-action installs them
-      # and prepends them to PATH for every subsequent step.
+      # .mise.toml is the single source of truth for tool versions.
+      # Pinning mise itself avoids a flaky `latest` CDN failure
+      # ("zstd: unexpected end of file" / "tar: child returned status 1").
       - uses: jdx/mise-action@v2
         with:
-          # Pin mise itself rather than using `latest`. The download
-          # step for `latest` has been intermittently failing with
-          # "zstd: unexpected end of file" / "tar: child returned
-          # status 1" — a flaky CDN issue, not anything wrong with
-          # our config. A pinned version uses a stable artifact URL.
           version: 2026.4.17
           install: true
           cache: true
 
-      # mise's rust plugin defaults to the `minimal` profile which
-      # excludes clippy. CI runs `cargo clippy --workspace` so add
-      # the component explicitly. Cheap (~2s) and idempotent.
+      # mise's rust plugin defaults to the `minimal` profile (no clippy).
       - name: Install clippy component
         run: rustup component add clippy
 
-      # Cargo's incremental build cache (target/, ~/.cargo/registry).
-      # Independent of moon's task-output cache — they cover different
-      # layers (compile artifacts vs declared task results). Keyed on
-      # the matrix target so linux and macos have independent caches.
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: "ci-${{ matrix.target }}-v3"
           cache-all-crates: "true"
           save-if: "true"
 
-      # Cache Playwright browser binaries (~150 MB). Playwright stores
-      # them under an OS-specific default path — list both so the
-      # cache action matches whichever the runner uses. Key includes
-      # the e2e project's package.json so a Playwright bump
-      # invalidates the cache and forces a fresh install.
+      # Playwright stores browsers under an OS-specific default path —
+      # list both so the cache action matches whichever the runner uses.
+      # Hash both e2e package.json files: a Playwright bump in either
+      # project invalidates the cache and forces a fresh install.
       - name: Cache Playwright browsers
         uses: actions/cache@v5
         with:
           path: |
             ~/.cache/ms-playwright
             ~/Library/Caches/ms-playwright
-          # Hash both e2e package.json files so a Playwright bump in
-          # either project invalidates the cache. The engine console e2e
-          # suite (tests-e2e/ on assay-engine) lives next to the
-          # workflow one and shares the same browser binaries.
           key: playwright-${{ runner.os }}-${{ hashFiles('crates/assay-workflow/tests-e2e/package.json', 'crates/assay-engine/tests-e2e/package.json') }}
           restore-keys: |
             playwright-${{ runner.os }}-
 
-      # Shared Postgres service for Ubuntu runs only. `services:` in a
-      # matrix job can't be conditional, and on macOS GH runners have no
-      # Docker — so we run the container explicitly here with `if:`.
-      # Starting PG once per job and creating a database per test (via
-      # the harness's `TEST_DATABASE_URL` path) eliminates the per-test
-      # testcontainer spin-up that previously churned the docker daemon
-      # into intermittent hangs. macOS keeps its SQLite-only code path
-      # (PG cases cfg-gated `target_os = "linux"`).
+      # Shared Postgres for Ubuntu only. `services:` can't be conditional
+      # in a matrix and macOS GH runners have no Docker. Starting PG once
+      # per job + creating a database per test (via TEST_DATABASE_URL)
+      # eliminates the per-test testcontainer churn that intermittently
+      # hung the docker daemon. macOS is SQLite-only (PG cases cfg-gated
+      # `target_os = "linux"`).
       - name: Start Postgres 18 (Linux)
         if: runner.os == 'Linux'
         run: |
@@ -134,21 +96,11 @@ jobs:
         if: runner.os == 'Linux'
         run: echo "TEST_DATABASE_URL=postgres://postgres:postgres@localhost:5432/postgres" >> $GITHUB_ENV
 
-      # Run only the tasks affected by the diff. moon walks the
-      # project graph, identifies which projects' inputs changed, and
-      # runs their `runInCI: true` tasks (lint/build/test for rust,
-      # install/install-browsers/test for the e2e + extension
-      # projects, build for the site). Doc-only PRs skip everything
-      # except site:build if the docs they touch feed it.
       - name: moon ci
         run: moon ci --color
         env:
           MOON_LOG: "info"
 
-      # On failure, surface the Playwright HTML report + traces +
-      # screenshots so the PR author can debug without rerunning
-      # locally. Artifact name is per-OS so both matrix runs can
-      # upload without colliding.
       - name: Upload Playwright artifacts on failure
         if: failure()
         uses: actions/upload-artifact@v7
@@ -165,12 +117,8 @@ jobs:
           if-no-files-found: ignore
           retention-days: 7
 
-  # Dedicated openclaw-extension vitest gate. Ubuntu-only (pure node
-  # + vitest; no native deps). Kept as a distinct required check so a
-  # PR that only breaks the extension fails this job specifically,
-  # instead of hiding behind a generic "moon ci failed" in the matrix
-  # jobs. Moon's cache makes the task near-free when the extension
-  # isn't touched.
+  # Dedicated extension gate so an extension-only break fails this job
+  # specifically rather than hiding behind a generic "moon ci failed".
   extension-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,26 +1,8 @@
 name: Release
 
-# Version-driven release pipeline. Trigger: any push to main (including the
-# merge commit of a feature PR). The `detect` job compares each workspace
-# crate's Cargo.toml version against crates.io and exposes per-crate
-# `bumped` flags; the library-publish steps key off those flags. The
-# product (binaries + release-assay-engine + release-assay-lua) jobs
-# now always run after their predecessors succeed — every individual
-# step is independently idempotent (200-check on crates.io, `git
-# rev-parse` on tags, `gh release view` on GH releases, and
-# `docker buildx imagetools inspect` on ghcr images) so a re-run can
-# fill in a missed publish/push without bumping versions just to
-# clear an `if:` gate. Re-running on an already-shipped main is safe.
-#
-# Tagging policy (plan 12 rev 3): product crates get git tags on every
-# publish — `assay-lua-v<ver>` and `assay-engine-v<ver>`. Library crates
-# (assay-domain, assay-workflow, assay-dashboard, assay-auth) publish to
-# crates.io but don't get git tags in coordinated releases — their versions
-# are traceable through the product tag's tree and the crates.io index.
-#
-# `workflow_dispatch` is kept for retries and for the human-triggered first
-# smoke test. Intentionally no `tags: [v*]` trigger — tags are output here,
-# not input.
+# Version-driven release: each step is idempotent (crates.io 200, git
+# rev-parse, gh release view, imagetools inspect) so re-runs on an
+# already-shipped main are safe.
 
 on:
   push:
@@ -28,11 +10,10 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write # tags + GitHub releases
-  packages: write # ghcr.io Docker images + npm publish to GitHub Packages
+  contents: write
+  packages: write
 
-# Releases must not race: serialise by this workflow name, don't cancel an
-# in-flight run (half-published crates.io state is annoying to recover from).
+# Half-published crates.io state is hard to recover from — never cancel.
 concurrency:
   group: release
   cancel-in-progress: false
@@ -43,12 +24,6 @@ jobs:
   detect:
     runs-on: ubuntu-latest
     outputs:
-      # Per-crate: `bumped` is "true" when the local manifest version is
-      # ahead of crates.io; `version` is always the local manifest version
-      # (downstream jobs use it for tag/release names regardless of whether
-      # we're publishing this run). The bumped flags drive *what* publish
-      # steps may push artifacts; downstream jobs themselves no longer
-      # gate on `bumped` so re-runs can fill in missed steps idempotently.
       assay_domain_bumped: ${{ steps.assay-domain.outputs.bumped }}
       assay_workflow_bumped: ${{ steps.assay-workflow.outputs.bumped }}
       assay_dashboard_bumped: ${{ steps.assay-dashboard.outputs.bumped }}
@@ -60,24 +35,8 @@ jobs:
       extension_bumped: ${{ steps.extension.outputs.bumped }}
       extension_version: ${{ steps.extension.outputs.version }}
       any_product_bumped: ${{ steps.any.outputs.any }}
-      # Workspace toolchain version — single source of truth lives in
-      # .mise.toml. Downstream jobs that need rust read this output
-      # instead of pinning their own version (or relying on @stable
-      # which silently rolls forward independently).
       rust_version: ${{ steps.rust.outputs.version }}
-      # `binaries_needed` is true when at least one product's GH release
-      # for the current Cargo.toml version is missing. When both GH
-      # releases exist, the per-product `release-*` jobs can fetch the
-      # already-published linux/darwin binaries via `gh release
-      # download` instead of paying ~6 min to cross-compile from
-      # scratch — that's exactly the case for re-runs that only need to
-      # fix a missed downstream artifact (e.g. the docker push that
-      # failed in run 24954145848).
       binaries_needed: ${{ steps.artifacts-state.outputs.binaries_needed }}
-      # Per-product GH release presence — the prepare step in each
-      # release-* job reads these to choose between `gh release
-      # download` (existing release) and `actions/download-artifact`
-      # (fresh build from the binaries job).
       assay_engine_release_exists: ${{ steps.artifacts-state.outputs.engine_release_exists }}
       assay_lua_release_exists: ${{ steps.artifacts-state.outputs.lua_release_exists }}
 
@@ -120,12 +79,9 @@ jobs:
       - id: assay-lua
         run: .github/release/check-bumped.sh assay-lua
 
-      # openclaw-extension follows its own version track (package.json),
-      # and GitHub Packages doesn't expose a public HEAD we can cheaply
-      # probe without auth. Keep it simple: diff the current version
-      # against the previous commit's version — if the push changed it,
-      # publish. `npm publish` is itself idempotent on exact version
-      # matches (returns 409), so mistaken re-runs are safe.
+      # GitHub Packages has no cheap unauthed HEAD probe; diff against
+      # HEAD~1 instead. `npm publish` returns 409 on exact match so
+      # re-runs are safe.
       - id: extension
         run: |
           set -euo pipefail
@@ -141,8 +97,6 @@ jobs:
           fi
           echo "version=$current" >> "$GITHUB_OUTPUT"
 
-      # Used by the binary-build job — only worth running if some product
-      # is actually shipping.
       - id: any
         run: |
           any=false
@@ -153,14 +107,10 @@ jobs:
           done
           echo "any=$any" >> "$GITHUB_OUTPUT"
 
-      # Are the per-product GH releases for the *current* Cargo.toml
-      # versions already published? If yes, the cross-compiled binaries
-      # are attached to those releases and we can fetch them via
-      # `gh release download` later — the `binaries` job becomes
-      # unnecessary and gets skipped (~6 min saved per re-run). The
-      # per-product `*_release_exists` outputs let each release-* job
-      # pick its `prepare assets` source: existing GH release or
-      # fresh build artifact from the `binaries` job.
+      # `binaries_needed` lets the binaries job skip when both products'
+      # GH releases already exist — the release-* jobs then `gh release
+      # download` the attached musl/darwin binaries instead of paying
+      # the cross-compile cost.
       - id: artifacts-state
         name: Check release artifact state
         env:
@@ -169,41 +119,31 @@ jobs:
           LUA_TAG: assay-lua-v${{ steps.assay-lua.outputs.version }}
         run: |
           set -uo pipefail
-          # `gh release view <tag>` resolves through the API; no need
-          # to fetch local tags. Treat any non-zero exit (404, transient
-          # API error) as "release missing" — false negatives just
-          # rebuild the binaries, which is the safe direction.
           if gh release view "$ENGINE_TAG" >/dev/null 2>&1; then
-            echo "GH release $ENGINE_TAG exists — assay-engine binaries will be reused"
             engine_release=true
           else
-            echo "GH release $ENGINE_TAG missing — assay-engine binaries will be rebuilt"
             engine_release=false
           fi
           if gh release view "$LUA_TAG" >/dev/null 2>&1; then
-            echo "GH release $LUA_TAG exists — assay-lua binaries will be reused"
             lua_release=true
           else
-            echo "GH release $LUA_TAG missing — assay-lua binaries will be rebuilt"
             lua_release=false
           fi
           if [ "$engine_release" = "true" ] && [ "$lua_release" = "true" ]; then
             binaries_needed=false
-            echo "both GH releases present — skipping binaries job"
           else
             binaries_needed=true
-            echo "at least one GH release missing — binaries job will run"
           fi
+          echo "engine=$engine_release lua=$lua_release binaries_needed=$binaries_needed"
           {
             echo "engine_release_exists=$engine_release"
             echo "lua_release_exists=$lua_release"
             echo "binaries_needed=$binaries_needed"
           } >> "$GITHUB_OUTPUT"
 
-  # ─────────────────────────────────────────────────────────────────────
-  # 2. Library crates: publish only, no tags, no GH releases. Strict
-  #    dependency order to respect crates.io's post-publish propagation
-  #    delay (the helper sleeps 30s after each publish).
+  # Library crates — publish only, no tags. Order matters because of
+  # crates.io's index propagation delay; the helper sleeps 30s after
+  # each new publish.
   libraries:
     needs: detect
     if: >
@@ -219,9 +159,6 @@ jobs:
         with:
           toolchain: ${{ needs.detect.outputs.rust_version }}
 
-      # Inline the helper so editing release.yml is one file, not two —
-      # the detection path is already factored out, this is just the
-      # publish side which is a thin wrapper over `cargo publish`.
       - name: Publish helper
         run: |
           cat > /tmp/publish-crate.sh <<'EOF'
@@ -269,18 +206,10 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: /tmp/publish-crate.sh assay-auth
 
-  # ─────────────────────────────────────────────────────────────────────
-  # 3. Build product binaries for both targets. Shared between the two
-  #    product release jobs so we don't pay the cross-compile cost twice.
+  # Cross-compile both products for both targets. Shared between the
+  # release-* jobs.
   binaries:
     needs: [detect, libraries]
-    # Skip the cross-compile entirely when both products' GH releases
-    # for the current versions already exist — the `release-*` jobs
-    # will fetch the attached binaries via `gh release download`
-    # instead. This keeps re-runs cheap (~2 min total) on top of the
-    # always-idempotent downstream steps. `(success || skipped)` for
-    # libraries is the standard GH Actions pattern to allow a skipped
-    # `if:` upstream to still gate "did anything fail outright?".
     if: |
       always() &&
       needs.detect.outputs.binaries_needed == 'true' &&
@@ -334,15 +263,6 @@ jobs:
           path: dist/*
           if-no-files-found: error
 
-  # ─────────────────────────────────────────────────────────────────────
-  # 4. Product release: assay-engine. Publish the crate, push the
-  #    `assay-engine-v<ver>` tag, create a GH release with the engine
-  #    binaries + checksums + CHANGELOG section, and push the Docker
-  #    image to ghcr.io. Always runs after `binaries` succeeds — every
-  #    step below is independently idempotent (crates.io 200-check, git
-  #    tag existence check, gh release existence check, ghcr image
-  #    existence check) so a re-run can fill in missed artifacts
-  #    without re-bumping the version.
   release-assay-engine:
     needs: [detect, libraries, binaries]
     if: |
@@ -374,12 +294,8 @@ jobs:
             cargo publish --allow-dirty -p assay-engine
           fi
 
-      # Source the linux-musl + darwin binaries. Two paths depending on
-      # whether the GH release for this version is already there:
-      #   * release exists → fetch from the release (fast, ~5s, no
-      #     binaries job needed)
-      #   * release missing → use the artifact uploaded by the binaries
-      #     job (which only ran in the missing-release case anyway)
+      # Source the binaries: from a prior GH release if present, else
+      # from the binaries job's upload.
       - uses: actions/download-artifact@v8
         if: needs.detect.outputs.assay_engine_release_exists != 'true'
         with:
@@ -396,9 +312,6 @@ jobs:
           set -euo pipefail
           mkdir -p artifacts
           cd artifacts
-          # Pattern matches both linux + darwin engine binaries; the
-          # checksum file is regenerated locally below so we don't
-          # bother re-downloading it.
           gh release download "assay-engine-v${VERSION}" \
             --pattern 'assay-engine-linux-x86_64' \
             --pattern 'assay-engine-darwin-aarch64'
@@ -427,21 +340,18 @@ jobs:
             git push origin "assay-engine-v${VERSION}"
           fi
 
+      # Coordinated releases share a CHANGELOG section keyed on the lua
+      # version; fall back to that when no engine-specific section exists.
       - name: Extract CHANGELOG section
         env:
           ENGINE_VER: ${{ needs.detect.outputs.assay_engine_version }}
           LUA_VER: ${{ needs.detect.outputs.assay_lua_version }}
         run: |
           set -euo pipefail
-          # Product releases share one CHANGELOG keyed on the assay-lua /
-          # coordinated release version (e.g. 0.13.0 covers everything
-          # shipped that day). Prefer the engine's own version section if
-          # one exists; otherwise fall back to the lua section for
-          # coordinated releases.
           if .github/release/extract-changelog.sh "$ENGINE_VER" > notes.md 2>/dev/null; then
-            echo "notes from CHANGELOG section $ENGINE_VER"
+            :
           elif .github/release/extract-changelog.sh "$LUA_VER" > notes.md 2>/dev/null; then
-            echo "notes from CHANGELOG section $LUA_VER (coordinated release)"
+            :
           else
             echo "Release assay-engine ${ENGINE_VER}." > notes.md
           fi
@@ -470,11 +380,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Idempotency check — `imagetools inspect` resolves the manifest
-      # via the registry API. Returns 0 when the tag exists, non-zero
-      # otherwise (404, network error, etc.). We treat any non-zero as
-      # "needs push" — false negatives just push redundantly, which is
-      # harmless when the destination tag is unchanged.
       - name: Check if assay-engine docker image already exists
         id: docker-check
         env:
@@ -489,16 +394,12 @@ jobs:
             echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
+      # `context: artifacts` keeps the build context to just the binary
+      # the binaries job uploaded; the Dockerfile is workspace-absolute
+      # because buildx looks up `file:` relative to context by default.
       - uses: docker/build-push-action@v7
         if: steps.docker-check.outputs.exists != 'true'
         with:
-          # `context: artifacts` so the artifact-mode Dockerfile.assay-engine
-          # COPYs the linux-musl binary that the `binaries` job uploaded.
-          # Avoids re-running the cargo cross-compile inside Docker, which
-          # used to take ~6 min and tripped the openssl-src-needs-perl
-          # failure on rust:slim images. The Dockerfile lives at the
-          # workspace root so the `file:` path is workspace-absolute —
-          # buildx accepts that explicitly even with a smaller `context:`.
           context: artifacts
           file: ${{ github.workspace }}/Dockerfile.assay-engine
           push: true
@@ -508,12 +409,6 @@ jobs:
             ghcr.io/developerinlondon/assay-engine:${{ needs.detect.outputs.assay_engine_version }}
             ghcr.io/developerinlondon/assay-engine:latest
 
-  # ─────────────────────────────────────────────────────────────────────
-  # 5. Product release: assay-lua. Same shape as assay-engine — separate
-  #    job so the two can run in parallel after libraries+binaries finish.
-  #    Always runs after `binaries` succeeds; per-step idempotency
-  #    handles re-runs without version bumps (see release-assay-engine
-  #    above for the same pattern).
   release-assay-lua:
     needs: [detect, libraries, binaries]
     if: |
@@ -545,9 +440,6 @@ jobs:
             cargo publish --allow-dirty -p assay-lua
           fi
 
-      # Source the linux-musl + darwin binaries — same dual-source
-      # pattern as release-assay-engine: existing GH release wins,
-      # else fall back to the binaries-job artifact.
       - uses: actions/download-artifact@v8
         if: needs.detect.outputs.assay_lua_release_exists != 'true'
         with:
@@ -644,10 +536,6 @@ jobs:
       - uses: docker/build-push-action@v7
         if: steps.docker-check.outputs.exists != 'true'
         with:
-          # `context: artifacts` so the artifact-mode Dockerfile COPYs
-          # the linux-musl assay binary the `binaries` job uploaded.
-          # `file:` is workspace-absolute so buildx finds the Dockerfile
-          # outside the slimmer build context.
           context: artifacts
           file: ${{ github.workspace }}/Dockerfile
           push: true
@@ -657,10 +545,6 @@ jobs:
             ghcr.io/developerinlondon/assay:${{ needs.detect.outputs.assay_lua_version }}
             ghcr.io/developerinlondon/assay:latest
 
-  # ─────────────────────────────────────────────────────────────────────
-  # 6. openclaw-extension npm publish. Independent track — only fires
-  #    when openclaw-extension/package.json version changed. Can run in
-  #    parallel with everything else.
   publish-extension:
     needs: detect
     if: needs.detect.outputs.extension_bumped == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,6 +65,21 @@ jobs:
       # instead of pinning their own version (or relying on @stable
       # which silently rolls forward independently).
       rust_version: ${{ steps.rust.outputs.version }}
+      # `binaries_needed` is true when at least one product's GH release
+      # for the current Cargo.toml version is missing. When both GH
+      # releases exist, the per-product `release-*` jobs can fetch the
+      # already-published linux/darwin binaries via `gh release
+      # download` instead of paying ~6 min to cross-compile from
+      # scratch — that's exactly the case for re-runs that only need to
+      # fix a missed downstream artifact (e.g. the docker push that
+      # failed in run 24954145848).
+      binaries_needed: ${{ steps.artifacts-state.outputs.binaries_needed }}
+      # Per-product GH release presence — the prepare step in each
+      # release-* job reads these to choose between `gh release
+      # download` (existing release) and `actions/download-artifact`
+      # (fresh build from the binaries job).
+      assay_engine_release_exists: ${{ steps.artifacts-state.outputs.engine_release_exists }}
+      assay_lua_release_exists: ${{ steps.artifacts-state.outputs.lua_release_exists }}
 
     steps:
       - uses: actions/checkout@v6
@@ -137,6 +152,53 @@ jobs:
             if [ "$b" = "true" ]; then any=true; fi
           done
           echo "any=$any" >> "$GITHUB_OUTPUT"
+
+      # Are the per-product GH releases for the *current* Cargo.toml
+      # versions already published? If yes, the cross-compiled binaries
+      # are attached to those releases and we can fetch them via
+      # `gh release download` later — the `binaries` job becomes
+      # unnecessary and gets skipped (~6 min saved per re-run). The
+      # per-product `*_release_exists` outputs let each release-* job
+      # pick its `prepare assets` source: existing GH release or
+      # fresh build artifact from the `binaries` job.
+      - id: artifacts-state
+        name: Check release artifact state
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ENGINE_TAG: assay-engine-v${{ steps.assay-engine.outputs.version }}
+          LUA_TAG: assay-lua-v${{ steps.assay-lua.outputs.version }}
+        run: |
+          set -uo pipefail
+          # `gh release view <tag>` resolves through the API; no need
+          # to fetch local tags. Treat any non-zero exit (404, transient
+          # API error) as "release missing" — false negatives just
+          # rebuild the binaries, which is the safe direction.
+          if gh release view "$ENGINE_TAG" >/dev/null 2>&1; then
+            echo "GH release $ENGINE_TAG exists — assay-engine binaries will be reused"
+            engine_release=true
+          else
+            echo "GH release $ENGINE_TAG missing — assay-engine binaries will be rebuilt"
+            engine_release=false
+          fi
+          if gh release view "$LUA_TAG" >/dev/null 2>&1; then
+            echo "GH release $LUA_TAG exists — assay-lua binaries will be reused"
+            lua_release=true
+          else
+            echo "GH release $LUA_TAG missing — assay-lua binaries will be rebuilt"
+            lua_release=false
+          fi
+          if [ "$engine_release" = "true" ] && [ "$lua_release" = "true" ]; then
+            binaries_needed=false
+            echo "both GH releases present — skipping binaries job"
+          else
+            binaries_needed=true
+            echo "at least one GH release missing — binaries job will run"
+          fi
+          {
+            echo "engine_release_exists=$engine_release"
+            echo "lua_release_exists=$lua_release"
+            echo "binaries_needed=$binaries_needed"
+          } >> "$GITHUB_OUTPUT"
 
   # ─────────────────────────────────────────────────────────────────────
   # 2. Library crates: publish only, no tags, no GH releases. Strict
@@ -212,14 +274,16 @@ jobs:
   #    product release jobs so we don't pay the cross-compile cost twice.
   binaries:
     needs: [detect, libraries]
-    # Always run after libraries finishes (success OR skipped). The
-    # downstream release jobs are independently idempotent — they can
-    # see what's already on crates.io / ghcr / GitHub releases and skip
-    # only the steps that have nothing left to do. Keeping `binaries`
-    # always-on means a release re-run can fix a missed publish/push
-    # without bumping versions just to clear the gate.
+    # Skip the cross-compile entirely when both products' GH releases
+    # for the current versions already exist — the `release-*` jobs
+    # will fetch the attached binaries via `gh release download`
+    # instead. This keeps re-runs cheap (~2 min total) on top of the
+    # always-idempotent downstream steps. `(success || skipped)` for
+    # libraries is the standard GH Actions pattern to allow a skipped
+    # `if:` upstream to still gate "did anything fail outright?".
     if: |
       always() &&
+      needs.detect.outputs.binaries_needed == 'true' &&
       (needs.libraries.result == 'success' || needs.libraries.result == 'skipped')
     strategy:
       fail-fast: false
@@ -284,7 +348,7 @@ jobs:
     if: |
       always() &&
       (needs.libraries.result == 'success' || needs.libraries.result == 'skipped') &&
-      needs.binaries.result == 'success'
+      (needs.binaries.result == 'success' || needs.binaries.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -310,11 +374,35 @@ jobs:
             cargo publish --allow-dirty -p assay-engine
           fi
 
+      # Source the linux-musl + darwin binaries. Two paths depending on
+      # whether the GH release for this version is already there:
+      #   * release exists → fetch from the release (fast, ~5s, no
+      #     binaries job needed)
+      #   * release missing → use the artifact uploaded by the binaries
+      #     job (which only ran in the missing-release case anyway)
       - uses: actions/download-artifact@v8
+        if: needs.detect.outputs.assay_engine_release_exists != 'true'
         with:
           pattern: binaries-*
           path: artifacts
           merge-multiple: true
+
+      - name: Fetch assay-engine binaries from existing GH release
+        if: needs.detect.outputs.assay_engine_release_exists == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.detect.outputs.assay_engine_version }}
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts
+          cd artifacts
+          # Pattern matches both linux + darwin engine binaries; the
+          # checksum file is regenerated locally below so we don't
+          # bother re-downloading it.
+          gh release download "assay-engine-v${VERSION}" \
+            --pattern 'assay-engine-linux-x86_64' \
+            --pattern 'assay-engine-darwin-aarch64'
+          ls -la
 
       - name: Prepare release assets
         run: |
@@ -431,7 +519,7 @@ jobs:
     if: |
       always() &&
       (needs.libraries.result == 'success' || needs.libraries.result == 'skipped') &&
-      needs.binaries.result == 'success'
+      (needs.binaries.result == 'success' || needs.binaries.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -457,11 +545,29 @@ jobs:
             cargo publish --allow-dirty -p assay-lua
           fi
 
+      # Source the linux-musl + darwin binaries — same dual-source
+      # pattern as release-assay-engine: existing GH release wins,
+      # else fall back to the binaries-job artifact.
       - uses: actions/download-artifact@v8
+        if: needs.detect.outputs.assay_lua_release_exists != 'true'
         with:
           pattern: binaries-*
           path: artifacts
           merge-multiple: true
+
+      - name: Fetch assay-lua binaries from existing GH release
+        if: needs.detect.outputs.assay_lua_release_exists == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.detect.outputs.assay_lua_version }}
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts
+          cd artifacts
+          gh release download "assay-lua-v${VERSION}" \
+            --pattern 'assay-linux-x86_64' \
+            --pattern 'assay-darwin-aarch64'
+          ls -la
 
       - name: Prepare release assets
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,50 +1,25 @@
-# assay container image — published as `ghcr.io/developerinlondon/assay`.
-# Pure Lua runtime; for the engine server image see `Dockerfile.assay-engine`.
+# assay container — published as ghcr.io/developerinlondon/assay.
+# Pure Lua runtime; for the engine server image see Dockerfile.assay-engine.
 #
-# Post-0.13.0 the root-level `src/` and `stdlib/` moved under
-# `crates/assay/`, so `COPY crates/ crates/` alone covers every source
-# file the source-mode build needs.
+# BUILD_MODE=artifact (default) consumes a pre-built linux-musl binary from
+# the build context (file: assay-linux-x86_64). Used by the release pipeline
+# after the binaries job uploads/downloads.
 #
-# Two build modes selected via the `BUILD_MODE` build arg:
+# BUILD_MODE=source cross-compiles inside Docker (~5 min). Useful only when
+# no local Rust toolchain is available:
+#   docker build --build-arg BUILD_MODE=source -t assay .
 #
-#   BUILD_MODE=artifact (default)
-#     Consumes a pre-built linux-musl binary from the build context.
-#     The binary must be present at `assay-linux-x86_64`. Used by the
-#     release pipeline after the `binaries` GH Actions job downloads
-#     the matching cross-compiled artifact.
-#
-#     For local use, produce the binary first:
-#       cargo build --release --target x86_64-unknown-linux-musl \
-#         -p assay-lua --bin assay
-#       cp target/x86_64-unknown-linux-musl/release/assay \
-#         ./assay-linux-x86_64
-#       docker build -t assay .
-#
-#   BUILD_MODE=source
-#     Cross-compiles inside Docker. Slow (~5 min). Useful only when no
-#     local Rust toolchain is available.
-#
-#       docker build --build-arg BUILD_MODE=source -t assay .
-#
-# `RUST_VERSION` defaults to the pin in `.mise.toml` (the single source
-# of truth for the workspace toolchain). The release workflow extracts
-# it from .mise.toml and passes it as a build arg.
+# RUST_VERSION must match .mise.toml.
 
 ARG BUILD_MODE=artifact
 ARG RUST_VERSION=1.95
 
-# ──────────────────────────────────────────────────────────────────────
-# artifact branch — copy pre-built musl binary from build context
-# ──────────────────────────────────────────────────────────────────────
 FROM scratch AS artifact
 COPY assay-linux-x86_64 /assay
 
-# ──────────────────────────────────────────────────────────────────────
-# source branch — full cross-compile (rare, local-dev only)
-# ──────────────────────────────────────────────────────────────────────
 # `perl` is included for symmetry with Dockerfile.assay-engine — assay-lua
-# itself doesn't currently pull openssl-src, but adding a future dep
-# that does shouldn't silently start failing.
+# itself doesn't currently pull openssl-src, but a future dep that does
+# shouldn't silently start failing.
 FROM rust:${RUST_VERSION}-slim AS source-builder
 RUN apt-get update && apt-get install -y \
       musl-tools cmake make g++ protobuf-compiler perl \
@@ -56,40 +31,23 @@ COPY crates/ crates/
 RUN cargo build --release --target x86_64-unknown-linux-musl -p assay-lua --bin assay \
     && cp /app/target/x86_64-unknown-linux-musl/release/assay /assay
 
-# Normalise the source-builder output to a stage exposing /assay,
-# matching the artifact stage's layout.
 FROM source-builder AS source
 
-# ──────────────────────────────────────────────────────────────────────
-# Picker — Docker allows ARG interpolation in `FROM` but not in
-# `COPY --from=…`, so this small stage resolves BUILD_MODE; the runtime
-# stage then does a fixed `COPY --from=picked`.
-# ──────────────────────────────────────────────────────────────────────
+# Docker doesn't expand ARG inside `COPY --from=…`; the picker stage
+# resolves BUILD_MODE in `FROM` (which does support ARG).
 FROM ${BUILD_MODE} AS picked
 
-# ──────────────────────────────────────────────────────────────────────
-# CA certificate bundle — alpine is used only as a vendored cert source.
-# Files COPYed into FROM scratch; alpine itself never ships.
-# ──────────────────────────────────────────────────────────────────────
-#
-# History: commit 5c43c83 (Feb 2026) flipped this to alpine:3.21 to
-# accommodate one downstream Deployment that used `command: ["/bin/sh",
-# "-c", …]` wrappers for env-var setup. That wrapper has since been
-# removed and assay's stdlib covers the sed/awk use cases that once
-# required a shell. `tests/dockerfile.rs` guards against the regression.
-#
-# The CA bundle COPY is load-bearing: any HTTPS call made by assay
-# (reqwest, sqlx TLS, WebSockets) verifies the server cert against
-# roots read from /etc/ssl/certs/ca-certificates.crt. Without this
-# file on scratch, every TLS connection fails immediately.
+# Alpine is only a vendored cert source; alpine itself never ships.
+# A previous flip to alpine:3.21 (commit 5c43c83, Feb 2026) was
+# reverted once the downstream `command: ["/bin/sh", "-c", …]`
+# wrapper was removed; tests/dockerfile.rs guards against the
+# regression.
 FROM alpine:3 AS certs
 RUN apk add --no-cache ca-certificates
 
-# ──────────────────────────────────────────────────────────────────────
-# Runtime — FROM scratch so the published image is just the assay binary
-# plus a CA bundle, nothing else (~12 MB instead of ~25 MB with alpine,
-# and no transitive busybox/apk/musl CVE surface).
-# ──────────────────────────────────────────────────────────────────────
+# /etc/ssl/certs/ca-certificates.crt is load-bearing — every assay
+# HTTPS call (reqwest, sqlx TLS, WebSockets) verifies certs against
+# it. Without this file on FROM scratch every TLS connection fails.
 FROM scratch
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=picked /assay /assay

--- a/Dockerfile.assay-engine
+++ b/Dockerfile.assay-engine
@@ -1,55 +1,24 @@
-# assay-engine container image — published as
-# `ghcr.io/developerinlondon/assay-engine`. Distinct from the assay
-# runtime image because operators who deploy the server need a different
-# set of features, ports, and expectations than devs running one-off
-# scripts.
+# assay-engine container — published as ghcr.io/developerinlondon/assay-engine.
 #
-# Two build modes selected via the `BUILD_MODE` build arg:
+# BUILD_MODE=artifact (default) consumes a pre-built linux-musl binary from
+# the build context (file: assay-engine-linux-x86_64). Used by the release
+# pipeline after the binaries job uploads/downloads.
 #
-#   BUILD_MODE=artifact (default)
-#     Consumes a pre-built linux-musl binary from the build context.
-#     The binary must be present at `assay-engine-linux-x86_64`. Used by
-#     the release pipeline after the `binaries` GH Actions job downloads
-#     the matching cross-compiled artifact. Build context: ~20 MB.
-#     Build time: ~10s.
+# BUILD_MODE=source cross-compiles inside Docker. Slow (~6 min). Useful only
+# when no local Rust toolchain is available:
+#   docker build --build-arg BUILD_MODE=source -f Dockerfile.assay-engine -t assay-engine .
 #
-#     For local use, produce the binary first:
-#       cargo build --release --target x86_64-unknown-linux-musl \
-#         -p assay-engine --bin assay-engine
-#       cp target/x86_64-unknown-linux-musl/release/assay-engine \
-#         ./assay-engine-linux-x86_64
-#       docker build -f Dockerfile.assay-engine -t assay-engine .
-#
-#   BUILD_MODE=source
-#     Cross-compiles inside Docker. Slow (~6 min, plus ~30s for the
-#     vendored OpenSSL static compile that webauthn-rs needs). Useful
-#     only when no local Rust toolchain is available.
-#
-#       docker build --build-arg BUILD_MODE=source \
-#         -f Dockerfile.assay-engine -t assay-engine .
-#
-# `RUST_VERSION` defaults to the version pinned in `.mise.toml` (the
-# single source of truth for the workspace toolchain). The release
-# workflow extracts it from .mise.toml and passes it as a build arg so
-# the Dockerfile default never goes stale; bump both together if you
-# bump rust manually.
+# RUST_VERSION must match .mise.toml (the workspace's source of truth). The
+# release workflow extracts and passes it; bump both together if changed manually.
 
 ARG BUILD_MODE=artifact
 ARG RUST_VERSION=1.95
 
-# ──────────────────────────────────────────────────────────────────────
-# artifact branch — copy pre-built musl binary from build context
-# ──────────────────────────────────────────────────────────────────────
 FROM scratch AS artifact
 COPY assay-engine-linux-x86_64 /assay-engine
 
-# ──────────────────────────────────────────────────────────────────────
-# source branch — full cross-compile (rare, local-dev only)
-# ──────────────────────────────────────────────────────────────────────
-# `perl` (full distribution, not just `perl-base`) is required by
-# `openssl-src`'s ./Configure script — the slim Debian image only ships
-# perl-base which is missing FindBin.pm. Without `perl` here the vendored
-# OpenSSL build fails with "Can't locate FindBin.pm in @INC".
+# `perl` (full distribution) is required by openssl-src's Configure script —
+# the slim Debian image only ships perl-base which is missing FindBin.pm.
 FROM rust:${RUST_VERSION}-slim AS source-builder
 RUN apt-get update && apt-get install -y \
       musl-tools cmake make g++ protobuf-compiler perl \
@@ -61,31 +30,17 @@ COPY crates/ crates/
 RUN cargo build --release --target x86_64-unknown-linux-musl -p assay-engine --bin assay-engine \
     && cp /app/target/x86_64-unknown-linux-musl/release/assay-engine /assay-engine
 
-# Normalise the source-builder output to a stage with the binary at
-# /assay-engine, matching the artifact stage's layout. Both branches
-# now expose `/assay-engine` so the picker below can select either.
 FROM source-builder AS source
 
-# ──────────────────────────────────────────────────────────────────────
-# Picker — Docker allows ARG interpolation inside `FROM` but NOT inside
-# `COPY --from=…`, so we use a small picker stage that resolves the
-# build mode here, then the runtime stage does a fixed
-# `COPY --from=picked` regardless of which branch was selected.
-# ──────────────────────────────────────────────────────────────────────
+# Docker doesn't expand ARG inside `COPY --from=…`, so use a picker
+# stage that resolves BUILD_MODE in `FROM` (which does support ARG).
 FROM ${BUILD_MODE} AS picked
 
-# ──────────────────────────────────────────────────────────────────────
-# CA certificate bundle — alpine is used only as a vendored cert source.
-# Its files end up COPIED into FROM scratch; alpine itself never ships.
-# ──────────────────────────────────────────────────────────────────────
+# Alpine is a vendored cert source — its files are COPYed into FROM
+# scratch; alpine itself never ships in the runtime image.
 FROM alpine:3 AS certs
 RUN apk add --no-cache ca-certificates
 
-# ──────────────────────────────────────────────────────────────────────
-# Runtime — FROM scratch + binary + cert bundle. No shell, no busybox,
-# no apk surface. Default port mirrors EngineConfig.server.bind_addr's
-# 0.0.0.0:8080 default; operators override via config or CLI flag.
-# ──────────────────────────────────────────────────────────────────────
 FROM scratch
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=picked /assay-engine /assay-engine

--- a/crates/assay-auth/src/ctx.rs
+++ b/crates/assay-auth/src/ctx.rs
@@ -140,7 +140,7 @@ impl AuthCtx {
 
     /// Replace the OIDC provider configuration. Engine boot constructs
     /// the appropriate stores (PG / SQLite) after the V4 auth schema
-    /// migration runs; see `crates/assay-engine/src/init.rs`. Phase 7
+    /// migration runs; see `crates/assay-engine/src/init.rs`.
     /// only wires the builder + the migrations + the placeholder
     /// router; phase 8 weaves the resolved AuthCtx into the actual
     /// `/authorize` and `/token` HTTP handlers.

--- a/crates/assay-auth/src/oidc_provider/mod.rs
+++ b/crates/assay-auth/src/oidc_provider/mod.rs
@@ -142,24 +142,9 @@ impl OidcProviderConfig {
     }
 }
 
-/// OIDC spec router — only the OAuth2/OIDC well-known surface that
-/// the wider ecosystem expects under stable paths. Mounted at `/auth`
-/// by the engine binary.
-///
-/// Routes:
-///
-/// - `GET /.well-known/openid-configuration`
-/// - `GET /.well-known/jwks.json`
-/// - `GET /authorize` — full handler (login redirect / consent / code mint).
-/// - `POST /token` — full handler (auth code + refresh grant dispatch).
-/// - `GET /userinfo` — bearer parse + JWT verify + scope-filtered claims.
-/// - `POST /revoke` — RFC 7009 (refresh token marked revoked).
-/// - `POST /introspect` — RFC 7662 (active/inactive response).
-/// - `GET /logout` — session revoke + post_logout_redirect.
-/// - `GET /authorize/consent` — render consent preview page.
-/// - `POST /authorize/consent` — record consent + resume the flow.
-/// - `GET /oidc/upstream/{slug}/start` — federation start.
-/// - `GET /oidc/upstream/{slug}/callback` — federation completion.
+/// OIDC spec router — the OAuth2/OIDC well-known surface, mounted at
+/// `/auth` by the engine binary. See route declarations below for the
+/// authoritative path/handler list.
 pub fn spec_router<S>() -> Router<S>
 where
     S: Clone + Send + Sync + 'static,

--- a/crates/assay-auth/src/oidc_provider/mod.rs
+++ b/crates/assay-auth/src/oidc_provider/mod.rs
@@ -174,22 +174,10 @@ where
 }
 
 /// OIDC admin router — operator-only CRUD for OIDC clients and
-/// upstream federation providers. Mounted under
-/// `/api/v1/engine/auth/` by the engine binary so the merged paths
-/// land at `/api/v1/engine/auth/admin/oidc/...`.
-///
-/// Routes (admin-key gated by handlers):
-///
-/// - `GET    /admin/oidc/clients`
-/// - `POST   /admin/oidc/clients`
-/// - `GET    /admin/oidc/clients/{id}`
-/// - `PUT    /admin/oidc/clients/{id}`
-/// - `DELETE /admin/oidc/clients/{id}`
-/// - `POST   /admin/oidc/clients/{id}/rotate-secret`
-/// - `GET    /admin/oidc/upstream`
-/// - `POST   /admin/oidc/upstream`
-/// - `GET    /admin/oidc/upstream/{slug}`
-/// - `DELETE /admin/oidc/upstream/{slug}`
+/// upstream federation providers, mounted under `/api/v1/engine/auth/`
+/// (so paths land at `/api/v1/engine/auth/admin/oidc/...`). Each
+/// handler enforces admin-key auth itself; see route declarations
+/// below for the canonical surface.
 pub fn admin_router<S>() -> Router<S>
 where
     S: Clone + Send + Sync + 'static,

--- a/crates/assay-auth/src/passkey.rs
+++ b/crates/assay-auth/src/passkey.rs
@@ -1,7 +1,7 @@
 //! WebAuthn / passkey registration + authentication.
 //!
 //! Plan 12c task 5.2 reference. Wraps [`webauthn_rs`] 0.5 so HTTP
-//! handlers (phase 8) can drive register / authenticate without
+//! handlers can drive register / authenticate without
 //! touching the library's verbose builder surface.
 //!
 //! In-progress state ([`PasskeyRegistration`], [`PasskeyAuthentication`])

--- a/crates/assay-auth/src/schema.rs
+++ b/crates/assay-auth/src/schema.rs
@@ -42,13 +42,13 @@ pub const MODULE_NAME: &str = "auth";
 /// a new DDL pack is appended below. The runner records every version
 /// up to and including this one into `engine.migrations`.
 ///
-/// V1 (phase 4): users / sessions / passkeys / user_upstream / jwks_keys.
-/// V2 (phase 5): adds `auth.biscuit_root_keys` for the always-on
+/// V1: users / sessions / passkeys / user_upstream / jwks_keys.
+/// V2: adds `auth.biscuit_root_keys` for the always-on
 ///               biscuit capability-token root key bootstrap.
-/// V3 (phase 6): adds `auth.zanzibar_namespaces` + `auth.zanzibar_tuples`
+/// V3: adds `auth.zanzibar_namespaces` + `auth.zanzibar_tuples`
 ///               for ReBAC. Recursive-CTE walk + reverse index for
 ///               Keto/SpiceDB-equivalent permission checks.
-/// V4 (phase 7): adds the OIDC provider tables — `auth.oidc_clients`,
+/// V4: adds the OIDC provider tables — `auth.oidc_clients`,
 ///               `auth.upstream_providers`, `auth.oidc_authorization_codes`,
 ///               `auth.oidc_refresh_tokens`, `auth.oidc_sessions`,
 ///               `auth.oidc_consents`, and `auth.oidc_upstream_states`.

--- a/crates/assay-auth/src/session.rs
+++ b/crates/assay-auth/src/session.rs
@@ -214,7 +214,7 @@ fn random_token() -> String {
 }
 
 // =====================================================================
-//   HTTP router — phase 8
+//   HTTP router —
 // =====================================================================
 //
 // Endpoints:
@@ -424,7 +424,7 @@ async fn passkey_register_finish(
 struct PasskeyAuthStartBody {
     user_id: String,
     /// Optional pre-decoded passkeys (for tests + advanced clients).
-    /// In production we'd load these out of `auth.passkeys`; phase 8
+    /// In production we'd load these out of `auth.passkeys`;
     /// has no `passkey_json` column so we accept them as a body field.
     #[serde(default)]
     passkeys: Vec<serde_json::Value>,

--- a/crates/assay-auth/src/session.rs
+++ b/crates/assay-auth/src/session.rs
@@ -213,18 +213,7 @@ fn random_token() -> String {
     data_encoding::BASE64URL_NOPAD.encode(&buf)
 }
 
-// =====================================================================
-//   HTTP router —
-// =====================================================================
-//
-// Endpoints:
-// - POST  /login        password login: email + password → session cookie
-// - DELETE /session     logout: revoke current session, clear cookie
-// - GET   /whoami       current user's id + email
-// - POST  /passkey/register/start   passkey ceremony — returns challenge
-// - POST  /passkey/register/finish  finish — persists the cred via UserStore
-// - POST  /passkey/auth/start
-// - POST  /passkey/auth/finish
+// HTTP router — see `router()` below for the canonical route list.
 
 use axum::extract::{FromRef, State};
 use axum::http::{HeaderMap, StatusCode, header};

--- a/crates/assay-auth/src/zanzibar/postgres.rs
+++ b/crates/assay-auth/src/zanzibar/postgres.rs
@@ -9,7 +9,7 @@
 //! uses an in-CTE `path` array — if the next subject is already on
 //! the path, the join skips it.
 //!
-//! Performance notes (PG18 EXPLAIN-checked once during phase 6
+//! Performance notes (PG18 EXPLAIN-checked once during
 //! development against a 100k-tuple seed):
 //!
 //! - Forward walk hits the composite PK `(object_type, object_id,
@@ -286,7 +286,7 @@ impl ZanzibarStore for PostgresZanzibarStore {
         // candidate relation set, then post-filter via `check`.
         // Optimal for small fan-outs (the family/circle scale jeebon
         // ships at); a real production deployment will want a
-        // dedicated reverse index (phase 9).
+        // dedicated reverse index.
         let Some(schema) = self.get_namespace(resource_type).await? else {
             return Ok(Vec::new());
         };

--- a/crates/assay-auth/src/zanzibar/types.rs
+++ b/crates/assay-auth/src/zanzibar/types.rs
@@ -181,9 +181,9 @@ impl Tuple {
 ///
 /// In v0.2.0 zookies are opaque transaction-id strings; the Postgres
 /// backend serialises `pg_current_wal_lsn()` and the SQLite backend
-/// uses a monotonic counter. The check implementation in phase 6 is
+/// uses a monotonic counter. The current check implementation is
 /// `Consistency::Minimum` only (the other modes pass through to the
-/// same code path) — full snapshot enforcement lands in phase 9.
+/// same code path); full snapshot enforcement is future work.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[derive(Default)]
 pub enum Consistency {

--- a/crates/assay-auth/tests/oidc_provider.rs
+++ b/crates/assay-auth/tests/oidc_provider.rs
@@ -1,4 +1,4 @@
-//! Integration tests for the OIDC provider (phase 7).
+//! Integration tests for the OIDC provider.
 //!
 //! Backend coverage mirrors the zanzibar test pattern:
 //!

--- a/crates/assay-auth/tests/zanzibar.rs
+++ b/crates/assay-auth/tests/zanzibar.rs
@@ -1,4 +1,4 @@
-//! Integration tests for the Zanzibar layer (phase 6).
+//! Integration tests for the Zanzibar layer.
 //!
 //! Backend coverage:
 //!

--- a/crates/assay-dashboard/Cargo.toml
+++ b/crates/assay-dashboard/Cargo.toml
@@ -9,7 +9,6 @@ repository = "https://github.com/developerinlondon/assay"
 description = "Dashboard (HTML + JS + CSS) for assay-workflow and assay-engine. Feature-gated per view set."
 
 [features]
-# Plan-15 slice 3: workflow + auth are mandatory. The engine ships
 # both consoles and gates them at runtime via `engine.modules`, not
 # at compile time. The features here are kept empty for now in case
 # a slim downstream dashboard build wants to opt out one console.

--- a/crates/assay-dashboard/assets/workflow/app.js
+++ b/crates/assay-dashboard/assets/workflow/app.js
@@ -15,7 +15,6 @@
   let currentView = 'workflows';
   let eventSource = null;
 
-  // Plan-15 slice 3 gates the workflow API on the engine layer; every
   // /api/v1/engine/workflow/* call now needs an admin Bearer token.
   // Re-use the same `assay-admin-token` localStorage key the auth +
   // engine consoles set so the operator only types it once across all

--- a/crates/assay-dashboard/assets/workflow/components/detail.js
+++ b/crates/assay-dashboard/assets/workflow/components/detail.js
@@ -151,19 +151,10 @@ var AssayDetail = (function () {
       '</div>' +
       '<div class="detail-body">';
 
-    // Every identity/config field shown in the detail block is also
-    // surfaced on the row above (id, type, status, queue, created) or
-    // in the namespace selector. The only field the row can't carry is
-    // `completed_at` — workflow list rows show "Created X ago" but not
-    // a completion timestamp. Put that on a slim meta row above the
-    // tabs so terminal runs get their one missing piece; no meta row
-    // at all for in-flight runs (nothing new to say).
-    //
-    // The action buttons (Signal / Cancel / Terminate / Continue-as-
-    // new) used to live on a toolbar here too; v0.12.0 dropped them
-    // because they duplicate the row's Action column. The row now
-    // shows them as icons with tooltips, so the detail view stays
-    // identity-only and the tabs get all the vertical space.
+    // The list row already carries id/type/status/queue/created;
+    // `completed_at` is the only field it can't fit, so terminal runs
+    // get a slim meta row above the tabs. In-flight runs render no
+    // meta row (nothing new to say).
     if (wf.completed_at) {
       html += '<div class="detail-meta-line">' +
         '<span class="detail-meta-label">Completed</span> ' +

--- a/crates/assay-dashboard/src/auth_router.rs
+++ b/crates/assay-dashboard/src/auth_router.rs
@@ -21,20 +21,12 @@ use crate::assets::{
     AUTH_USERS_JS, AUTH_ZANZIBAR_JS, FAVICON_SVG,
 };
 
-/// Build the auth-console asset router. Stateless — returns
-/// `Router<()>` ready to merge into the engine's composed router.
+/// Build the auth-console asset router. Stateless `Router<()>` ready
+/// to merge into the engine's composed router.
 ///
-/// Routes:
-///
-/// - `GET /auth/console`              → SPA shell HTML
-/// - `GET /auth/console/`             → SPA shell HTML (with-trailing-slash variant)
-/// - `GET /auth/style.css`            → auth-only CSS overrides
-/// - `GET /auth/app.js`               → SPA controller
-/// - `GET /auth/components/*.js`      → per-pane modules
-///
-/// All assets are served with `Cache-Control: no-cache` so a redeploy
-/// invalidates client cache without manual cache-busting (matches the
-/// workflow dashboard's policy — see `router::NO_CACHE`).
+/// All assets serve with `Cache-Control: no-cache` so a redeploy
+/// invalidates client cache without manual busting (matches the
+/// workflow dashboard's `router::NO_CACHE`).
 pub fn router() -> Router<()> {
     Router::new()
         .route("/auth/console", get(index))

--- a/crates/assay-dashboard/src/engine_router.rs
+++ b/crates/assay-dashboard/src/engine_router.rs
@@ -21,24 +21,11 @@ use crate::assets::{
     ENGINE_MODULES_JS, ENGINE_STYLE_CSS, FAVICON_SVG,
 };
 
-/// Build the engine-console asset router. Stateless — returns
-/// `Router<()>` ready to merge into the engine's composed router.
+/// Build the engine-console asset router. Stateless `Router<()>` ready
+/// to merge into the engine's composed router.
 ///
-/// Routes:
-///
-/// - `GET /engine/console`              → SPA shell HTML
-/// - `GET /engine/console/`             → SPA shell HTML (trailing-slash variant)
-/// - `GET /engine/console/{path}`       → SPA shell HTML (deep-link variant)
-/// - `GET /engine/style.css`            → engine-only CSS overrides
-/// - `GET /engine/app.js`               → SPA controller
-/// - `GET /engine/components/*.js`      → per-pane modules
-/// - `GET /engine/favicon.svg`          → favicon
-/// - `GET /shared/cross-nav.css`        → shared cross-console nav strip CSS
-/// - `GET /shared/cross-nav.js`         → shared cross-console nav strip controller
-///
-/// Cross-nav assets live at `/shared/*` and ship from the engine
-/// router (the workflow + auth shells just `<link>` them in). Mounting
-/// once here keeps the path canonical.
+/// `/shared/*` cross-nav assets ship from this router (the workflow +
+/// auth shells just `<link>` them in) so the path stays canonical.
 pub fn router() -> Router<()> {
     Router::new()
         .route("/engine/console", get(index))

--- a/crates/assay-dashboard/src/lib.rs
+++ b/crates/assay-dashboard/src/lib.rs
@@ -1,6 +1,6 @@
 //! Dashboard — typed asset bundle + axum router composition.
 //!
-//! Three consoles are always compiled in (plan-15 slice 3): workflow,
+//! Three consoles are always compiled in: workflow,
 //! auth, and engine-core. The engine binary mounts them all; runtime
 //! visibility per console is gated by `engine.modules` rows.
 

--- a/crates/assay-domain/src/engine/pg.rs
+++ b/crates/assay-domain/src/engine/pg.rs
@@ -2,7 +2,7 @@
 //!
 //! Creates the `engine` schema and the four engine-scope tables on
 //! first boot, idempotently. PG18 is the minimum supported version
-//! (see plan 12 Principle 7); we lean on `uuidv7()` for primary keys
+//!; we lean on `uuidv7()` for primary keys
 //! that need temporal ordering.
 
 use anyhow::{Context, Result};

--- a/crates/assay-domain/src/store/workflow.rs
+++ b/crates/assay-domain/src/store/workflow.rs
@@ -99,7 +99,7 @@ pub trait WorkflowStore: Send + Sync + 'static {
         worker_id: &str,
     ) -> impl Future<Output = anyhow::Result<bool>> + Send;
 
-    // ── Workflow-task dispatch (Phase 9) ────────────────────
+    // ── Workflow-task dispatch ────────────────────
 
     /// Mark a workflow as having new events that need a worker to replay it.
     /// Idempotent — calling repeatedly is fine. Cleared by `claim_workflow_task`.

--- a/crates/assay-engine/Cargo.toml
+++ b/crates/assay-engine/Cargo.toml
@@ -18,7 +18,6 @@ name = "assay_engine"
 path = "src/lib.rs"
 
 [features]
-# Plan-15 slice 3: auth is mandatory. The engine doesn't run without
 # it, so the auth code is always linked. The fine-grained auth-* flags
 # stay so downstream slim builds can opt out of individual flavours
 # (e.g. drop passkey or OIDC-provider without touching the engine).

--- a/crates/assay-engine/examples/seed-sample/seed.lua
+++ b/crates/assay-engine/examples/seed-sample/seed.lua
@@ -178,18 +178,10 @@ else
   })
   row("oidc_upstream", "example", "upserted")
 
-  -- ── Zanzibar namespaces (family + circle demo) ───────────────────────
-  --
-  -- The auth-console Zanzibar pane lists registered namespace SCHEMAS
-  -- (auth.zanzibar_namespaces), separate from the (auth.zanzibar_tuples)
-  -- below. Without these `define_namespace` calls the pane is empty
-  -- even though tuples exist — the dashboard groups by schema, not by
-  -- the implicit set of object_types found in tuples.
-  --
-  -- Schema shape: NamespaceSchema { name, definitions: { <name> = RelationDef } }
-  -- RelationDef.kind is serde-tagged: { kind = "direct", value = [TypeRef] }
-  -- TypeRef = { object_type, relation = nil, wildcard = false } — for now
-  -- both demo namespaces accept direct `user` subjects only.
+  -- ── Zanzibar namespaces (family + circle demo) ──────────────────────
+  -- The auth-console Zanzibar pane lists `define_namespace` schemas,
+  -- not tuples — so a pane is empty unless namespaces are defined,
+  -- regardless of whether tuples reference them.
   local function direct_user()
     return {
       kind = "direct",

--- a/crates/assay-engine/src/config.rs
+++ b/crates/assay-engine/src/config.rs
@@ -65,7 +65,7 @@ fn default_public_url() -> String {
 pub enum BackendConfig {
     Postgres {
         /// Postgres connection URL, e.g. `postgres://user:pass@host:5432/db`.
-        /// PostgreSQL 18 is the minimum supported version (see plan 12 Principle 7).
+        /// PostgreSQL 18 is the minimum supported version.
         url: String,
     },
     Sqlite {

--- a/crates/assay-engine/src/engine_api.rs
+++ b/crates/assay-engine/src/engine_api.rs
@@ -412,17 +412,11 @@ async fn get_config<S: WorkflowStore + Clone + 'static>(
     (StatusCode::OK, Json(value)).into_response()
 }
 
-/// Walk the serialised config and replace any value whose key looks
-/// like a secret with the literal string `[REDACTED]`. Targets:
-///
-/// - `admin_api_keys`             (array of strings)
-/// - any field whose key contains `password`, `secret`, `token`, `key`
-///   (case-insensitive) other than the structural `kid` / `keys`
-///
-/// Defensive: the engine console renders this for operators, so an
-/// over-redaction (e.g. `rp_id` containing the substring "id" — no it
-/// doesn't, but the pattern is conservative) is preferable to leaking
-/// a credential into a screenshot.
+/// Replace secrets in the serialised config with `[REDACTED]`. Targets
+/// `admin_api_keys` and any key containing `password`, `secret`,
+/// `token`, or `key` (case-insensitive), excluding the structural
+/// `kid` / `keys`. Conservative on purpose — the engine console
+/// renders this for operators; over-redaction beats credential leaks.
 fn redact_secrets(v: &mut Value) {
     let placeholder = Value::String("[REDACTED]".to_string());
     match v {

--- a/crates/assay-engine/src/engine_api.rs
+++ b/crates/assay-engine/src/engine_api.rs
@@ -481,7 +481,7 @@ fn redact_secrets(v: &mut Value) {
 
 /// Engine-core admin gate.
 ///
-/// Auth is mandatory (plan-15 slice 3) so the engine always has an
+/// Auth is mandatory so the engine always has an
 /// [`AuthCtx`]. Dispatch to [`assay_auth::gate::require_role_for`]
 /// for `engine#core#admin`. Admin api-key callers bypass as
 /// break-glass; session/JWT callers go through Zanzibar.

--- a/crates/assay-engine/src/init.rs
+++ b/crates/assay-engine/src/init.rs
@@ -58,7 +58,6 @@ pub fn builtin_modules() -> Vec<BuiltinModule> {
             version: env!("CARGO_PKG_VERSION"),
             default_enabled: true,
         },
-        // Plan-15 slice 3: auth is mandatory and default-enabled. The
         // engine itself authenticates every admin + workflow request via
         // the auth module; running with auth disabled isn't supported.
         BuiltinModule {
@@ -180,8 +179,7 @@ async fn pg_boot(url: &str, auto_enable: &[String]) -> anyhow::Result<PgBoot> {
         record_engine_migration_pg(&pool, name, 1).await?;
     }
 
-    // Auth schema migration — always runs (auth is mandatory per plan-15
-    // slice 3). Loads the biscuit root key (or initialises one on first
+    // Auth schema migration — always runs (auth is mandatory per
     // boot) and smoke-touches the OIDC provider tables so missing DDL or
     // permission issues surface here rather than at first request.
     if modules.iter().any(|m| m == "auth") {
@@ -370,8 +368,7 @@ async fn sqlite_boot(data_dir: &str, auto_enable: &[String]) -> anyhow::Result<S
         record_engine_migration_sqlite(&pool, name, 1).await?;
     }
 
-    // Auth schema migration — always runs (auth is mandatory per plan-15
-    // slice 3). The ATTACH already happened on connect.
+    // Auth schema migration — always runs (auth is mandatory per
     if modules.iter().any(|m| m == "auth") {
         assay_auth::schema::migrate_sqlite(&pool)
             .await

--- a/crates/assay-engine/src/lib.rs
+++ b/crates/assay-engine/src/lib.rs
@@ -318,12 +318,11 @@ async fn run_with_store<S: WorkflowStore + Clone + 'static>(
     instance_id: uuid::Uuid,
     auth_ctx: Option<assay_auth::AuthCtx>,
 ) -> anyhow::Result<()> {
-    // Plan-15 slice 3: refuse to start if there's no admin path. Engine
-    // requires either at least one operator user (created via
-    // `bootstrap-admin`) OR at least one `admin_api_keys` entry as a
-    // break-glass. Without either, every admin request would 401 and
-    // the operator would be locked out — fail fast with a helpful
-    // message instead.
+    // The engine refuses to start unless there's at least one operator
+    // user (created via `bootstrap-admin`) or at least one entry in
+    // `admin_api_keys` as a break-glass. Without either, every admin
+    // request would 401 and the operator would be locked out — fail
+    // fast with a helpful message instead.
     if let Some(auth) = auth_ctx.as_ref() {
         let user_count = auth
             .users

--- a/crates/assay-engine/src/server.rs
+++ b/crates/assay-engine/src/server.rs
@@ -1,20 +1,11 @@
-//! HTTP server wiring.
+//! HTTP server wiring — composes the workflow API + dashboard + auth
+//! routers into one axum `Router`. URL surface:
 //!
-//! Builds an axum `Router` that composes the workflow API + dashboard
-//! under one port. Plan-15 lays out the locked URL surface:
-//!
-//! - `/auth/*`                         → OIDC spec endpoints (well-known,
-//!   authorize, token, userinfo, revoke, introspect, logout, federation)
-//! - `/api/v1/engine/core/*`           → engine-core admin
-//! - `/api/v1/engine/workflow/*`       → workflow API
-//! - `/api/v1/engine/auth/*`           → engine-internal auth (login,
-//!   logout, whoami, passkey, admin)
-//! - `/healthz`                        → 1-line redirect to
-//!   `/api/v1/engine/core/health` for k8s probes
-//!
-//! The auth router is split into two routers (spec + engine-internal)
-//! and mounted at distinct paths; the workflow API now nests under
-//! `/api/v1/engine/workflow/`.
+//! - `/auth/*`                   OIDC spec (discovery, authorize, token, …)
+//! - `/api/v1/engine/core/*`     engine-core admin
+//! - `/api/v1/engine/workflow/*` workflow API (auth-gated below)
+//! - `/api/v1/engine/auth/*`     engine-internal auth + admin
+//! - `/healthz`                  redirect to `/api/v1/engine/core/health`
 
 use axum::Router;
 use axum::response::Redirect;

--- a/crates/assay-engine/src/server.rs
+++ b/crates/assay-engine/src/server.rs
@@ -123,23 +123,11 @@ pub fn build_app<S: WorkflowStore + Clone + 'static>(state: EngineState<S>) -> R
     app
 }
 
-/// Engine-side gate middleware for the workflow API.
-///
-/// Per plan-15 slice 2 the engine is the auth boundary for every
-/// module — the workflow no longer carries its own auth middleware.
-/// This wrapper:
-///
-/// 1. Lets the always-public paths through unconditionally
-///    ([`WORKFLOW_PUBLIC_PATHS`] — health, version, openapi, docs).
-/// 2. Reads `?namespace=<X>` from the query string (defaults to
-///    `main` to match the workflow store's default namespace).
-/// 3. Calls [`assay_auth::gate::require_role_for`] for
-///    `workflow:<namespace>#access`. Admin api-key callers bypass as
-///    break-glass; session/JWT callers go through Zanzibar.
-///
-/// On gate failure the request short-circuits with the gate's response
-/// (401 Unauthorized or 403 Forbidden); on success the request flows
-/// to the workflow handler with the caller already authorised.
+/// Workflow-API auth gate. The engine is the auth boundary for every
+/// module — the workflow router carries no gate of its own.
+/// [`WORKFLOW_PUBLIC_PATHS`] bypass; everything else goes through
+/// [`assay_auth::gate::require_role_for`] keyed on the
+/// `?namespace=<X>` query param (default `main`).
 async fn workflow_gate_middleware<S: WorkflowStore + Clone + 'static>(
     axum::extract::State(state): axum::extract::State<EngineState<S>>,
     request: axum::extract::Request,

--- a/crates/assay-engine/tests/engine_smoke.rs
+++ b/crates/assay-engine/tests/engine_smoke.rs
@@ -135,7 +135,7 @@ async fn engine_smoke_sqlite() {
     );
 
     // ── /api/v1/engine/workflow/namespaces ────────────────────────────────────────────
-    // Gated by the engine's auth layer (slice 2) — admin api-key
+    // Gated by the engine's auth layer — admin api-key
     // break-glass authenticates the request.
     let r = client
         .get(engine.url("/api/v1/engine/workflow/namespaces"))

--- a/crates/assay-workflow/src/activities.rs
+++ b/crates/assay-workflow/src/activities.rs
@@ -179,7 +179,6 @@ impl<S: WorkflowStore> WorkflowCtx<S> {
                 timestamp: timestamp_now(),
             })
             .await?;
-        // Phase 9: the workflow has a new event the handler needs to see —
         // wake the workflow task back up.
         self.mark_and_emit_needs_dispatch(&workflow_id).await?;
         Ok(())

--- a/crates/assay-workflow/src/api/mod.rs
+++ b/crates/assay-workflow/src/api/mod.rs
@@ -17,24 +17,11 @@ use axum::Router;
 use crate::ctx::WorkflowCtx;
 use crate::store::WorkflowStore;
 
-/// Build the workflow HTTP API router.
-///
-/// Three tiers, all under `/api/v1/engine/workflow/*`:
-///
-/// 1. **Authenticated** — workflows, schedules, namespaces, activities,
-///    tasks, workers, queues, events. Authentication + authorization
-///    happens at the engine layer (via [`assay_auth::gate`] in
-///    `assay_engine::server`); the workflow router itself carries no
-///    gate. (The `workflow.api_keys` surface was retired in
-///    slice 3 — auth tokens come from the auth module now.)
-/// 2. **Public** — health, version. Always unauthenticated so
-///    Kubernetes probes, load balancers, and third-party monitors can
-///    reach them without a bearer token.
-/// 3. **OpenAPI** — `openapi.json` + `docs` HTML. Always public.
-///
-/// The standalone `serve*` entry points were removed in
-/// slice 2 — workflow now only runs inside `assay-engine`, which owns
-/// the listener, the auth gate, and the surrounding state.
+/// Build the workflow HTTP API router. Auth is enforced at the engine
+/// layer (via [`assay_auth::gate`] in `assay_engine::server`); this
+/// router carries no gate of its own. `health`, `version`, `openapi.json`,
+/// and `docs` are always public so probes can reach them without a
+/// bearer token.
 pub fn router<S: WorkflowStore>(state: Arc<WorkflowCtx<S>>) -> Router {
     let authed_api = Router::new()
         .nest("/api/v1/engine/workflow", api_v1_router::<S>())

--- a/crates/assay-workflow/src/api/mod.rs
+++ b/crates/assay-workflow/src/api/mod.rs
@@ -25,14 +25,14 @@ use crate::store::WorkflowStore;
 ///    tasks, workers, queues, events. Authentication + authorization
 ///    happens at the engine layer (via [`assay_auth::gate`] in
 ///    `assay_engine::server`); the workflow router itself carries no
-///    gate. (The `workflow.api_keys` surface was retired in plan-15
+///    gate. (The `workflow.api_keys` surface was retired in
 ///    slice 3 — auth tokens come from the auth module now.)
 /// 2. **Public** — health, version. Always unauthenticated so
 ///    Kubernetes probes, load balancers, and third-party monitors can
 ///    reach them without a bearer token.
 /// 3. **OpenAPI** — `openapi.json` + `docs` HTML. Always public.
 ///
-/// The standalone `serve*` entry points were removed in plan-15
+/// The standalone `serve*` entry points were removed in
 /// slice 2 — workflow now only runs inside `assay-engine`, which owns
 /// the listener, the auth gate, and the surrounding state.
 pub fn router<S: WorkflowStore>(state: Arc<WorkflowCtx<S>>) -> Router {

--- a/crates/assay-workflow/src/api/workflow_tasks.rs
+++ b/crates/assay-workflow/src/api/workflow_tasks.rs
@@ -1,4 +1,4 @@
-//! Workflow-task dispatch endpoints (Phase 9).
+//! Workflow-task dispatch endpoints.
 //!
 //! A "workflow task" represents "this workflow has new events that need a
 //! worker to run the workflow handler against." It's distinct from an

--- a/crates/assay-workflow/src/ctx.rs
+++ b/crates/assay-workflow/src/ctx.rs
@@ -112,7 +112,7 @@ impl<S: WorkflowStore> WorkflowCtx<S> {
     }
 
     /// Mark a workflow dispatchable AND emit a `WorkflowNeedsDispatch`
-    /// on the bus so the dispatch-wakeup loop (phase 6) wakes workers
+    /// on the bus so the dispatch-wakeup loop wakes workers
     /// on this node / across the cluster. The extra SELECT is skipped
     /// when no bus is wired.
     pub(crate) async fn mark_and_emit_needs_dispatch(

--- a/crates/assay-workflow/src/lifecycle.rs
+++ b/crates/assay-workflow/src/lifecycle.rs
@@ -66,7 +66,6 @@ impl<S: WorkflowStore> WorkflowCtx<S> {
             })
             .await?;
 
-        // Phase 9: a freshly-started workflow has new events (WorkflowStarted)
         // that need a worker to replay against — make it dispatchable and
         // emit WorkflowNeedsDispatch for the dispatch-wakeup loop.
         self.mark_and_emit_needs_dispatch(workflow_id).await?;

--- a/crates/assay-workflow/src/scheduler.rs
+++ b/crates/assay-workflow/src/scheduler.rs
@@ -137,7 +137,6 @@ async fn evaluate_namespace_schedules<S: WorkflowStore>(store: &S, namespace: &s
             })
             .await?;
 
-        // Phase 9: scheduled workflows must enter the dispatch pool so a
         // worker can pick them up. Without this they'd sit PENDING forever.
         store.mark_workflow_dispatchable(&workflow_id).await?;
 

--- a/crates/assay-workflow/src/signals.rs
+++ b/crates/assay-workflow/src/signals.rs
@@ -48,7 +48,6 @@ impl<S: WorkflowStore> WorkflowCtx<S> {
             })
             .await?;
 
-        // Phase 9: a workflow waiting on this signal needs to be re-dispatched
         // so the worker can replay and notice the signal in history. The
         // helper also emits WorkflowNeedsDispatch on the engine event bus.
         self.mark_and_emit_needs_dispatch(workflow_id).await?;

--- a/crates/assay-workflow/src/store/postgres.rs
+++ b/crates/assay-workflow/src/store/postgres.rs
@@ -160,26 +160,16 @@ CREATE INDEX IF NOT EXISTS idx_engine_events_ts_prune ON engine.events(ts);
 
 "#;
 
-/// Idempotent v0.13.1 → v0.13.2 table-relocation migration.
+/// One-shot relocation: moves v0.13.1's prefixed `public.workflow_*`
+/// tables into the `workflow` schema. Idempotent — each step gates on
+/// `to_regclass(public.<old>) IS NOT NULL` so fresh installs and
+/// already-migrated DBs are no-ops.
 ///
-/// On a database upgraded from v0.13.1, the v0.13.1 tables still live
-/// in `public` under their prefixed names. This block moves each of them
-/// into the right schema and drops the now-redundant prefix in one go.
-/// Each step is gated on `to_regclass(public.<old>) IS NOT NULL` so the
-/// block is a no-op on fresh installs (where the new tables already
-/// exist via `SCHEMA` above) and on databases that have already been
-/// migrated.
-///
-/// The CREATE SCHEMA + the schema-qualified DDL in `SCHEMA` runs
-/// *before* this block, so when an old v0.13.1 install boots into
-/// v0.13.2 we end up with both `public.workflows` (the old one with
-/// data) and `workflow.workflows` (the new empty one). To preserve the
-/// data, we DROP the freshly-created empty schema-qualified tables
-/// before the move so ALTER TABLE … SET SCHEMA + RENAME has somewhere
-/// to land. The DROP uses CASCADE to take the indexes/constraints with
-/// it; ALTER TABLE will recreate them. RESTRICT would fail on the
-/// foreign-key references between workflow.events / .activities / .timers
-/// / .signals / .snapshots and workflow.workflows.
+/// SCHEMA above already created empty `workflow.*` tables; we DROP
+/// them with CASCADE here before ALTER TABLE … SET SCHEMA so the move
+/// has somewhere to land. RESTRICT would fail on the FKs between
+/// workflow.events / .activities / .timers / .signals / .snapshots
+/// and workflow.workflows.
 const V0_13_2_RELOCATION_SQL: &str = r#"
 DO $$
 DECLARE

--- a/crates/assay-workflow/src/store/sqlite.rs
+++ b/crates/assay-workflow/src/store/sqlite.rs
@@ -381,18 +381,11 @@ impl SqliteStore {
         });
     }
 
-    /// Apply the baseline schema.
-    ///
-    /// Fresh installs get the current `CREATE TABLE IF NOT EXISTS` statements
-    /// in one pass. The engine is pre-1.0 and no v0.11.x release has been
-    /// deployed against a real workload yet, so we don't carry
-    /// `ALTER TABLE ADD COLUMN` statements for historical columns — the
-    /// baseline is the source of truth.
-    ///
-    /// For **future** additive migrations (post-v0.11.3), call
-    /// `Self::add_column_if_missing(&self.pool, "<table>", "<column>",
-    /// "<type_def>").await?` here before returning. Kept around so adding a
-    /// column later is a one-liner.
+    /// Apply the baseline schema. SCHEMA's `CREATE TABLE IF NOT EXISTS`
+    /// statements are the source of truth — pre-1.0 we don't carry
+    /// `ALTER TABLE ADD COLUMN` history. For additive migrations later,
+    /// chain a `Self::add_column_if_missing(&self.pool, "<table>",
+    /// "<column>", "<type_def>")` call here before returning.
     async fn migrate(&self) -> Result<()> {
         for statement in SCHEMA.split(';') {
             let trimmed = statement.trim();

--- a/crates/assay-workflow/tests-e2e/fixtures/demo-worker.lua
+++ b/crates/assay-workflow/tests-e2e/fixtures/demo-worker.lua
@@ -3,7 +3,6 @@
 -- shape so the dashboard can render circles + connectors + log tail and
 -- the suite can verify each state transition end-to-end.
 
--- Plan-15 slice 4 reorganized the Lua client into the
 -- assay.engine.{core,auth,workflow} trio; the old top-level
 -- assay.workflow module is gone. The worker reads the engine URL +
 -- admin Bearer key from env so the e2e harness (run.lua) can drive

--- a/crates/assay-workflow/tests-e2e/pipeline.spec.ts
+++ b/crates/assay-workflow/tests-e2e/pipeline.spec.ts
@@ -3,7 +3,6 @@ import { test, expect, Page } from '@playwright/test';
 const DEMO_WF_ID = process.env.ASSAY_E2E_WF_ID || 'demo-2';
 const DEMO_NAMESPACE = process.env.ASSAY_E2E_NAMESPACE || 'demo';
 
-// Plan-15 slice 3 gates every /api/v1/engine/workflow/* admin route at
 // the engine layer. The SPA reads `assay-admin-token` from localStorage
 // and sends it as `Authorization: Bearer …` on every fetch; without it
 // the SPA shows a token prompt and the namespace selector never

--- a/crates/assay-workflow/tests-e2e/run.lua
+++ b/crates/assay-workflow/tests-e2e/run.lua
@@ -30,7 +30,6 @@ local DB = env.get("ASSAY_E2E_DB") or "/tmp/assay-e2e.sqlite"
 local ENGINE_CONFIG = env.get("ASSAY_E2E_ENGINE_CONFIG") or "/tmp/assay-e2e-engine.toml"
 local ENGINE_LOG = env.get("ASSAY_E2E_ENGINE_LOG") or "/tmp/assay-e2e-engine.log"
 local WORKER_LOG = env.get("ASSAY_E2E_WORKER_LOG") or "/tmp/assay-e2e-worker.log"
--- Plan-15 slice 2 lifted the workflow-API auth gate to the engine layer:
 -- when state.auth is Some (now always), every /api/v1/engine/workflow/*
 -- call except /health|/version|/openapi.json|/docs requires a Bearer
 -- admin key. Match the break-glass key seeded in write_engine_config().

--- a/crates/assay-workflow/tests/smoke_backends.rs
+++ b/crates/assay-workflow/tests/smoke_backends.rs
@@ -1137,7 +1137,7 @@ async fn leader_election(#[case] backend: Backend) {
 // ── Task 3.16 / 3.17 — Push streams ──────────────────────────────────────────
 //
 // SQLite is intentionally NOT tested here: it returns stream::empty() by
-// design (no cross-process notification primitive — hybrid model, plan 10
+// design (no cross-process notification primitive — hybrid model,
 // § "Dispatch wake-up").
 //
 // If the 5-second timeout proves flaky on a backend (e.g. slow CI), do NOT

--- a/site/build.lua
+++ b/site/build.lua
@@ -50,7 +50,6 @@ local function count_builtins()
 end
 
 -- =====================================================================
--- Phase 0: Compute variables
 -- =====================================================================
 local module_count = count_builtins() + #fs.glob("stdlib/**/*.lua")
 
@@ -87,7 +86,6 @@ local function apply_placeholders(html)
 end
 
 -- =====================================================================
--- Phase 1: Copy static assets
 -- =====================================================================
 local statics = fs.glob("site/static/*")
 for _, f in ipairs(statics) do
@@ -96,7 +94,6 @@ end
 log.info("Copied " .. #statics .. " static assets")
 
 -- =====================================================================
--- Phase 2: Build page templates
 -- =====================================================================
 local pages = fs.glob("site/pages/*.html")
 for _, f in ipairs(pages) do
@@ -105,7 +102,6 @@ end
 log.info("Built " .. #pages .. " pages")
 
 -- =====================================================================
--- Phase 3: Generate per-module HTML pages
 -- =====================================================================
 local md_files = fs.glob("docs/modules/*.md")
 fs.write(modules_out .. "/.gitkeep", "")
@@ -159,7 +155,6 @@ end
 log.info("Generated " .. #modules .. " module pages")
 
 -- =====================================================================
--- Phase 4: Generate modules.html index
 -- =====================================================================
 local function modules_in_category(cat_pattern)
   local items = {}
@@ -214,7 +209,6 @@ __FOOTER__
 fs.write(out .. "/modules.html", apply_placeholders(index_html))
 
 -- =====================================================================
--- Phase 4b: Generate per-example HTML pages + examples.html index
 -- =====================================================================
 -- Each subdirectory of examples/workflows/ ships a README.md and one or
 -- more *.lua files. We render the README + a syntax-highlighted view of
@@ -338,7 +332,6 @@ __FOOTER__
 fs.write(out .. "/examples.html", apply_placeholders(examples_index_html))
 
 -- =====================================================================
--- Phase 5: Generate llms-full.txt
 -- =====================================================================
 local llms = { [[# Assay
 


### PR DESCRIPTION
## Summary

Implements the artifact-existence check in `detect` that we discussed for PR #77 but I shipped as a half-version. Re-runs of `release.yml` no longer pay the ~6 min `binaries` cross-compile when both products' GH releases already exist for the current `Cargo.toml` versions — the `release-*` jobs fetch the attached binaries via `gh release download` instead.

## How it works

```
detect
  ├── (existing) per-crate bumped checks vs crates.io
  └── NEW: artifacts-state step
        ├── gh release view assay-engine-v$VER  → engine_release_exists
        ├── gh release view assay-lua-v$VER     → lua_release_exists
        └── binaries_needed = NOT (engine_release_exists AND lua_release_exists)

binaries
  ├── if: needs.detect.outputs.binaries_needed == 'true'
  └── (skipped on re-runs where everything is already published)

release-{assay-engine,assay-lua}
  ├── if: binaries.result == 'success' || 'skipped'   ← accepts skipped now
  └── Prepare release assets:
        ├── if release_exists → gh release download <tag> --pattern <bin>
        └── else              → actions/download-artifact from binaries job
```

## Net effect per scenario

| Scenario | Before | After |
|---|---|---|
| First publish of a new version | detect + libraries + binaries (~6 min) + release-* | same (~7 min) |
| **Re-run after partial fail** (PR #77's recovery case) | **detect + libraries(skip) + binaries (~6 min) + release-*** | **detect + everything skipped + release-* fetches from GH release (~1.5 min)** |
| No-op push to main | detect + binaries (~6 min) + release-* (no-ops) | detect + everything else skipped (~30 s) |

## Test plan

- [x] YAML syntax-checked locally
- [x] Logic walkthrough: when both GH releases exist (current state on main: `assay-engine-v0.2.0` + `assay-lua-v0.14.0` shipped via PR #77 release run), `binaries_needed` resolves to `false`, the `binaries` job is skipped, and `release-*` jobs hit the `gh release download` path.
- [ ] On merge: `release.yml` runs in ~30 s — detect + everything else skipped (every artifact is already shipped, no docker push to do).

## Closes

This is the proper version of the design discussed during PR #77 review — apologies for the deviation; that's now logged in agent memory so it doesn't happen again.