### PR TITLE
0.14.1 / 0.3.1 / 0.2.1 — six issue closes (stdlib + cancel handler)

### DIFF
--- a/.claude/plans/16-v0.14.1-stdlib-and-cancel-fixes.md
+++ b/.claude/plans/16-v0.14.1-stdlib-and-cancel-fixes.md
@@ -1,0 +1,207 @@
+# Plan 16 — assay 0.14.1 + assay-workflow 0.3.1 + assay-engine 0.2.1
+
+**Status:** in progress **Branch:** `fix/0.14.1-stdlib-and-cancel` **Started:** 2026-04-26
+
+A coordinated patch release closing six open issues (#66, #40, #64, #67, #71, #72) with a single PR.
+Issue #75 (drop OpenSSL) is explicitly out of scope and stays open for a dedicated minor.
+
+## Scope and version bumps
+
+Single PR, three per-crate patch tags:
+
+| Crate            | Bump            | Why                                                        |
+| ---------------- | --------------- | ---------------------------------------------------------- |
+| `assay`          | 0.14.0 → 0.14.1 | Stdlib additions + template builtin loader + lua coroutine |
+| `assay-workflow` | 0.3.0 → 0.3.1   | Defensive cancel-handler body parsing                      |
+| `assay-engine`   | 0.2.0 → 0.2.1   | Re-ships the workflow patch in the engine binary           |
+
+`assay-domain`, `assay-auth`, `assay-dashboard` do not move.
+
+## Issues addressed
+
+### #66 — `workflow.cancel` empty-body deserialize error (bug)
+
+**Root cause** (confirmed in code 2026-04-26):
+
+- `crates/assay/stdlib/engine/workflow.lua` `api_call` does `body or {}`. Empty Lua table → JSON
+  `[]` because `lua_table_to_json` treats empty tables as arrays.
+- `crates/assay-workflow/src/api/workflows.rs::cancel_workflow` declares
+  `body: Option<Json<CancelBody>>`. Axum, seeing `Content-Type: application/json`, attempts to parse
+  `[]` as `CancelBody` and errors before `Option` can be `None`.
+
+**Fix (defense in depth, both layers):**
+
+1. _Stdlib (assay 0.14.1)_ — `api_call` passes `nil` instead of synthesising `{}` when no body was
+   supplied. Touches POST/PATCH/PUT branches.
+2. _Server (assay-workflow 0.3.1)_ — make `cancel_workflow` tolerant of either no body, `{}`, `[]`,
+   or `{"reason": "..."}`. Use a custom extractor or `body: Option<Bytes>` parsed manually so a
+   stray array doesn't 400.
+
+**Regression test:**
+
+- Lua-level: spin up an engine, start a workflow, cancel it via the stdlib client → expect 200, not
+  error.
+- HTTP-level: `curl -X POST .../cancel -H 'Content-Type: application/json' -d '[]'` → 200.
+- HTTP-level (existing): no body, `{}`, and `{"reason":"x"}` continue to work.
+
+### #40 — Lua coroutine: `error converting Lua nil to function` on resume (bug)
+
+Filed against `assay 0.10.4` against the old `temporal.worker(...)` API. That API is gone (replaced
+by `workflow.client():listen()`), and the only `lua.create_thread` call left in the tree is
+`crates/assay/src/lua/builtins/core.rs:545` (inside the generic `coroutine.create` shim, unrelated).
+
+**Tasks:**
+
+1. Try to reproduce against `workflow.client():listen()` with a workflow that calls
+   `ctx:register_query(...)` and `os.date(...)`. Use a tempdir SQLite engine and `assay-workflow`
+   e2e fixture.
+2. If green: close as fixed-by-the-engine-rewrite, add a regression test covering the same code
+   paths the issue called out (`register_query`, `os.date`, coroutine resume with `(ctx, input)`).
+3. If reproducible: bisect to the actual fault site, fix, add the regression test.
+
+### #64 — `template` builtin: support `{% include %}` / `{% extends %}` / `{% import %}`
+
+Code lives in `crates/assay/src/lua/builtins/template.rs`. Today every call constructs a fresh
+`minijinja::Environment::new()` with no loader.
+
+**Approach:** add a third template function rather than overloading existing ones.
+
+```lua
+template.render_with_loader("templates", "page.html", { name = "hi" })
+```
+
+- Rust: `Environment::new()` then `env.set_loader(minijinja::path_loader(dir))`, then render the
+  named template.
+- Lua signature: `(template_dir: string, template_name: string, vars: table) -> string`.
+- Errors as `template.render_with_loader: <minijinja error>` with the same prefix style the existing
+  two functions use.
+
+**Test plan** (matches the issue reporter's spec):
+
+- `tests/builtins_template.rs` integration test creates `templates/base.html`, `templates/page.html`
+  (uses `{% extends %}` + `{% include %}`), `templates/row.html`, calls `render_with_loader`,
+  asserts `<li>hi</li>`.
+- A second test verifies `{% import %}` of macros works through the loader.
+
+### #67 — ANSI → HTML helper in stdlib
+
+Pure Lua module: `crates/assay/stdlib/ansi.lua`. No native code required.
+
+- `ansi.to_html(line)` — escape HTML-unsafe chars, then convert SGR sequences to
+  `<span class="ansi-fg-N">` / `ansi-bg-N` / `ansi-bold` wrappers.
+- `ansi.strip(line)` — drop all CSI sequences, return plain text.
+- Coverage: fg 30–37 + 90–97 (bright), bg 40–47 + 100–107 (bright), bold (1), reset (0), default-fg
+  (39), default-bg (49). Unknown SGR codes dropped cleanly. Non-SGR CSI (cursor moves, erase-line)
+  pre-stripped.
+- Tests: `crates/assay/tests/stdlib_ansi.rs` covering the cases the issue enumerates.
+- Docs: `docs/modules/ansi.md`.
+
+### #71 — `release-check` stdlib (GitHub Releases + apt + version compare)
+
+Three coordinated additions:
+
+1. **`assay.github`** already exists for the GitHub API; _extend_ it (don't create a parallel
+   module) with:
+   - `github.latest_release(owner, repo, opts?)` → release record with `tag_name`, `version`
+     (v-stripped), `assets[]`, `published_at`.
+   - `github.find_asset(release, name_pattern)` → asset table or nil.
+   - `github.fetch_asset_text(asset)` / `github.fetch_asset_bytes(asset)`.
+   - `github.release_checksum(release, { asset_pattern, digest })` — convenience for the common
+     `<asset>.sha256` sibling pattern.
+2. **`assay.apt`** new module: `crates/assay/stdlib/apt.lua`.
+   - `apt.packages({ base_url, dist, component, arch })` → index object with `:find(name)` returning
+     `{ version, versions[], architecture, depends, ... }`.
+   - Auto-decompresses `Packages.gz` / `Packages.xz` / `Packages.zst` / uncompressed `Packages`.
+   - Internally uses the new `assay.compress` primitives below for the bytes and `assay.version` for
+     sorting versions.
+3. **`assay.version`** new module: `crates/assay/stdlib/version.lua`.
+   - `version.compare(a, b, scheme?)` → -1 / 0 / 1; schemes `"semver"` (default), `"debian"`,
+     `"rpm"`, `"numeric"`.
+   - `version.max(list, scheme?)`.
+
+**Compression primitive (necessary building block):** `assay.compress`
+
+- `compress.gunzip(bytes) -> bytes`
+- `compress.unxz(bytes) -> bytes`
+- `compress.unzstd(bytes) -> bytes`
+- Implemented as a Rust builtin (`crates/assay/src/lua/builtins/compress.rs`) using `flate2` +
+  `xz2` + `zstd`. Dependencies are already pulled in by other crates; verify before adding.
+
+Tests:
+
+- `crates/assay/tests/stdlib_release_check.rs` — github.latest_release, github.release_checksum,
+  version.compare(scheme=semver/debian).
+- `crates/assay/tests/stdlib_apt.rs` — fixture-based: serve a `Packages.gz` from a localhost mock,
+  decompress, parse, find tailscale, max(version).
+
+Docs: `docs/modules/github.md` extended; new `docs/modules/apt.md`, `docs/modules/version.md`,
+`docs/modules/compress.md`.
+
+### #72 — `tailscale` stdlib module
+
+Pure Lua module on top of existing `http`, `json`, `os.getenv`. New file
+`crates/assay/stdlib/tailscale.lua`.
+
+API:
+
+- `tailscale.client(opts?)` — returns a client; OAuth2 client_credentials grant cached until token
+  expiry. Reads `TS_CLIENT_ID` / `TS_CLIENT_SECRET` by default.
+- `client:mint_key(opts)` — POST `/tailnet/{tailnet}/keys`. Mirrors the capabilities payload exactly
+  as the issue describes.
+- `client:list_devices()` / `client:find_device({hostname=...})` / `client:get_device(id)`.
+- `client:set_key_expiry(id, { disabled = bool })` — idempotent, returns `"changed"` or
+  `"unchanged"`.
+- `client:authorize_device(id)`, `client:set_device_tags(id, tags)`, `client:delete_device(id)`.
+- `tailscale.acl_test(opts)` — wrapper around `/tailnet/{tailnet}/acl/preview` for ACL CI diff.
+
+**Form-encoding requirement:** OAuth2 token exchange is form-encoded. The issue flags that without
+URL-encoding, secrets containing `&=+%` will silently 401. Add `assay.url.encode(s)` and
+`assay.url.encode_form(table)` as a small support module (`crates/assay/stdlib/url.lua`, pure Lua) —
+useful far beyond tailscale. Implement encode_form so callers don't string-concat.
+
+Tests: `crates/assay/tests/stdlib_tailscale.rs` driven against a mocked Tailscale API surface.
+
+Docs: `docs/modules/tailscale.md`, `docs/modules/url.md`.
+
+## Documentation + site updates
+
+- `docs/modules/`: new files — `ansi.md`, `apt.md`, `compress.md`, `tailscale.md`, `url.md`,
+  `version.md`. Existing `github.md` and `template.md` extended.
+- `docs/migration-to-0.14.1.md`: very short — no breaking changes; lists new modules and the
+  workflow.cancel fix as a behaviour change.
+- `CHANGELOG.md`: new section `## [0.14.1 / engine 0.2.1 / workflow 0.3.1] - 2026-04-26` with
+  per-crate bump table and per-issue line items.
+- `site/pages/changelog.html`: regenerate (build script if any, or manual copy if static).
+- `site/pages/index.html`: update headline list of stdlib modules to include the new ones if it
+  currently enumerates them.
+
+Audit step: grep `site/` and `docs/` for "stdlib" / "workflow.cancel" / references that newly-added
+modules should appear in.
+
+## Execution order
+
+1. Branch from `main` → `fix/0.14.1-stdlib-and-cancel`.
+2. Issue #66 stdlib fix (small, lowest-risk warmup).
+3. Issue #66 engine-side defensive handler.
+4. Regression test for #66 (Lua + HTTP curl-equivalent).
+5. Issue #64 template path-loader (single Rust builtin + test).
+6. Issue #67 ANSI module + test + doc.
+7. Issue #72 url + tailscale modules + tests + docs.
+8. Issue #71 compress builtin → version → apt → github extension; tests + docs.
+9. Issue #40 reproduce → fix-or-close-as-fixed; regression test in either case.
+10. Version bumps in three Cargo.toml files; CHANGELOG.md + migration doc; site refresh.
+11. Run `cargo check --workspace`, `cargo test --workspace --lib --tests`, targeted
+    `cargo test --test stdlib_*` for the new modules, `cargo test --test engine_smoke` for the
+    cancel path.
+12. Commit per logical group (one commit per issue + one bump commit + one docs commit), atomic
+    style — `fix(workflow): ...`, `feat(stdlib): ...`, `chore(release): bump...`.
+13. Push branch, open PR with `--assignee @me`.
+
+## Out of scope (don't drift into)
+
+- #75 (drop OpenSSL → RustCrypto for webauthn-rs) — separate effort, larger than a patch.
+- The optional "json.object{}" / `__jsontype` runtime sentinel from #66 fix (b)-extended. Stdlib +
+  handler fix is enough for the bug; sentinel is a minor.
+- Any auth crate work — auth is in v0.14.0 already, no patch needed.
+- `apt.zst` support would be nice; only land if `zstd` crate is already in the dep tree. If it adds
+  compile time, defer.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,20 @@ jobs:
         env:
           MOON_LOG: "info"
 
+      # `assay site/build.lua` (the moon `site:build` task above)
+      # rewrites the stdlib table in README.md in place from
+      # docs/modules/*.md frontmatter. If that rewrite produced a diff,
+      # the committed README was out of sync — fail with a clear hint
+      # rather than letting drift slip through. Linux only: macOS would
+      # produce the same result, asserting twice is noise.
+      - name: Docs are in sync (README stdlib table)
+        if: runner.os == 'Linux'
+        run: |
+          if ! git diff --exit-code -- README.md; then
+            echo "::error title=README.md out of sync::Run 'assay site/build.lua' locally and commit the result. The stdlib table is generated from docs/modules/*.md frontmatter; edit those (or build.lua's category_order) — not README directly."
+            exit 1
+          fi
+
       - name: Upload Playwright artifacts on failure
         if: failure()
         uses: actions/upload-artifact@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,116 @@
 
 All notable changes to Assay are documented here.
 
+## [assay 0.14.1 / assay-workflow 0.3.1 / assay-engine 0.2.1] - 2026-04-26
+
+**Headline:** A patch release closing six open issues — one workflow API bug, six stdlib additions,
+one template-builtin gap, and one coroutine regression — without breaking changes. Two layers move:
+the Lua runtime side (`assay`) and the engine side (`assay-workflow` for the cancel handler change,
+`assay-engine` to ship the patched binary).
+
+| Crate            | Version         | Notes                                                                                                             |
+| ---------------- | --------------- | ----------------------------------------------------------------------------------------------------------------- |
+| `assay`          | 0.14.0 → 0.14.1 | Six new stdlib modules (ansi, url, tailscale, version, apt, compress); github releases extension; template loader |
+| `assay-workflow` | 0.3.0 → 0.3.1   | Defensive empty-body parsing on `POST /workflows/{id}/cancel`                                                     |
+| `assay-engine`   | 0.2.0 → 0.2.1   | Re-ships the workflow patch in the binary                                                                         |
+
+### Fixed
+
+- **#66 — `workflow.cancel` rejected with empty-body deserialize error.** The Lua stdlib
+  `_api("POST", path)` helpers were synthesising `body or {}` on every call, which serialised to
+  `[]` (Lua can't distinguish empty array from empty object), and the `POST /workflows/{id}/cancel`
+  handler then failed to deserialise that `[]` into `CancelBody`. Two-layer fix:
+  - _Stdlib_ (`assay 0.14.1`): the engine + workflow + auth `_api` helpers now pass `body` through
+    unchanged so a `nil` body sends no body and no `Content-Type` header.
+  - _Server_ (`assay-workflow 0.3.1`): `cancel_workflow` now consumes the body as raw bytes and
+    tolerates any of: missing body, `{}`, `[]`, or `{"reason":"..."}`. Regression test in
+    `crates/assay-workflow/tests/api_integration.rs::cancel_accepts_any_body_shape`.
+
+- **#40 — Lua coroutine resume `error converting Lua nil to function`.** The bug was filed against
+  `assay 0.10.4` and the long-removed `temporal.worker(...)` API. The v0.13.0 engine rewrite
+  replaced the mlua `create_thread` path with pure-Lua `coroutine.create` in
+  `stdlib/engine/workflow/worker.lua`, which inherits globals from the parent state — so `os.date`
+  and `ctx:register_query` are reachable inside the coroutine. New regression test
+  (`crates/assay/tests/coroutine_ctx_resume.rs`) pins this contract.
+
+### Added — stdlib (assay 0.14.1)
+
+- **`assay.ansi`** — ANSI SGR → HTML conversion (`ansi.to_html`) and stripper (`ansi.strip`) for
+  browser-facing log viewers. Pure Lua, no deps. Covers fg/bg 30–37 / 90–97 / 40–47 / 100–107, bold,
+  reset, default-fg/bg; unknown codes dropped cleanly; non-SGR CSI pre-stripped; HTML-unsafe chars
+  escaped before span-wrapping. Closes #67.
+
+- **`assay.url`** — RFC 3986 percent encoding (`url.encode`, `url.decode`) plus form-body builder
+  (`url.encode_form`). Used by `assay.tailscale` for OAuth2 `application/x-www-form-urlencoded`
+  bodies; generally useful wherever a script builds query strings or form bodies by hand. Spaces
+  become `%20` (RFC 3986); `url.decode` does form-style `+` → space.
+
+- **`assay.tailscale`** — Tailscale REST client. `tailscale.client(...)` performs OAuth2
+  `client_credentials` exchange (form body built via `assay.url.encode_form`, so secrets containing
+  `&=+%` encode safely), caches the bearer token until `expires_at - 30s`, and exposes: `mint_key`,
+  `list_devices`, `find_device`, `get_device`, `set_key_expiry` (idempotent — returns `"changed"` or
+  `"unchanged"`), `authorize_device`, `set_device_tags`, `delete_device`, `acl_test`. Closes #72.
+
+- **`assay.version`** — Cross-scheme version comparison. `version.compare(a, b, scheme?)` returns
+  -1/0/1 across `"semver"` (default, semver.org-spec pre-release ordering), `"debian"` (epoch +
+  tilde-aware alternating digit/non-digit comparator), `"rpm"` (same shape, no tilde rule),
+  `"numeric"` (dotted ints, missing segments default to 0). `version.max(list, scheme?)` returns the
+  largest. Closes #71 (§3).
+
+- **`assay.compress`** — Decompression Rust builtin. `compress.gunzip`, `compress.unxz`,
+  `compress.unzstd`. Bytes in, bytes out (Lua strings are byte buffers). Used internally by
+  `assay.apt`; generally useful for any HTTP download with `Content-Encoding` compression.
+
+- **`assay.apt`** — Debian package index reader. `apt.packages({base_url,
+  dist, component, arch})`
+  fetches `dists/{dist}/{component}/binary-{arch}/Packages.{gz,xz,zst,plain}`, auto-decompresses,
+  parses the RFC 822 control file, and returns an index with
+  `:find(name) -> { version, versions[], architecture, depends, ... }`. Versions are sorted via
+  `assay.version.compare(..., "debian")`. Closes #71 (§2).
+
+- **`assay.github`** extension — Module-level GitHub Releases helpers alongside the existing client
+  API: `github.latest_release(owner, repo)`, `github.find_asset(release, name_pattern)`,
+  `github.fetch_asset_text/bytes(asset)`,
+  `github.release_checksum(release, { asset_pattern, digest })`. Used by release-version checkers.
+  Closes #71 (§1).
+
+### Added — Lua builtins (assay 0.14.1)
+
+- **`template.render_with_loader(template_dir, name, vars)`** — Renders a template through a
+  minijinja path loader so `{% extends %}`, `{% include %}`, and `{% import %}` resolve sibling
+  templates. The existing `template.render` and `template.render_string` constructed a fresh
+  `Environment::new()` per call with no loader and so could never resolve references between
+  templates. Closes #64.
+
+- **`compress.gunzip` / `compress.unxz` / `compress.unzstd`** — see stdlib section above.
+  Implemented as a Rust builtin via `flate2`, `xz2`, `zstd`.
+
+### Changed — http (assay 0.14.1)
+
+- `http.get/post/...` response `body` is now constructed from raw bytes rather than `resp.text()`
+  (UTF-8 lossy). Lua strings are byte buffers, so this round-trips binary payloads (gzip/xz/zst
+  index files, asset downloads) without corruption. Visible only to callers fetching non-UTF-8
+  content; UTF-8 callers see no behaviour change.
+
+### Changed — workflow API (assay-workflow 0.3.1)
+
+- `cancel_workflow` handler now consumes the raw body and tolerates any shape — the previous
+  `Option<Json<CancelBody>>` extractor would 400 on `[]`. See #66 fix above.
+
+### Migration
+
+No breaking changes. Stdlib additions are additive. The cancel handler contract is wider than before
+(more inputs accepted; same outputs). Engine binaries should be redeployed to pick up the cancel
+fix; library consumers of `assay-workflow` get it automatically with
+`cargo update -p assay-workflow`.
+
+See `docs/migration-to-0.14.1.md` for the short version.
+
+### Out of scope
+
+- **#75** (drop OpenSSL → RustCrypto for `webauthn-rs`) — left open; tracked for a dedicated minor
+  since it touches the auth crate and changes a build-time dependency tree.
+
 ## [assay-engine 0.2.0] - 2026-04-25
 
 **Headline:** assay-engine becomes a full Ory replacement + IdP, on top of the Temporal-replacement

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -260,7 +266,7 @@ dependencies = [
 
 [[package]]
 name = "assay-engine"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "assay-auth",
@@ -287,7 +293,7 @@ dependencies = [
 
 [[package]]
 name = "assay-lua"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "anyhow",
  "axum",
@@ -295,6 +301,7 @@ dependencies = [
  "clap_complete",
  "data-encoding",
  "digest 0.10.7",
+ "flate2",
  "futures-util",
  "glob",
  "http-body-util",
@@ -325,12 +332,14 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "wiremock",
+ "xz2",
  "zeroize",
+ "zstd",
 ]
 
 [[package]]
 name = "assay-workflow"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "assay-domain",
@@ -1998,6 +2007,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "flume"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3034,6 +3053,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "lzma-sys"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3075,6 +3105,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memo-map"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d1115007560874e373613744c6fba374c17688327a71c1476d1a5954cc857b"
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3096,6 +3132,8 @@ version = "2.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b479616bb6f0779fb0f3964246beda02d4b01144e1b0d5519616e012ccc2a245"
 dependencies = [
+ "memo-map",
+ "self_cell",
  "serde",
 ]
 
@@ -3104,6 +3142,16 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -4569,6 +4617,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "self_cell"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
+
+[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4888,6 +4942,12 @@ dependencies = [
  "digest 0.10.7",
  "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "simple_asn1"
@@ -6802,6 +6862,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6909,3 +6978,31 @@ name = "zmij"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4de98dfa5d5b7fef4ee834d0073d560c9ca7b6c46a71d058c48db7960f8cfaf7"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Assay
 
 **One static binary that replaces Temporal + Kratos + Hydra + Keto.** Plus a full Lua 5.5 runtime
-with 51 modules for Kubernetes, monitoring, secrets, and AI agents.
+with 60 modules for Kubernetes, monitoring, secrets, and AI agents.
 
 [![CI](https://github.com/developerinlondon/assay/actions/workflows/ci.yml/badge.svg)](https://github.com/developerinlondon/assay/actions/workflows/ci.yml)
 [![Crates.io](https://img.shields.io/crates/v/assay-lua.svg)](https://crates.io/crates/assay-lua)
@@ -9,11 +9,12 @@ with 51 modules for Kubernetes, monitoring, secrets, and AI agents.
 
 ## What is Assay?
 
-Two binaries, one project. ~9-11 MB static each, `FROM scratch`-shippable, PG18 + SQLite first-
-class.
+Two binaries, one project. `FROM scratch`-shippable, PG18 + SQLite first-class. Sizes today: `assay`
+~12 MB, `assay-engine` ~19 MB (the engine grew with the auth + IdP work in v0.2.0).
 
-- **`assay`** — Lua 5.5 runtime with 51 stdlib modules (Kubernetes, Prometheus, Vault, GitHub,
-  Gmail, OpenClaw, …). Drop-in replacement for 50-250 MB Python/Node/kubectl scripting containers.
+- **`assay`** — Lua 5.5 runtime with 57 stdlib modules (Kubernetes, Prometheus, Vault, GitHub,
+  Gmail, OpenClaw, Tailscale, …). Drop-in replacement for 50-250 MB Python/Node/kubectl scripting
+  containers.
 - **`assay-engine`** — durable **workflow engine** (Temporal-replacement: deterministic-replay
   activities, signals, timers, child workflows, schedules, search attributes) **+ full IdP**
   (Kratos + Hydra + Keto replacement: OIDC client + provider, passkey, JWT/JWKS rotation, biscuit
@@ -26,7 +27,7 @@ assay script.lua     # Run Lua with all builtins
 assay checks.yaml    # Structured checks with retry/backoff/JSON output
 assay exec -e 'log.info("hello")'   # Inline evaluation
 assay context "grafana"              # LLM-ready module docs
-assay modules                        # List all 51 modules
+assay modules                        # List all 57 modules
 
 # Workflow + auth + dashboard server (one process)
 assay-engine serve --config engine.toml
@@ -50,7 +51,7 @@ jobs. The runtime talks to a deployed `assay-engine` over HTTP via the `assay.wo
 | `assay-engine` auth Zanzibar  | **Ory Keto / SpiceDB**    | Recursive-CTE walk on PG18 + SQLite                    |
 | `assay-engine` auth biscuit   | (Ory has nothing)         | Datalog-attenuable capability tokens — built-in        |
 | `assay-engine` dashboard      | Ory Console + Temporal UI | Single SPA, auth panes appear when auth is on          |
-| `assay` runtime               | Python / Node + kubectl   | 11 MB, 5 ms cold start, 51 stdlib modules              |
+| `assay` runtime               | Python / Node + kubectl   | 12 MB, 5 ms cold start, 57 stdlib modules              |
 
 ## Two binaries, two use cases
 
@@ -59,7 +60,7 @@ jobs. The runtime talks to a deployed `assay-engine` over HTTP via the `assay.wo
 | Scripting / automation       | `assay`        | `cargo install assay-lua` or download release |
 | Workflow + auth + IdP server | `assay-engine` | `cargo install assay-engine` or Docker        |
 
-`assay` runs Lua scripts with the full 51-module stdlib; for workflows/auth it talks to a deployed
+`assay` runs Lua scripts with the full 57-module stdlib; for workflows/auth it talks to a deployed
 `assay-engine` over HTTP. `assay-engine` is a standalone HTTP server with workflow + auth +
 dashboard, pluggable across PG18 (default) and SQLite — both backends compiled in, runtime-selected
 via config.
@@ -70,8 +71,8 @@ See [docs/migration-to-0.2.0.md](./docs/migration-to-0.2.0.md) for the upgrade p
 
 | Runtime          | Compressed |   On-disk | vs Assay | Cold Start | K8s-native |
 | ---------------- | ---------: | --------: | :------: | ---------: | :--------: |
-| **assay**        |  **11 MB** | **15 MB** |  **1x**  |   **5 ms** |  **Yes**   |
-| **assay-engine** |   **9 MB** | **12 MB** |  **1x**  |   **8 ms** |  **Yes**   |
+| **assay**        |  **~9 MB** | **12 MB** |  **1x**  |   **5 ms** |  **Yes**   |
+| **assay-engine** | **~14 MB** | **19 MB** |  **1x**  |   **8 ms** |  **Yes**   |
 | Python alpine    |      17 MB |     50 MB |    2x    |     300 ms |     No     |
 | bitnami/kubectl  |      35 MB |     90 MB |    4x    |     200 ms |  Partial   |
 | Node.js alpine   |      57 MB |    180 MB |    6x    |     500 ms |     No     |
@@ -221,8 +222,9 @@ All 17 Rust builtins are available globally in `.lua` scripts — no `require` n
 
 ## Stdlib Modules
 
-34 embedded Lua modules loaded via `require("assay.<name>")`. All follow the client pattern:
-`M.client(url, opts)` then `c:method()`.
+36 embedded Lua modules loaded via `require("assay.<name>")`. Most follow the client pattern:
+`M.client(url, opts)` then `c:method()`. A few utilities (`ansi`, `url`, `version`) are pure
+functions and can be called directly off the module table.
 
 | Module                          | Description                                                                                           |
 | ------------------------------- | ----------------------------------------------------------------------------------------------------- |
@@ -252,6 +254,8 @@ All 17 Rust builtins are available globally in `.lua` scripts — no `require` n
 | `assay.crossplane`              | Providers, XRDs, compositions                                                                         |
 | `assay.velero`                  | Backups, restores, schedules                                                                          |
 | `assay.harbor`                  | Projects, repos, vulnerability scanning                                                               |
+| `assay.tailscale`               | OAuth2 client_credentials, mint auth keys, list/find/get devices, set key expiry, tags, ACL preview   |
+| `assay.apt`                     | Read Debian `Packages.{gz,xz,zst,plain}` indexes, parse stanzas, sorted versions via `assay.version`  |
 | **Data & Storage**              |                                                                                                       |
 | `assay.postgres`                | User/database management, grants                                                                      |
 | `assay.s3`                      | S3-compatible storage with Sig V4 auth                                                                |
@@ -265,6 +269,11 @@ All 17 Rust builtins are available globally in `.lua` scripts — no `require` n
 | `assay.gcal`                    | Calendar events CRUD (OAuth2)                                                                         |
 | `assay.oauth2`                  | Google OAuth2 token management                                                                        |
 | `assay.email_triage`            | Email classification and triage                                                                       |
+| **Utilities & Text**            |                                                                                                       |
+| `assay.ansi`                    | ANSI SGR → HTML conversion + stripper for browser-facing log viewers                                  |
+| `assay.url`                     | RFC 3986 percent-encoding + form-body builder (`url.encode`, `url.encode_form`, `url.decode`)         |
+| `assay.version`                 | Compare versions across semver / debian / rpm / numeric schemes                                       |
+| `assay.compress` (builtin)      | gunzip / unxz / unzstd — bytes in, bytes out                                                          |
 
 ## Examples
 
@@ -458,9 +467,9 @@ and one-shot shell scripts.
 ## Development
 
 ```bash
-cargo build --release -p assay-lua      # Lua runtime binary (~11 MB)
+cargo build --release -p assay-lua      # Lua runtime binary (~12 MB)
 cargo build --release -p assay-engine \
-    --features backend-postgres,backend-sqlite,auth   # Workflow + auth server (~9 MB)
+    --features backend-postgres,backend-sqlite,auth   # Workflow + auth server (~19 MB)
 cargo clippy --workspace -- -D warnings
 cargo test --workspace
 dprint fmt                              # Format (Rust, Markdown, YAML, JSON, TOML)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Assay
 
 **One static binary that replaces Temporal + Kratos + Hydra + Keto.** Plus a full Lua 5.5 runtime
-with 60 modules for Kubernetes, monitoring, secrets, and AI agents.
+with 65 modules for Kubernetes, monitoring, secrets, and AI agents.
 
 [![CI](https://github.com/developerinlondon/assay/actions/workflows/ci.yml/badge.svg)](https://github.com/developerinlondon/assay/actions/workflows/ci.yml)
 [![Crates.io](https://img.shields.io/crates/v/assay-lua.svg)](https://crates.io/crates/assay-lua)
@@ -12,7 +12,7 @@ with 60 modules for Kubernetes, monitoring, secrets, and AI agents.
 Two binaries, one project. `FROM scratch`-shippable, PG18 + SQLite first-class. Sizes today: `assay`
 ~12 MB, `assay-engine` ~19 MB (the engine grew with the auth + IdP work in v0.2.0).
 
-- **`assay`** — Lua 5.5 runtime with 57 stdlib modules (Kubernetes, Prometheus, Vault, GitHub,
+- **`assay`** — Lua 5.5 runtime with 45 stdlib modules (Kubernetes, Prometheus, Vault, GitHub,
   Gmail, OpenClaw, Tailscale, …). Drop-in replacement for 50-250 MB Python/Node/kubectl scripting
   containers.
 - **`assay-engine`** — durable **workflow engine** (Temporal-replacement: deterministic-replay
@@ -27,7 +27,7 @@ assay script.lua     # Run Lua with all builtins
 assay checks.yaml    # Structured checks with retry/backoff/JSON output
 assay exec -e 'log.info("hello")'   # Inline evaluation
 assay context "grafana"              # LLM-ready module docs
-assay modules                        # List all 57 modules
+assay modules                        # List all 65 modules
 
 # Workflow + auth + dashboard server (one process)
 assay-engine serve --config engine.toml
@@ -51,7 +51,7 @@ jobs. The runtime talks to a deployed `assay-engine` over HTTP via the `assay.wo
 | `assay-engine` auth Zanzibar  | **Ory Keto / SpiceDB**    | Recursive-CTE walk on PG18 + SQLite                    |
 | `assay-engine` auth biscuit   | (Ory has nothing)         | Datalog-attenuable capability tokens — built-in        |
 | `assay-engine` dashboard      | Ory Console + Temporal UI | Single SPA, auth panes appear when auth is on          |
-| `assay` runtime               | Python / Node + kubectl   | 12 MB, 5 ms cold start, 57 stdlib modules              |
+| `assay` runtime               | Python / Node + kubectl   | 12 MB, 5 ms cold start, 45 stdlib modules              |
 
 ## Two binaries, two use cases
 
@@ -60,7 +60,7 @@ jobs. The runtime talks to a deployed `assay-engine` over HTTP via the `assay.wo
 | Scripting / automation       | `assay`        | `cargo install assay-lua` or download release |
 | Workflow + auth + IdP server | `assay-engine` | `cargo install assay-engine` or Docker        |
 
-`assay` runs Lua scripts with the full 57-module stdlib; for workflows/auth it talks to a deployed
+`assay` runs Lua scripts with the full 45-module stdlib; for workflows/auth it talks to a deployed
 `assay-engine` over HTTP. `assay-engine` is a standalone HTTP server with workflow + auth +
 dashboard, pluggable across PG18 (default) and SQLite — both backends compiled in, runtime-selected
 via config.
@@ -226,282 +226,53 @@ All 17 Rust builtins are available globally in `.lua` scripts — no `require` n
 `M.client(url, opts)` then `c:method()`. A few utilities (`ansi`, `url`, `version`) are pure
 functions and can be called directly off the module table.
 
-| Module                          | Description                                                                                           |
-| ------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| **Monitoring**                  |                                                                                                       |
-| `assay.prometheus`              | PromQL queries, alerts, targets, rules, series                                                        |
-| `assay.alertmanager`            | Alerts, silences, receivers                                                                           |
-| `assay.loki`                    | Log push, query (LogQL), labels, series                                                               |
-| `assay.grafana`                 | Health, dashboards, datasources, annotations                                                          |
-| **Kubernetes & GitOps**         |                                                                                                       |
-| `assay.k8s`                     | 30+ resource types, CRDs, readiness, pod logs                                                         |
-| `assay.argocd`                  | Apps, sync, health, projects, repositories                                                            |
-| `assay.kargo`                   | Stages, freight, promotions, pipelines                                                                |
-| `assay.flux`                    | GitRepositories, Kustomizations, HelmReleases                                                         |
-| `assay.traefik`                 | Routers, services, middlewares                                                                        |
-| **Security & Identity**         |                                                                                                       |
-| `assay.vault` / `assay.openbao` | KV secrets, transit, PKI, policies                                                                    |
-| `assay.certmanager`             | Certificates, issuers, ACME                                                                           |
-| `assay.eso`                     | ExternalSecrets, SecretStores                                                                         |
-| `assay.dex`                     | OIDC discovery, JWKS                                                                                  |
-| `assay.zitadel`                 | OIDC identity, JWT machine auth                                                                       |
-| `assay.ory.kratos`              | Ory Kratos — login/registration/recovery flows, identities, sessions                                  |
-| `assay.ory.hydra`               | Ory Hydra — OAuth2/OIDC clients, authorize, tokens, login/consent/logout                              |
-| `assay.ory.keto`                | Ory Keto — ReBAC relation tuples, permission checks, expand                                           |
-| `assay.ory.rbac`                | Capability-based RBAC engine over Keto — define roles + capabilities, query users, manage memberships |
-| `assay.ory`                     | Ory stack umbrella — `ory.connect()` builds kratos/hydra/keto in one call; also re-exports `rbac`     |
-| **Infrastructure**              |                                                                                                       |
-| `assay.crossplane`              | Providers, XRDs, compositions                                                                         |
-| `assay.velero`                  | Backups, restores, schedules                                                                          |
-| `assay.harbor`                  | Projects, repos, vulnerability scanning                                                               |
-| `assay.tailscale`               | OAuth2 client_credentials, mint auth keys, list/find/get devices, set key expiry, tags, ACL preview   |
-| `assay.apt`                     | Read Debian `Packages.{gz,xz,zst,plain}` indexes, parse stanzas, sorted versions via `assay.version`  |
-| **Data & Storage**              |                                                                                                       |
-| `assay.postgres`                | User/database management, grants                                                                      |
-| `assay.s3`                      | S3-compatible storage with Sig V4 auth                                                                |
-| `assay.unleash`                 | Feature flags, environments, strategies                                                               |
-| `assay.healthcheck`             | HTTP checks, JSON path, latency                                                                       |
-| **AI Agent**                    |                                                                                                       |
-| `assay.openclaw`                | Agent tools, state, diff, approve, LLM tasks                                                          |
-| `assay.gitlab`                  | Projects, repos, commits, MRs, pipelines, registry                                                    |
-| `assay.github`                  | PRs, issues, actions, repos, GraphQL                                                                  |
-| `assay.gmail`                   | Search, read, reply, send (OAuth2)                                                                    |
-| `assay.gcal`                    | Calendar events CRUD (OAuth2)                                                                         |
-| `assay.oauth2`                  | Google OAuth2 token management                                                                        |
-| `assay.email_triage`            | Email classification and triage                                                                       |
-| **Utilities & Text**            |                                                                                                       |
-| `assay.ansi`                    | ANSI SGR → HTML conversion + stripper for browser-facing log viewers                                  |
-| `assay.url`                     | RFC 3986 percent-encoding + form-body builder (`url.encode`, `url.encode_form`, `url.decode`)         |
-| `assay.version`                 | Compare versions across semver / debian / rpm / numeric schemes                                       |
-| `assay.compress` (builtin)      | gunzip / unxz / unzstd — bytes in, bytes out                                                          |
+The table below is generated by `assay site/build.lua` from the `category:` frontmatter in each
+`docs/modules/<slug>.md`. Edit the frontmatter / docs, not the table.
 
-## Examples
+<!-- BEGIN STDLIB TABLE -->
+<!-- Generated by site/build.lua from docs/modules/*.md frontmatter — do not edit by hand. -->
 
-### Kubernetes Health Check
+| Module | Description |
+| --- | --- |
+| **Monitoring & Observability** | |
+| `assay.alertmanager` |  |
+| `assay.grafana` |  |
+| `assay.loki` |  |
+| `assay.prometheus` |  |
+| **Kubernetes & GitOps** | |
+| `assay.argocd` |  |
+| `assay.flux` |  |
+| `assay.k8s` |  |
+| `assay.kargo` |  |
+| `assay.traefik` |  |
+| **Security & Identity** | |
+| `assay.certmanager` |  |
+| `assay.dex` |  |
+| `assay.eso` |  |
+| `assay.openbao` |  |
+| `assay.ory` |  |
+| `assay.vault` |  |
+| `assay.zitadel` |  |
+| **Infrastructure** | |
+| `assay.apt` |  |
+| `assay.crossplane` |  |
+| `assay.harbor` |  |
+| `assay.tailscale` |  |
+| `assay.velero` |  |
+| **Data & Storage** | |
+| `assay.postgres` |  |
+| `assay.s3` |  |
+| **Feature Flags & Health** | |
+| `assay.healthcheck` |  |
+| `assay.unleash` |  |
+| **Text, URLs & Versions** | |
+| `assay.ansi` |  |
+| `assay.url` |  |
+| `assay.version` |  |
+| **AI Agents & Workflow** | |
+| `assay.ai-agents` |  |
+| `assay.github` |  |
+| `assay.gitlab` |  |
+| `assay.workflow` |  |
 
-```lua
-#!/usr/bin/assay
-local k8s = require("assay.k8s")
-local c = k8s.client("https://kubernetes.default.svc", {
-  token = fs.read("/var/run/secrets/kubernetes.io/serviceaccount/token"),
-})
-
-local deploy = c:deployment("default", "my-app")
-assert.eq(deploy.status.readyReplicas, deploy.spec.replicas, "Not all replicas ready")
-log.info("Deployment ready: " .. deploy.metadata.name)
-```
-
-### Web Server with SSE
-
-```lua
-#!/usr/bin/assay
-http.serve(8080, {
-  GET = {
-    ["/health"] = function(req)
-      return { status = 200, json = { ok = true } }
-    end,
-    ["/login"] = function(req)
-      -- Array header values emit the same header name multiple times.
-      -- Required for setting multiple Set-Cookie values in one response.
-      return {
-        status = 200,
-        headers = {
-          ["Set-Cookie"] = {
-            "session=abc; Path=/; HttpOnly",
-            "csrf=xyz; Path=/",
-          },
-        },
-        json = { ok = true },
-      }
-    end,
-    ["/events"] = function(req)
-      return {
-        sse = function(send)
-          send({ data = "connected" })
-          for i = 1, 10 do
-            sleep(1)
-            send({ event = "update", data = json.encode({ count = i }), id = tostring(i) })
-          end
-        end
-      }
-    end
-  }
-})
-```
-
-### YAML Check Mode
-
-```yaml
-timeout: 120s
-retries: 3
-backoff: 5s
-
-checks:
-  - name: api-health
-    type: http
-    url: https://api.example.com/health
-    expect:
-      status: 200
-      json: ".status == \"healthy\""
-
-  - name: prometheus-targets
-    type: prometheus
-    url: http://prometheus:9090
-    query: "count(up)"
-    expect:
-      min: 1
-```
-
-```bash
-assay checks.yaml   # Exit 0 if all pass, 1 if any fail
-```
-
-## OpenClaw Integration
-
-Assay integrates with [OpenClaw](https://openclaw.dev) as an agent tool with human approval gates:
-
-```bash
-assay run --mode tool script.lua              # Structured JSON output for agents
-assay resume --token <token> --approve yes    # Resume after human approval
-```
-
-Install the extension: `openclaw plugins install @developerinlondon/assay-openclaw-extension`
-
-## Module Discovery
-
-Find the right module before writing code:
-
-```bash
-assay context "grafana"   # Returns method signatures for LLM prompts
-assay context "vault"     # Exact API docs, no hallucination
-assay modules             # List all 51 modules
-```
-
-Custom modules: place `.lua` files in `./modules/` (project) or `~/.assay/modules/` (global).
-
-## Managing the workflow engine from the CLI
-
-Once `assay serve` is running, the same binary manages it via REST:
-
-```bash
-# Start a workflow, wait for it to complete (exit 0/1/2 for scripts).
-assay workflow start --type MyFlow --input '{"x":1}' --id wf-42
-assay workflow wait wf-42 --timeout 300
-
-# List + filter + inspect.
-assay workflow list --status RUNNING --search-attrs '{"env":"prod"}'
-assay workflow describe wf-42
-assay workflow events wf-42 --follow        # polls until terminal
-assay workflow state wf-42 pipeline_stage   # register_query reader
-
-# Signal / cancel / terminate.
-assay workflow signal wf-42 approve '{"by":"alice"}'
-assay workflow cancel wf-42
-assay workflow terminate wf-42 --reason "wrong input"
-
-# Schedules (full lifecycle without a delete-and-recreate cycle).
-assay schedule create nightly --type Report --cron '0 0 2 * * *' \
-    --timezone Europe/Berlin --input '{"lookback":24}'
-assay schedule patch nightly --cron '0 0 3 * * *'
-assay schedule pause nightly
-assay schedule resume nightly
-
-# Namespaces, workers, queues.
-assay namespace create tenant-acme
-assay namespace describe main   # live counts
-assay worker list
-assay queue stats
-```
-
-**Configuration** (in precedence order — flag > env > config file > default):
-
-```bash
-assay workflow list --engine-url http://engine:8080 --api-key sk_xxxx
-
-# Or via env (fits Kubernetes Secret → env patterns):
-export ASSAY_ENGINE_URL=https://assay.example.com
-export ASSAY_API_KEY=sk_xxxx
-assay workflow list
-
-# Or via a YAML config file — auto-discovered at
-# --config FLAG / $ASSAY_CONFIG_FILE / $XDG_CONFIG_HOME/assay/config.yaml /
-# ~/.config/assay/config.yaml / /etc/assay/config.yaml.
-cat >/etc/assay/config.yaml <<'YAML'
-engine_url: https://assay.example.com
-api_key_file: /run/secrets/assay-api-key    # preferred — keeps secrets out of env
-namespace: main
-output: table
-YAML
-```
-
-**Output formats.** Default is `table` on a TTY, `json` when stdout is piped. Override per-call:
-
-```bash
-assay workflow list --output json | jq '.[].id'
-assay workflow list --output jsonl | head -5      # streaming-friendly
-assay workflow list --output yaml
-```
-
-**JSON input anywhere** — literal, `@file`, or `-` for stdin:
-
-```bash
-assay workflow start --type MyFlow --input @request.json
-echo '{"k":"v"}' | assay workflow signal wf-1 go -
-```
-
-**Shell completion.** Writes a script for bash / zsh / fish / powershell / elvish:
-
-```bash
-assay completion bash > /etc/bash_completion.d/assay
-assay completion zsh  > "${fpath[1]}/_assay"
-assay completion fish > ~/.config/fish/completions/assay.fish
-```
-
-**Exit codes:** 0 success · 1 HTTP error / unreachable / not-found · 2 `workflow wait` timeout · 64
-usage error (bad JSON).
-
-Prefer the Lua stdlib for automation — `local workflow = require("assay.workflow")` mirrors the same
-surface programmatically without spawning a subprocess per call. The CLI is for humans at a terminal
-and one-shot shell scripts.
-
-## Development
-
-```bash
-cargo build --release -p assay-lua      # Lua runtime binary (~12 MB)
-cargo build --release -p assay-engine \
-    --features backend-postgres,backend-sqlite,auth   # Workflow + auth server (~19 MB)
-cargo clippy --workspace -- -D warnings
-cargo test --workspace
-dprint fmt                              # Format (Rust, Markdown, YAML, JSON, TOML)
-```
-
-The workspace splits across six crates: `assay-domain` (shared types + traits), `assay-workflow`
-(Temporal-replacement engine), `assay-auth` (Ory-replacement IdP), `assay-dashboard` (the SPA),
-`assay-engine` (composer + binary), and `assay-lua` / `assay` (the Lua runtime). Both
-`backend-
-postgres` and `backend-sqlite` features are additive — both compile in by default and the
-active backend is picked at runtime via `engine.toml`.
-
-## License
-
-Assay is licensed under the [Apache License, Version 2.0](LICENSE). You can use, modify, and
-redistribute it freely — including in commercial and proprietary products — as long as you preserve
-the copyright notice and the license text.
-
-## Contributing
-
-Pull requests are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for the workflow and
-[CLA.md](CLA.md) for the Contributor License Agreement that all contributors are required to sign
-(it lets the project owner relicense or incorporate contributions into commercial editions in the
-future, while you keep the copyright on your contribution).
-
-## Links
-
-- **Website**: https://assay.rs
-- **Crate**: https://crates.io/crates/assay-lua
-- **Docker**: `ghcr.io/developerinlondon/assay:latest`
-- **Changelog**: https://assay.rs/changelog.html
-- **Module Reference**: https://assay.rs/modules.html
-- **Comparison**: https://assay.rs/comparison.html
-- **Agent Guides**: https://assay.rs/agent-guides.html
-- **LLM Context**: https://assay.rs/llms.txt
+<!-- END STDLIB TABLE --><!-- END STDLIB TABLE -->

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: assay
-description: Infrastructure scripting runtime — 51 modules for Kubernetes, ArgoCD, Vault, Prometheus, HTTP servers, AI agents, databases. Replaces kubectl, Python, Node.js, curl, jq in one 9 MB binary.
+description: Infrastructure scripting runtime — 60 modules for Kubernetes, ArgoCD, Vault, Prometheus, HTTP servers, AI agents, databases. Replaces kubectl, Python, Node.js, curl, jq in one ~12 MB binary.
 metadata:
   author: developerinlondon
   version: "0.6.1"
@@ -8,7 +8,7 @@ metadata:
 
 # Assay Skill — LLM Agent Guide
 
-Assay is a single ~9 MB static binary that runs Lua scripts in Kubernetes. It replaces 50-250 MB
+Assay is a single ~12 MB static binary that runs Lua scripts in Kubernetes. It replaces 50-250 MB
 Python/Node/kubectl containers in K8s Jobs. One binary, two modes: run a `.lua` script directly, or
 run a `.yaml` check config with retry/backoff/structured output.
 
@@ -44,7 +44,7 @@ assay modules
 | `assay exec -e 'lua code'`  | Evaluate Lua inline                           |
 | `assay exec script.lua`     | Run Lua file via exec subcommand              |
 | `assay context "<keyword>"` | Find modules matching keyword, shows quickref |
-| `assay modules`             | List all 51 modules (34 stdlib + 17 builtins) |
+| `assay modules`             | List all 60 modules (36 stdlib + 24 builtins) |
 
 ## Discovering Modules
 
@@ -274,37 +274,37 @@ block polling) and **management** (inspect/mutate the engine from anywhere, REST
 CLI). Returns parsed JSON on success, nil on a 404 for describe/get_state, raises with HTTP status
 on other non-2xx.
 
-| Function                                                                                | Description                                          |
-| --------------------------------------------------------------------------------------- | ---------------------------------------------------- |
-| `workflow.connect(url, opts?)`                                                          | Verify reachability; opts = `{ token = "Bearer …" }` |
-| `workflow.define(name, function(ctx, input) … end)`                                     | Register a workflow handler (runs as a coroutine)    |
-| `workflow.activity(name, function(ctx, input) … end)`                                   | Register an activity implementation                  |
+| Function                                                                                            | Description                                                                                                    |
+| --------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `workflow.connect(url, opts?)`                                                                      | Verify reachability; opts = `{ token = "Bearer …" }`                                                           |
+| `workflow.define(name, function(ctx, input) … end)`                                                 | Register a workflow handler (runs as a coroutine)                                                              |
+| `workflow.activity(name, function(ctx, input) … end)`                                               | Register an activity implementation                                                                            |
 | `workflow.listen({queue, namespace?, identity?})`                                                   | Block; poll workflow tasks AND activity tasks. **v0.11.10:** `namespace` scopes the worker (default `"main"`). |
 | `workflow.start({workflow_type, workflow_id, namespace?, input?, search_attributes?, task_queue?})` | Start a workflow. **v0.11.10:** `namespace` + `search_attributes` now flow through to the engine.              |
-| `workflow.list({namespace?, status?, type?, search_attrs?, limit?, offset?})`           | List + filter workflows                              |
-| `workflow.describe(id)` / `workflow.get_events(id)`                                     | Inspect                                              |
-| `workflow.get_state(id, name?)`                                                         | Read the latest register_query snapshot (nil on 404) |
-| `workflow.list_children(id)`                                                            | List a parent's child workflows                      |
-| `workflow.signal(id, name, payload?)`                                                   | Send a signal                                        |
-| `workflow.cancel(id)` / `workflow.terminate(id, reason?)`                               | Graceful / hard stop                                 |
-| `workflow.continue_as_new(id, input?)`                                                  | Client-side continue-as-new (distinct from `ctx:`)   |
-| `workflow.schedules.{create, list, describe, patch, pause, resume, delete}`             | Full schedule management                             |
-| `workflow.namespaces.{create, list, describe, stats, delete}`                           | Namespace management                                 |
-| `workflow.workers.list(opts?)` / `workflow.queues.stats(opts?)`                         | Engine-state inspection                              |
+| `workflow.list({namespace?, status?, type?, search_attrs?, limit?, offset?})`                       | List + filter workflows                                                                                        |
+| `workflow.describe(id)` / `workflow.get_events(id)`                                                 | Inspect                                                                                                        |
+| `workflow.get_state(id, name?)`                                                                     | Read the latest register_query snapshot (nil on 404)                                                           |
+| `workflow.list_children(id)`                                                                        | List a parent's child workflows                                                                                |
+| `workflow.signal(id, name, payload?)`                                                               | Send a signal                                                                                                  |
+| `workflow.cancel(id)` / `workflow.terminate(id, reason?)`                                           | Graceful / hard stop                                                                                           |
+| `workflow.continue_as_new(id, input?)`                                                              | Client-side continue-as-new (distinct from `ctx:`)                                                             |
+| `workflow.schedules.{create, list, describe, patch, pause, resume, delete}`                         | Full schedule management                                                                                       |
+| `workflow.namespaces.{create, list, describe, stats, delete}`                                       | Namespace management                                                                                           |
+| `workflow.workers.list(opts?)` / `workflow.queues.stats(opts?)`                                     | Engine-state inspection                                                                                        |
 
 Workflow handler `ctx`:
 
-| Method                                     | Returns         | Notes                                                                                                        |
-| ------------------------------------------ | --------------- | ------------------------------------------------------------------------------------------------------------ |
-| `ctx:execute_activity(name, input, opts?)` | activity result | Sync; raises after retries exhausted                                                                         |
-| `ctx:execute_parallel(activities)`         | list of results | **v0.11.3**: fan out; handler resumes only when all terminal. Raises if any fail.                            |
-| `ctx:sleep(seconds)`                       | nil             | Durable timer; survives worker restart                                                                       |
-| `ctx:wait_for_signal(name, opts?)`         | signal payload  | Block until matching signal arrives. **v0.11.9**: `opts.timeout` bounds the wait; returns nil on timeout.    |
-| `ctx:start_child_workflow(type, opts)`     | child result    | `opts.workflow_id` required and deterministic                                                                |
-| `ctx:side_effect(name, fn)`                | value of fn()   | Run once, cache in event log; use for `crypto.uuid()`, `os.time()`, anything non-deterministic               |
-| `ctx:register_query(name, fn)`             | nil             | **v0.11.3**: expose live state via `GET /workflows/{id}/state`. Handler runs on every replay.                |
-| `ctx:upsert_search_attributes(patch)`      | nil             | **v0.11.3**: merge into the workflow's indexed metadata; callers filter with `workflow.list({search_attrs})` |
-| `ctx:continue_as_new(input)`               | nil (yields)    | **v0.11.3**: close this run, start a fresh one with empty history; same type/namespace/queue                 |
+| Method                                     | Returns         | Notes                                                                                                                                 |
+| ------------------------------------------ | --------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `ctx:execute_activity(name, input, opts?)` | activity result | Sync; raises after retries exhausted                                                                                                  |
+| `ctx:execute_parallel(activities)`         | list of results | **v0.11.3**: fan out; handler resumes only when all terminal. Raises if any fail.                                                     |
+| `ctx:sleep(seconds)`                       | nil             | Durable timer; survives worker restart                                                                                                |
+| `ctx:wait_for_signal(name, opts?)`         | signal payload  | Block until matching signal arrives. **v0.11.9**: `opts.timeout` bounds the wait; returns nil on timeout.                             |
+| `ctx:start_child_workflow(type, opts)`     | child result    | `opts.workflow_id` required and deterministic                                                                                         |
+| `ctx:side_effect(name, fn)`                | value of fn()   | Run once, cache in event log; use for `crypto.uuid()`, `os.time()`, anything non-deterministic                                        |
+| `ctx:register_query(name, fn)`             | nil             | **v0.11.3**: expose live state via `GET /workflows/{id}/state`. Handler runs on every replay.                                         |
+| `ctx:upsert_search_attributes(patch)`      | nil             | **v0.11.3**: merge into the workflow's indexed metadata; callers filter with `workflow.list({search_attrs})`                          |
+| `ctx:continue_as_new(input)`               | nil (yields)    | **v0.11.3**: close this run, start a fresh one with empty history; same type/namespace/queue                                          |
 | `ctx:cancel(reason?)`                      | never (raises)  | **v0.11.11**: terminate the workflow with engine status `CANCELLED`. Self-decided cancel; not the same as an external cancel request. |
 
 **Dashboard** at `/workflow/` — read-only views in v0.11.2; **v0.11.3** adds tier-1 operator
@@ -325,16 +325,16 @@ create/delete, engine version shown in the status bar.
 embedded `/workflow` dashboard per-deployment — brand name (`_NAME`), mark-badge glyph (`_MARK`;
 v0.11.11), subtitle (`_SUBTITLE`; v0.11.11), logo image (`_LOGO_URL`), browser title
 (`_PAGE_TITLE`), parent-app back-link (`_PARENT_URL` + `_PARENT_NAME`), API Docs link override /
-hide (`_API_DOCS_URL`; set to `""` to hide), and an extra stylesheet URL (`_CSS_URL`) loaded
-after assay's own CSS for re-skinning via CSS custom properties. Any customised identity flips
-the footer to `Powered by Assay Workflow Engine vX.Y.Z` with a link to https://assay.rs
-(v0.11.11). Every knob defaults to assay's identity; unset env keeps the standalone experience
-unchanged. Use when embedding assay inside another admin UI. Full table + theme tokens in
+hide (`_API_DOCS_URL`; set to `""` to hide), and an extra stylesheet URL (`_CSS_URL`) loaded after
+assay's own CSS for re-skinning via CSS custom properties. Any customised identity flips the footer
+to `Powered by Assay Workflow Engine vX.Y.Z` with a link to https://assay.rs (v0.11.11). Every knob
+defaults to assay's identity; unset env keeps the standalone experience unchanged. Use when
+embedding assay inside another admin UI. Full table + theme tokens in
 `docs/modules/workflow.md#dashboard-whitelabel`.
 
 ## Stdlib Modules Quick Reference
 
-All 35 modules follow `require("assay.<name>")` then `M.client(url, opts)`.
+All 36 stdlib modules follow `require("assay.<name>")` then `M.client(url, opts)`.
 
 | Module               | Description                                                                                                                                                      |
 | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -597,7 +597,7 @@ hardcode credentials in scripts.
 **Shebang scripts**: Add `#!/usr/bin/assay` as the first line and `chmod +x script.lua` to run
 scripts directly without the `assay` prefix.
 
-**Module not found**: All 34 stdlib modules are embedded in the binary. If `require("assay.foo")`
+**Module not found**: All 36 stdlib modules are embedded in the binary. If `require("assay.foo")`
 fails, run `assay modules` to see the exact module names.
 
 **Lua 5.5 specifics**: Assay uses Lua 5.5 (not LuaJIT). Integer division is `//`, bitwise ops use
@@ -689,7 +689,7 @@ Today: use `assay context <query>` from terminal and paste output into agent con
 
 ## MCP-Serve Vision (v0.6.0)
 
-`assay mcp-serve` will expose all 51 modules (34 stdlib + 17 builtins) as MCP tools over stdio/SSE
+`assay mcp-serve` will expose all 60 modules (36 stdlib + 24 builtins) as MCP tools over stdio/SSE
 transport:
 
 - Each stdlib module becomes an MCP tool (e.g., `grafana_health`, `k8s_pods`)

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: assay
-description: Infrastructure scripting runtime — 60 modules for Kubernetes, ArgoCD, Vault, Prometheus, HTTP servers, AI agents, databases. Replaces kubectl, Python, Node.js, curl, jq in one ~12 MB binary.
+description: Infrastructure scripting runtime — 65 modules for Kubernetes, ArgoCD, Vault, Prometheus, HTTP servers, AI agents, databases. Replaces kubectl, Python, Node.js, curl, jq in one ~12 MB binary.
 metadata:
   author: developerinlondon
   version: "0.6.1"
@@ -44,7 +44,7 @@ assay modules
 | `assay exec -e 'lua code'`  | Evaluate Lua inline                           |
 | `assay exec script.lua`     | Run Lua file via exec subcommand              |
 | `assay context "<keyword>"` | Find modules matching keyword, shows quickref |
-| `assay modules`             | List all 60 modules (36 stdlib + 24 builtins) |
+| `assay modules`             | List all 65 modules (45 stdlib + 20 builtins) |
 
 ## Discovering Modules
 
@@ -334,7 +334,7 @@ embedding assay inside another admin UI. Full table + theme tokens in
 
 ## Stdlib Modules Quick Reference
 
-All 36 stdlib modules follow `require("assay.<name>")` then `M.client(url, opts)`.
+All 45 stdlib modules follow `require("assay.<name>")` then `M.client(url, opts)`.
 
 | Module               | Description                                                                                                                                                      |
 | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -597,7 +597,7 @@ hardcode credentials in scripts.
 **Shebang scripts**: Add `#!/usr/bin/assay` as the first line and `chmod +x script.lua` to run
 scripts directly without the `assay` prefix.
 
-**Module not found**: All 36 stdlib modules are embedded in the binary. If `require("assay.foo")`
+**Module not found**: All 45 stdlib modules are embedded in the binary. If `require("assay.foo")`
 fails, run `assay modules` to see the exact module names.
 
 **Lua 5.5 specifics**: Assay uses Lua 5.5 (not LuaJIT). Integer division is `//`, bitwise ops use
@@ -689,7 +689,7 @@ Today: use `assay context <query>` from terminal and paste output into agent con
 
 ## MCP-Serve Vision (v0.6.0)
 
-`assay mcp-serve` will expose all 60 modules (36 stdlib + 24 builtins) as MCP tools over stdio/SSE
+`assay mcp-serve` will expose all 65 modules (45 stdlib + 20 builtins) as MCP tools over stdio/SSE
 transport:
 
 - Each stdlib module becomes an MCP tool (e.g., `grafana_health`, `k8s_pods`)

--- a/crates/assay-engine/Cargo.toml
+++ b/crates/assay-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-engine"
-version = "0.2.0"
+version = "0.2.1"
 categories = ["asynchronous", "database", "web-programming::http-server"]
 edition = "2024"
 keywords = ["workflow", "auth", "oidc", "zanzibar", "postgres"]

--- a/crates/assay-workflow/Cargo.toml
+++ b/crates/assay-workflow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-workflow"
-version = "0.3.0"
+version = "0.3.1"
 categories = ["asynchronous", "database"]
 edition = "2024"
 keywords = ["workflow", "durable-execution", "orchestration", "task-queue"]

--- a/crates/assay-workflow/src/api/workflows.rs
+++ b/crates/assay-workflow/src/api/workflows.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use axum::body::Bytes;
 use axum::extract::{Path, Query, State};
 use axum::routing::{get, post};
 use axum::{Json, Router};
@@ -247,11 +248,19 @@ pub struct CancelBody {
 pub async fn cancel_workflow<S: WorkflowStore>(
     State(state): State<Arc<WorkflowCtx<S>>>,
     Path(id): Path<String>,
-    body: Option<Json<CancelBody>>,
+    body: Bytes,
 ) -> Result<axum::http::StatusCode, AppError> {
-    // Accept either no body (back-compat with callers that just POST
-    // /cancel) or a body with optional reason.
-    let reason = body.and_then(|Json(b)| b.reason);
+    // Accept any of: no body, "{}", "[]", '{"reason":"..."}'. Older Lua stdlib
+    // builds (and any caller that auto-fills empty tables) send "[]" which
+    // does not deserialize into CancelBody; treat such bodies as no-reason
+    // rather than 400. See issue #66.
+    let reason = if body.is_empty() {
+        None
+    } else {
+        serde_json::from_slice::<CancelBody>(&body)
+            .ok()
+            .and_then(|b| b.reason)
+    };
     let cancelled = state.cancel_workflow(&id, reason.as_deref()).await?;
     if cancelled {
         Ok(axum::http::StatusCode::OK)

--- a/crates/assay-workflow/tests/api_integration.rs
+++ b/crates/assay-workflow/tests/api_integration.rs
@@ -140,6 +140,53 @@ async fn signal_and_cancel_workflow() {
     assert_eq!(resp.status(), 404);
 }
 
+// Regression for issue #66: stdlib used to send `[]` (empty Lua table → JSON
+// array) for no-body POSTs, which the Option<Json<CancelBody>> extractor
+// rejected with 400. The handler now consumes raw bytes and tolerates any
+// of: missing body, "{}", "[]", '{"reason":"..."}'.
+#[tokio::test]
+async fn cancel_accepts_any_body_shape() {
+    let (url, _handle) = start_test_server().await;
+    let c = client();
+
+    for (i, body_kind) in ["none", "empty_object", "empty_array", "with_reason"]
+        .iter()
+        .enumerate()
+    {
+        let wf_id = format!("wf-cancel-{i}");
+        c.post(format!("{url}/api/v1/engine/workflow/workflows"))
+            .json(&serde_json::json!({
+                "workflow_type": "Approval",
+                "workflow_id": wf_id,
+            }))
+            .send()
+            .await
+            .unwrap();
+
+        let cancel_url = format!("{url}/api/v1/engine/workflow/workflows/{wf_id}/cancel");
+        let req = c.post(&cancel_url);
+        let req = match *body_kind {
+            "none" => req,
+            "empty_object" => req
+                .header("content-type", "application/json")
+                .body("{}"),
+            "empty_array" => req
+                .header("content-type", "application/json")
+                .body("[]"),
+            "with_reason" => req
+                .header("content-type", "application/json")
+                .body(r#"{"reason":"explicit"}"#),
+            _ => unreachable!(),
+        };
+        let resp = req.send().await.unwrap();
+        assert_eq!(
+            resp.status(),
+            200,
+            "cancel with body_kind={body_kind} should be 200"
+        );
+    }
+}
+
 #[tokio::test]
 async fn worker_register_and_poll() {
     let (url, _handle) = start_test_server().await;

--- a/crates/assay/Cargo.toml
+++ b/crates/assay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-lua"
-version = "0.14.0"
+version = "0.14.1"
 categories = ["command-line-utilities", "development-tools::testing"]
 edition = "2024"
 homepage = "https://assay.rs"
@@ -91,10 +91,15 @@ futures-util = "0.3"
 tokio-tungstenite = { version = "0.28.0", features = ["connect", "rustls-tls-webpki-roots"] }
 
 # Template engine (Jinja2-compatible)
-minijinja = "2.15.1"
+minijinja = { version = "2.15.1", features = ["loader"] }
 
 # Markdown to HTML conversion
 pulldown-cmark = "0.13"
+
+# Decompression (gunzip/unxz/unzstd builtins)
+flate2 = "1"
+xz2 = "0.1"
+zstd = "0.13"
 
 # URL parsing/encoding (used by http server query string decoding)
 url = "2"

--- a/crates/assay/src/discovery.rs
+++ b/crates/assay/src/discovery.rs
@@ -212,6 +212,11 @@ const BUILTINS: &[(&str, &str, &[&str])] = &[
         "Unix timestamp in seconds",
         &["time", "timestamp", "unix", "epoch", "clock", "datetime"],
     ),
+    (
+        "compress",
+        "Decompression: gunzip, unxz, unzstd. Pure binary in/out.",
+        &["compress", "decompress", "gunzip", "gzip", "xz", "lzma", "zstd"],
+    ),
 ];
 
 /// Discover all modules: embedded stdlib + `./modules/` + `~/.assay/modules/` (or `$ASSAY_MODULES_PATH`).

--- a/crates/assay/src/lua/builtins/compress.rs
+++ b/crates/assay/src/lua/builtins/compress.rs
@@ -1,0 +1,43 @@
+//! Decompression builtins: gunzip, unxz, unzstd.
+//!
+//! Each function takes a Lua string (treated as raw bytes) and returns the
+//! decompressed bytes as a Lua string. Lua strings in mlua are byte buffers,
+//! so binary data round-trips cleanly.
+
+use std::io::Read;
+
+pub fn register_compress(lua: &mlua::Lua) -> mlua::Result<()> {
+    let t = lua.create_table()?;
+    t.set("gunzip", lua.create_function(gunzip)?)?;
+    t.set("unxz", lua.create_function(unxz)?)?;
+    t.set("unzstd", lua.create_function(unzstd)?)?;
+    lua.globals().set("compress", t)?;
+    Ok(())
+}
+
+fn gunzip(lua: &mlua::Lua, input: mlua::String) -> mlua::Result<mlua::String> {
+    let bytes = input.as_bytes();
+    let mut decoder = flate2::read::GzDecoder::new(&bytes[..]);
+    let mut out = Vec::new();
+    decoder
+        .read_to_end(&mut out)
+        .map_err(|e| mlua::Error::runtime(format!("compress.gunzip: {e}")))?;
+    lua.create_string(&out)
+}
+
+fn unxz(lua: &mlua::Lua, input: mlua::String) -> mlua::Result<mlua::String> {
+    let bytes = input.as_bytes();
+    let mut decoder = xz2::read::XzDecoder::new(&bytes[..]);
+    let mut out = Vec::new();
+    decoder
+        .read_to_end(&mut out)
+        .map_err(|e| mlua::Error::runtime(format!("compress.unxz: {e}")))?;
+    lua.create_string(&out)
+}
+
+fn unzstd(lua: &mlua::Lua, input: mlua::String) -> mlua::Result<mlua::String> {
+    let bytes = input.as_bytes();
+    let out = zstd::stream::decode_all(&bytes[..])
+        .map_err(|e| mlua::Error::runtime(format!("compress.unzstd: {e}")))?;
+    lua.create_string(&out)
+}

--- a/crates/assay/src/lua/builtins/http.rs
+++ b/crates/assay/src/lua/builtins/http.rs
@@ -420,10 +420,14 @@ async fn execute_http_request(
         return Ok(Value::Table(result));
     }
 
-    // Standard response: buffer full body
-    let body = resp.text().await.map_err(|e| {
+    // Standard response: buffer full body. Use raw bytes (not .text()) so binary
+    // payloads — gzip/xz/zstd, images, tarballs — round-trip cleanly. Lua strings
+    // in mlua are byte buffers, so this remains compatible with existing
+    // text-decoding callers.
+    let body_bytes = resp.bytes().await.map_err(|e| {
         mlua::Error::runtime(format!("http.{method_name}: reading body failed: {e}"))
     })?;
+    let body = lua.create_string(&body_bytes)?;
 
     let result = lua.create_table()?;
     result.set("status", status)?;

--- a/crates/assay/src/lua/builtins/mod.rs
+++ b/crates/assay/src/lua/builtins/mod.rs
@@ -1,4 +1,5 @@
 mod assert;
+mod compress;
 mod core;
 mod crypto;
 #[cfg(feature = "db")]
@@ -39,5 +40,6 @@ pub fn register_all(lua: &mlua::Lua, client: reqwest::Client) -> mlua::Result<()
     process::register_process(lua)?;
     disk::register_disk(lua)?;
     os_info::register_os(lua)?;
+    compress::register_compress(lua)?;
     Ok(())
 }

--- a/crates/assay/src/lua/builtins/template.rs
+++ b/crates/assay/src/lua/builtins/template.rs
@@ -49,6 +49,29 @@ pub fn register_template(lua: &Lua) -> mlua::Result<()> {
     })?;
     tmpl_table.set("render", render_fn)?;
 
+    let render_with_loader_fn =
+        lua.create_function(|_, (template_dir, template_name, vars): (String, String, Value)| {
+            let json_vars = match &vars {
+                Value::Table(_) => lua_value_to_json(&vars)?,
+                Value::Nil => serde_json::Value::Object(serde_json::Map::new()),
+                _ => {
+                    return Err(mlua::Error::runtime(
+                        "template.render_with_loader: third argument must be a table or nil",
+                    ));
+                }
+            };
+            let mini_vars = minijinja::value::Value::from_serialize(&json_vars);
+            let mut env = minijinja::Environment::new();
+            env.set_loader(minijinja::path_loader(&template_dir));
+            let tmpl = env.get_template(&template_name).map_err(|e| {
+                mlua::Error::runtime(format!("template.render_with_loader: {e}"))
+            })?;
+            tmpl.render(mini_vars).map_err(|e| {
+                mlua::Error::runtime(format!("template.render_with_loader: {e}"))
+            })
+        })?;
+    tmpl_table.set("render_with_loader", render_with_loader_fn)?;
+
     lua.globals().set("template", tmpl_table)?;
     Ok(())
 }

--- a/crates/assay/stdlib/ansi.lua
+++ b/crates/assay/stdlib/ansi.lua
@@ -1,0 +1,169 @@
+--- @module assay.ansi
+--- @description ANSI SGR → HTML conversion + stripper for log viewers. No state, no deps.
+--- @keywords ansi, sgr, escape, html, log, color, terminal
+--- @quickref ansi.to_html(line) -> string | Convert SGR to <span> tags, HTML-escape unsafe chars
+--- @quickref ansi.strip(line) -> string | Drop all CSI sequences, return plain text
+
+local M = {}
+
+local ESC = string.char(27)
+
+local HTML_ESCAPES = {
+  ["&"] = "&amp;",
+  ["<"] = "&lt;",
+  [">"] = "&gt;",
+  ['"'] = "&quot;",
+  ["'"] = "&#39;",
+}
+
+local function html_escape(s)
+  return (s:gsub("[&<>\"']", HTML_ESCAPES))
+end
+
+local function is_fg(code)
+  return (code >= 30 and code <= 37) or (code >= 90 and code <= 97)
+end
+
+local function is_bg(code)
+  return (code >= 40 and code <= 47) or (code >= 100 and code <= 107)
+end
+
+local function parse_params(params)
+  local codes = {}
+  if params == "" then
+    codes[1] = 0
+    return codes
+  end
+  for part in params:gmatch("([^;]*)") do
+    local n = tonumber(part)
+    if n then
+      codes[#codes + 1] = n
+    end
+  end
+  return codes
+end
+
+function M.strip(line)
+  if line == nil or line == "" then
+    return ""
+  end
+  local out = {}
+  local i = 1
+  local len = #line
+  while i <= len do
+    local c = line:sub(i, i)
+    if c == ESC and line:sub(i + 1, i + 1) == "[" then
+      local j = i + 2
+      while j <= len do
+        local b = line:byte(j)
+        if b and b >= 0x40 and b <= 0x7E then
+          break
+        end
+        j = j + 1
+      end
+      i = j + 1
+    else
+      out[#out + 1] = c
+      i = i + 1
+    end
+  end
+  return table.concat(out)
+end
+
+function M.to_html(line)
+  if line == nil or line == "" then
+    return ""
+  end
+
+  local out = {}
+  local fg_open = false
+  local bg_open = false
+  local bold_open = false
+
+  local function close_fg()
+    if fg_open then
+      out[#out + 1] = "</span>"
+      fg_open = false
+    end
+  end
+  local function close_bg()
+    if bg_open then
+      out[#out + 1] = "</span>"
+      bg_open = false
+    end
+  end
+  local function close_bold()
+    if bold_open then
+      out[#out + 1] = "</span>"
+      bold_open = false
+    end
+  end
+  local function close_all()
+    close_fg()
+    close_bg()
+    close_bold()
+  end
+
+  local i = 1
+  local len = #line
+  local text_buf = {}
+
+  local function flush_text()
+    if #text_buf > 0 then
+      out[#out + 1] = html_escape(table.concat(text_buf))
+      text_buf = {}
+    end
+  end
+
+  while i <= len do
+    local c = line:sub(i, i)
+    if c == ESC and line:sub(i + 1, i + 1) == "[" then
+      flush_text()
+      local j = i + 2
+      while j <= len do
+        local b = line:byte(j)
+        if b and b >= 0x40 and b <= 0x7E then
+          break
+        end
+        j = j + 1
+      end
+      local final = line:sub(j, j)
+      local params = line:sub(i + 2, j - 1)
+      if final == "m" then
+        local codes = parse_params(params)
+        for _, code in ipairs(codes) do
+          if code == 0 then
+            close_all()
+          elseif code == 1 then
+            if not bold_open then
+              out[#out + 1] = '<span class="ansi-bold">'
+              bold_open = true
+            end
+          elseif code == 39 then
+            close_fg()
+          elseif code == 49 then
+            close_bg()
+          elseif is_fg(code) then
+            close_fg()
+            out[#out + 1] = '<span class="ansi-fg-' .. code .. '">'
+            fg_open = true
+          elseif is_bg(code) then
+            close_bg()
+            out[#out + 1] = '<span class="ansi-bg-' .. code .. '">'
+            bg_open = true
+          end
+        end
+      end
+      i = j + 1
+    else
+      text_buf[#text_buf + 1] = c
+      i = i + 1
+    end
+  end
+
+  flush_text()
+  close_all()
+  return table.concat(out)
+end
+
+return M

--- a/crates/assay/stdlib/apt.lua
+++ b/crates/assay/stdlib/apt.lua
@@ -1,0 +1,168 @@
+--- @module assay.apt
+--- @description Debian/Ubuntu apt package index reader. Fetches and parses Packages indexes (gz/xz/zstd/plain) from any apt-style HTTP repository.
+--- @keywords apt, debian, ubuntu, packages, package, dpkg, repository, deb, version, index
+--- @quickref apt.packages(opts) -> idx | Fetch and parse a Packages index
+--- @quickref idx:find(name) -> pkg | nil | Look up a package by name
+--- @quickref pkg.version | Newest version (Debian-sorted)
+--- @quickref pkg.versions | All versions, sorted newest first
+
+local M = {}
+
+-- File names tried in order. Compressed first (smaller), plain last as fallback.
+local CANDIDATE_FILES = {
+  { name = "Packages.gz",  decode = "gunzip" },
+  { name = "Packages.xz",  decode = "unxz" },
+  { name = "Packages.zst", decode = "unzstd" },
+  { name = "Packages",     decode = nil },
+}
+
+local function trim(s)
+  return (s:gsub("^%s+", ""):gsub("%s+$", ""))
+end
+
+local function decompress(decode, body)
+  if decode == nil then return body end
+  return compress[decode](body)
+end
+
+local function build_url(opts, file_name)
+  local base = (opts.base_url or ""):gsub("/+$", "")
+  return base
+    .. "/dists/"
+    .. opts.dist
+    .. "/"
+    .. opts.component
+    .. "/binary-"
+    .. opts.arch
+    .. "/"
+    .. file_name
+end
+
+-- Parse a Debian control file (RFC 822-style). Stanzas separated by blank lines;
+-- continuation lines start with whitespace and append to the previous field's value.
+local function parse_stanzas(text)
+  local stanzas = {}
+  local current = {}
+  local last_field = nil
+
+  -- Normalise line endings.
+  text = text:gsub("\r\n", "\n")
+
+  for line in (text .. "\n"):gmatch("([^\n]*)\n") do
+    if line == "" then
+      if next(current) ~= nil then
+        stanzas[#stanzas + 1] = current
+        current = {}
+        last_field = nil
+      end
+    elseif line:match("^[ \t]") then
+      if last_field then
+        current[last_field] = current[last_field] .. "\n" .. trim(line)
+      end
+    else
+      local field, value = line:match("^([^:]+):%s*(.*)$")
+      if field then
+        last_field = field
+        current[field] = value
+      end
+    end
+  end
+  if next(current) ~= nil then
+    stanzas[#stanzas + 1] = current
+  end
+  return stanzas
+end
+
+local function fetch_index_body(opts)
+  local last_status, last_url
+  for _, candidate in ipairs(CANDIDATE_FILES) do
+    local url = build_url(opts, candidate.name)
+    local resp = http.get(url)
+    if resp.status == 200 then
+      return decompress(candidate.decode, resp.body)
+    end
+    last_status, last_url = resp.status, url
+  end
+  error(
+    "apt.packages: no Packages index found (last tried "
+      .. (last_url or "?")
+      .. " HTTP "
+      .. tostring(last_status or "?")
+      .. ")"
+  )
+end
+
+local function sort_versions_desc(versions)
+  local version = require("assay.version")
+  table.sort(versions, function(a, b)
+    return version.compare(a, b, "debian") > 0
+  end)
+  return versions
+end
+
+local function build_index(stanzas)
+  local by_name = {}
+  for _, s in ipairs(stanzas) do
+    local name = s["Package"]
+    local ver = s["Version"]
+    if name and ver then
+      local pkg = by_name[name]
+      if not pkg then
+        pkg = {
+          name = name,
+          versions = {},
+          stanzas = {},
+        }
+        by_name[name] = pkg
+      end
+      pkg.versions[#pkg.versions + 1] = ver
+      pkg.stanzas[#pkg.stanzas + 1] = s
+    end
+  end
+
+  for _, pkg in pairs(by_name) do
+    sort_versions_desc(pkg.versions)
+    -- Newest version is first; surface its stanza fields on the package itself.
+    local newest = pkg.versions[1]
+    local newest_stanza
+    for _, s in ipairs(pkg.stanzas) do
+      if s["Version"] == newest then
+        newest_stanza = s
+        break
+      end
+    end
+    pkg.version = newest
+    pkg.architecture = newest_stanza and newest_stanza["Architecture"]
+    pkg.depends = newest_stanza and newest_stanza["Depends"]
+    pkg.section = newest_stanza and newest_stanza["Section"]
+    pkg.description = newest_stanza and newest_stanza["Description"]
+    pkg.filename = newest_stanza and newest_stanza["Filename"]
+    pkg.sha256 = newest_stanza and newest_stanza["SHA256"]
+    pkg.size = newest_stanza and newest_stanza["Size"]
+  end
+
+  return by_name
+end
+
+--- Fetch and parse an apt Packages index.
+--- @param opts table `{ base_url, dist, component, arch }`
+--- @return table idx Index with `:find(name)` method.
+function M.packages(opts)
+  opts = opts or {}
+  if not opts.base_url then error("apt.packages: opts.base_url required") end
+  if not opts.dist then error("apt.packages: opts.dist required") end
+  if not opts.component then error("apt.packages: opts.component required") end
+  if not opts.arch then error("apt.packages: opts.arch required") end
+
+  local body = fetch_index_body(opts)
+  local stanzas = parse_stanzas(body)
+  local by_name = build_index(stanzas)
+
+  local idx = { _by_name = by_name }
+  function idx:find(name)
+    return self._by_name[name]
+  end
+  return idx
+end
+
+return M

--- a/crates/assay/stdlib/engine/auth.lua
+++ b/crates/assay/stdlib/engine/auth.lua
@@ -94,14 +94,14 @@ function M.client(opts)
 
   local function post(path, body, admin)
     return decode(
-      http.post(engine_url .. path, body or {}, { headers = build_headers(admin) }),
+      http.post(engine_url .. path, body, { headers = build_headers(admin) }),
       true
     )
   end
 
   local function put(path, body, admin)
     return decode(
-      http.put(engine_url .. path, body or {}, { headers = build_headers(admin) }),
+      http.put(engine_url .. path, body, { headers = build_headers(admin) }),
       true
     )
   end

--- a/crates/assay/stdlib/engine/core.lua
+++ b/crates/assay/stdlib/engine/core.lua
@@ -59,7 +59,7 @@ function M.client(opts)
 
   local function post(path, body, admin)
     return decode(
-      http.post(engine_url .. path, body or {}, { headers = build_headers(admin) }),
+      http.post(engine_url .. path, body, { headers = build_headers(admin) }),
       true
     )
   end

--- a/crates/assay/stdlib/engine/workflow.lua
+++ b/crates/assay/stdlib/engine/workflow.lua
@@ -74,9 +74,9 @@ function M.client(opts)
     local url = engine_url .. BASE .. path
     local opts2 = { headers = build_headers() }
     if method == "GET" then return http.get(url, opts2)
-    elseif method == "POST" then return http.post(url, body or {}, opts2)
-    elseif method == "PATCH" then return http.patch(url, body or {}, opts2)
-    elseif method == "PUT" then return http.put(url, body or {}, opts2)
+    elseif method == "POST" then return http.post(url, body, opts2)
+    elseif method == "PATCH" then return http.patch(url, body, opts2)
+    elseif method == "PUT" then return http.put(url, body, opts2)
     elseif method == "DELETE" then return http.delete(url, opts2)
     else error("engine.workflow: unsupported method: " .. method)
     end

--- a/crates/assay/stdlib/github.lua
+++ b/crates/assay/stdlib/github.lua
@@ -1,6 +1,6 @@
 --- @module assay.github
---- @description GitHub REST API client. PRs, issues, actions, repositories, GraphQL. No gh CLI dependency.
---- @keywords github, pr, pull-request, issue, actions, runs, graphql, repository, merge, review, comment
+--- @description GitHub REST API client. PRs, issues, actions, repositories, GraphQL, releases. No gh CLI dependency.
+--- @keywords github, pr, pull-request, issue, actions, runs, graphql, repository, merge, review, comment, release, asset, checksum
 --- @quickref c.pulls:get(repo, number) -> pr | Get pull request details
 --- @quickref c.pulls:list(repo, opts?) -> [pr] | List pull requests
 --- @quickref c.pulls:reviews(repo, number) -> [review] | List PR reviews
@@ -13,6 +13,11 @@
 --- @quickref c.runs:list(repo, opts?) -> {workflow_runs} | List workflow runs
 --- @quickref c.runs:get(repo, run_id) -> run | Get workflow run details
 --- @quickref c:graphql(query, variables?) -> data | Execute GraphQL query
+--- @quickref github.latest_release(owner, repo, opts?) -> release | Get latest release
+--- @quickref github.find_asset(release, name_pattern) -> asset | Match asset by Lua pattern
+--- @quickref github.fetch_asset_text(asset) -> string | Download asset body
+--- @quickref github.fetch_asset_bytes(asset) -> string | Download asset body (alias)
+--- @quickref github.release_checksum(release, opts) -> hex | Look up sibling .sha256 digest
 
 local M = {}
 
@@ -193,6 +198,124 @@ function M.client(opts)
   end
 
   return c
+end
+
+-- ===== Releases (module-level helpers) =====
+
+local function release_headers(token)
+  local h = {
+    ["Accept"] = "application/vnd.github+json",
+  }
+  if token then
+    h["Authorization"] = "Bearer " .. token
+  end
+  return h
+end
+
+local function release_token(opts)
+  return opts.token or env.get("GITHUB_TOKEN") or env.get("GH_TOKEN")
+end
+
+local function release_base_url(opts)
+  local base = opts.base_url or "https://api.github.com"
+  return (base:gsub("/+$", ""))
+end
+
+--- Get the latest release for a repository.
+--- @param owner string Repo owner
+--- @param repo string Repo name
+--- @param opts table? `{ token = "...", base_url = "..." }`
+--- @return table release JSON release with extra `version` field (tag_name with leading "v" stripped)
+function M.latest_release(owner, repo, opts)
+  opts = opts or {}
+  local base_url = release_base_url(opts)
+  local url = base_url .. "/repos/" .. owner .. "/" .. repo .. "/releases/latest"
+  local resp = http.get(url, { headers = release_headers(release_token(opts)) })
+  if resp.status ~= 200 then
+    error("github.latest_release: GET " .. url .. " HTTP " .. resp.status .. ": " .. resp.body)
+  end
+  local rel = json.parse(resp.body)
+  if rel.tag_name then
+    rel.version = (rel.tag_name:gsub("^v", ""))
+  end
+  return rel
+end
+
+--- Find the first asset whose name matches a Lua pattern.
+--- @param release table Release returned by `latest_release`.
+--- @param name_pattern string Lua pattern matched against `asset.name`.
+--- @return table|nil asset
+function M.find_asset(release, name_pattern)
+  if not release or not release.assets then return nil end
+  for _, asset in ipairs(release.assets) do
+    if asset.name and asset.name:match(name_pattern) then
+      return asset
+    end
+  end
+  return nil
+end
+
+--- Download an asset body as text. Lua strings are byte buffers, so this is
+--- safe for binary data too — `fetch_asset_bytes` is provided as an alias
+--- for clarity at the call site.
+--- @param asset table Asset table containing `browser_download_url`.
+--- @return string body
+function M.fetch_asset_text(asset)
+  if not asset or not asset.browser_download_url then
+    error("github.fetch_asset_text: asset missing browser_download_url")
+  end
+  local resp = http.get(asset.browser_download_url)
+  if resp.status ~= 200 then
+    error(
+      "github.fetch_asset_text: GET "
+        .. asset.browser_download_url
+        .. " HTTP "
+        .. resp.status
+    )
+  end
+  return resp.body
+end
+
+--- Alias of `fetch_asset_text`. Lua strings are bytes; both are equivalent.
+function M.fetch_asset_bytes(asset)
+  return M.fetch_asset_text(asset)
+end
+
+--- Look up a checksum recorded in a sibling `<asset>.<digest>` release file.
+--- Common GitHub-release convention: `tool.tar.gz` ships next to
+--- `tool.tar.gz.sha256`, where the latter holds `<hex>  tool.tar.gz`.
+--- @param release table Release table.
+--- @param opts table `{ asset_pattern = "...", digest = "sha256" }`.
+--- @return string hex Lowercase hex digest.
+function M.release_checksum(release, opts)
+  opts = opts or {}
+  local asset_pattern = opts.asset_pattern
+    or error("github.release_checksum: opts.asset_pattern required")
+  local digest = opts.digest or "sha256"
+
+  local primary = M.find_asset(release, asset_pattern)
+  if not primary then
+    error("github.release_checksum: no asset matching pattern: " .. asset_pattern)
+  end
+
+  local checksum_name = primary.name .. "." .. digest
+  local checksum_asset
+  for _, asset in ipairs(release.assets or {}) do
+    if asset.name == checksum_name then
+      checksum_asset = asset
+      break
+    end
+  end
+  if not checksum_asset then
+    error("github.release_checksum: no sibling asset named: " .. checksum_name)
+  end
+
+  local body = M.fetch_asset_text(checksum_asset)
+  local hex = body:match("^(%x+)")
+  if not hex then
+    error("github.release_checksum: could not extract hex digest from: " .. checksum_name)
+  end
+  return hex:lower()
 end
 
 return M

--- a/crates/assay/stdlib/tailscale.lua
+++ b/crates/assay/stdlib/tailscale.lua
@@ -1,0 +1,218 @@
+--- @module assay.tailscale
+--- @description Tailscale REST API client. OAuth2 client_credentials, mint auth keys, list/find devices, manage device key expiry, tags, authorize, delete, ACL preview.
+--- @keywords tailscale, ts, oauth2, authkey, mint, device, tailnet, key-expiry, tags, acl
+--- @quickref tailscale.client(opts?) -> client | OAuth2-authed Tailscale REST client
+--- @quickref c:mint_key(opts) -> key | POST /tailnet/{tailnet}/keys
+--- @quickref c:list_devices() -> [device] | GET /tailnet/{tailnet}/devices
+--- @quickref c:find_device({hostname=...}) -> device|nil | First device whose hostname or name matches
+--- @quickref c:get_device(id) -> device | GET /device/{id}
+--- @quickref c:set_key_expiry(id, {disabled=bool}) -> "changed"|"unchanged" | Idempotent POST /device/{id}/key
+--- @quickref c:authorize_device(id) -> table | POST /device/{id}/authorized
+--- @quickref c:set_device_tags(id, {"tag:..."}) -> table | POST /device/{id}/tags
+--- @quickref c:delete_device(id) -> true | DELETE /device/{id}
+--- @quickref c:acl_test(opts) -> result | POST /tailnet/{tailnet}/acl/preview
+
+local url = require("assay.url")
+
+local M = {}
+
+local DEFAULT_BASE_URL = "https://api.tailscale.com"
+local DEFAULT_TAILNET = "-"
+local DEFAULT_SCOPE = "all:write"
+local TOKEN_SKEW_SECONDS = 30
+
+function M.client(opts)
+  opts = opts or {}
+  local client_id = opts.client_id or env.get("TS_CLIENT_ID")
+  local client_secret = opts.client_secret or env.get("TS_CLIENT_SECRET")
+  if not client_id or client_id == "" then
+    error("tailscale.client: missing client_id (set TS_CLIENT_ID or pass client_id)")
+  end
+  if not client_secret or client_secret == "" then
+    error("tailscale.client: missing client_secret (set TS_CLIENT_SECRET or pass client_secret)")
+  end
+  local base_url = (opts.base_url or DEFAULT_BASE_URL):gsub("/+$", "")
+  local tailnet = opts.tailnet or DEFAULT_TAILNET
+  local scope = opts.scope or DEFAULT_SCOPE
+
+  local cached_token = nil
+  local cached_expires_at = 0
+
+  local function fetch_token()
+    local body = url.encode_form({
+      grant_type = "client_credentials",
+      client_id = client_id,
+      client_secret = client_secret,
+      scope = scope,
+    })
+    local resp = http.post(base_url .. "/api/v2/oauth/token", body, {
+      headers = { ["Content-Type"] = "application/x-www-form-urlencoded" },
+    })
+    if resp.status ~= 200 then
+      error("tailscale.client: token exchange HTTP " .. resp.status .. ": " .. (resp.body or ""))
+    end
+    local parsed = json.parse(resp.body)
+    if not parsed.access_token then
+      error("tailscale.client: token response missing access_token")
+    end
+    cached_token = parsed.access_token
+    local ttl = tonumber(parsed.expires_in) or 3600
+    cached_expires_at = os.time() + ttl
+  end
+
+  local function token()
+    if not cached_token or os.time() >= (cached_expires_at - TOKEN_SKEW_SECONDS) then
+      fetch_token()
+    end
+    return cached_token
+  end
+
+  local function auth_headers()
+    return {
+      ["Authorization"] = "Bearer " .. token(),
+      ["Content-Type"] = "application/json",
+      ["Accept"] = "application/json",
+    }
+  end
+
+  local function api_get(path_str)
+    local resp = http.get(base_url .. path_str, { headers = auth_headers() })
+    if resp.status ~= 200 then
+      error("tailscale: GET " .. path_str .. " HTTP " .. resp.status .. ": " .. (resp.body or ""))
+    end
+    if resp.body == nil or resp.body == "" then return nil end
+    return json.parse(resp.body)
+  end
+
+  local function api_post(path_str, payload)
+    local resp = http.post(base_url .. path_str, payload or {}, { headers = auth_headers() })
+    if resp.status ~= 200 and resp.status ~= 201 and resp.status ~= 204 then
+      error("tailscale: POST " .. path_str .. " HTTP " .. resp.status .. ": " .. (resp.body or ""))
+    end
+    if resp.body == nil or resp.body == "" then return true end
+    local ok, parsed = pcall(json.parse, resp.body)
+    if ok then return parsed end
+    return resp.body
+  end
+
+  local function api_delete(path_str)
+    local resp = http.delete(base_url .. path_str, { headers = auth_headers() })
+    if resp.status ~= 200 and resp.status ~= 204 then
+      error("tailscale: DELETE " .. path_str .. " HTTP " .. resp.status .. ": " .. (resp.body or ""))
+    end
+    return true
+  end
+
+  local c = {}
+  c.tailnet = tailnet
+  c.base_url = base_url
+
+  function c:mint_key(mint_opts)
+    mint_opts = mint_opts or {}
+    local capabilities = {
+      devices = {
+        create = {
+          reusable = mint_opts.reusable and true or false,
+          ephemeral = mint_opts.ephemeral and true or false,
+          preauthorized = mint_opts.preauthorized and true or false,
+          tags = mint_opts.tags or {},
+        },
+      },
+    }
+    local payload = { capabilities = capabilities }
+    if mint_opts.expiry_seconds then
+      payload.expirySeconds = mint_opts.expiry_seconds
+    end
+    if mint_opts.description then
+      payload.description = mint_opts.description
+    end
+    return api_post("/api/v2/tailnet/" .. tailnet .. "/keys", payload)
+  end
+
+  function c:list_devices()
+    local result = api_get("/api/v2/tailnet/" .. tailnet .. "/devices")
+    if type(result) == "table" and result.devices then
+      return result.devices
+    end
+    return result or {}
+  end
+
+  function c:find_device(query)
+    query = query or {}
+    local devices = self:list_devices()
+    if query.hostname then
+      for _, d in ipairs(devices) do
+        if d.hostname == query.hostname then return d end
+      end
+      for _, d in ipairs(devices) do
+        if d.name and (d.name == query.hostname
+            or d.name:sub(1, #query.hostname + 1) == query.hostname .. ".") then
+          return d
+        end
+      end
+    end
+    if query.id then
+      for _, d in ipairs(devices) do
+        if d.id == query.id or d.nodeId == query.id then return d end
+      end
+    end
+    return nil
+  end
+
+  function c:get_device(id)
+    if not id or id == "" then
+      error("tailscale.get_device: missing device id")
+    end
+    return api_get("/api/v2/device/" .. id)
+  end
+
+  function c:set_key_expiry(id, expiry_opts)
+    if not id or id == "" then
+      error("tailscale.set_key_expiry: missing device id")
+    end
+    expiry_opts = expiry_opts or {}
+    local desired = expiry_opts.disabled and true or false
+    local current = self:get_device(id)
+    if current and current.keyExpiryDisabled == desired then
+      return "unchanged"
+    end
+    api_post("/api/v2/device/" .. id .. "/key", { keyExpiryDisabled = desired })
+    return "changed"
+  end
+
+  function c:authorize_device(id)
+    if not id or id == "" then
+      error("tailscale.authorize_device: missing device id")
+    end
+    return api_post("/api/v2/device/" .. id .. "/authorized", { authorized = true })
+  end
+
+  function c:set_device_tags(id, tags)
+    if not id or id == "" then
+      error("tailscale.set_device_tags: missing device id")
+    end
+    if type(tags) ~= "table" then
+      error("tailscale.set_device_tags: tags must be an array of strings")
+    end
+    return api_post("/api/v2/device/" .. id .. "/tags", { tags = tags })
+  end
+
+  function c:delete_device(id)
+    if not id or id == "" then
+      error("tailscale.delete_device: missing device id")
+    end
+    return api_delete("/api/v2/device/" .. id)
+  end
+
+  function c:acl_test(acl_opts)
+    return api_post("/api/v2/tailnet/" .. tailnet .. "/acl/preview", acl_opts or {})
+  end
+
+  return c
+end
+
+function M.acl_test(client, acl_opts)
+  return client:acl_test(acl_opts)
+end
+
+return M

--- a/crates/assay/stdlib/url.lua
+++ b/crates/assay/stdlib/url.lua
@@ -1,0 +1,69 @@
+--- @module assay.url
+--- @description Pure-Lua URL helpers. RFC 3986 percent-encoding plus form-encoded body builder.
+--- @keywords url, urlencode, percent-encode, form, query, encode, decode, www-form-urlencoded
+--- @quickref url.encode(s) -> string | RFC 3986 percent-encode a string (space -> %20)
+--- @quickref url.encode_form(t) -> string | Build application/x-www-form-urlencoded body
+--- @quickref url.decode(s) -> string | Inverse of encode (also turns '+' into space)
+
+local M = {}
+
+local function is_unreserved(b)
+  return (b >= 0x30 and b <= 0x39) -- 0-9
+      or (b >= 0x41 and b <= 0x5A) -- A-Z
+      or (b >= 0x61 and b <= 0x7A) -- a-z
+      or b == 0x2D -- -
+      or b == 0x5F -- _
+      or b == 0x2E -- .
+      or b == 0x7E -- ~
+end
+
+function M.encode(s)
+  if s == nil then return "" end
+  s = tostring(s)
+  local out = {}
+  for i = 1, #s do
+    local b = string.byte(s, i)
+    if is_unreserved(b) then
+      out[#out + 1] = string.char(b)
+    else
+      out[#out + 1] = string.format("%%%02X", b)
+    end
+  end
+  return table.concat(out)
+end
+
+local function stringify(v)
+  if type(v) == "boolean" then
+    return v and "true" or "false"
+  end
+  return tostring(v)
+end
+
+function M.encode_form(t)
+  if t == nil then return "" end
+  if type(t) ~= "table" then
+    error("url.encode_form: expected table, got " .. type(t))
+  end
+  local keys = {}
+  for k, _ in pairs(t) do
+    keys[#keys + 1] = k
+  end
+  table.sort(keys, function(a, b) return tostring(a) < tostring(b) end)
+  local parts = {}
+  for _, k in ipairs(keys) do
+    parts[#parts + 1] = M.encode(stringify(k)) .. "=" .. M.encode(stringify(t[k]))
+  end
+  return table.concat(parts, "&")
+end
+
+function M.decode(s)
+  if s == nil then return "" end
+  s = tostring(s)
+  s = s:gsub("+", " ")
+  s = s:gsub("%%(%x%x)", function(hex)
+    return string.char(tonumber(hex, 16))
+  end)
+  return s
+end
+
+return M

--- a/crates/assay/stdlib/version.lua
+++ b/crates/assay/stdlib/version.lua
@@ -1,0 +1,271 @@
+--- @module assay.version
+--- @description Cross-scheme version comparison: semver, debian, rpm, plain numeric. Pure Lua.
+--- @keywords version, semver, debian, rpm, compare, sort
+--- @quickref version.compare(a, b, scheme?) -> -1|0|1 | Compare two versions; default scheme = "semver"
+--- @quickref version.max(list, scheme?) -> string | Return the largest version in the list
+
+local M = {}
+
+local function sign(n)
+  if n < 0 then return -1 end
+  if n > 0 then return 1 end
+  return 0
+end
+
+-- ===== semver =====
+
+local function strip_v(s)
+  local rest = s:match("^[vV](.*)$")
+  return rest or s
+end
+
+-- Split a semver-style version string into {main, pre} where main is the
+-- dotted core (1.2.3) and pre is the pre-release identifier list (or nil).
+-- Build metadata (after '+') is discarded for ordering per semver spec.
+local function semver_split(s)
+  s = strip_v(s)
+  local plus = s:find("+", 1, true)
+  if plus then s = s:sub(1, plus - 1) end
+
+  local main, pre = s, nil
+  local dash = s:find("-", 1, true)
+  if dash then
+    main = s:sub(1, dash - 1)
+    pre = s:sub(dash + 1)
+  end
+
+  local main_parts = {}
+  for part in main:gmatch("[^%.]+") do
+    main_parts[#main_parts + 1] = part
+  end
+
+  local pre_parts = nil
+  if pre and pre ~= "" then
+    pre_parts = {}
+    for part in pre:gmatch("[^%.]+") do
+      pre_parts[#pre_parts + 1] = part
+    end
+  end
+
+  return main_parts, pre_parts
+end
+
+local function cmp_main_segment(a, b)
+  local an = tonumber(a)
+  local bn = tonumber(b)
+  if an and bn then return sign(an - bn) end
+  if a == b then return 0 end
+  if a < b then return -1 end
+  return 1
+end
+
+local function cmp_pre_id(a, b)
+  local an = tonumber(a)
+  local bn = tonumber(b)
+  if an and bn then return sign(an - bn) end
+  -- Numeric identifiers always have lower precedence than alphanumeric.
+  if an and not bn then return -1 end
+  if bn and not an then return 1 end
+  if a == b then return 0 end
+  if a < b then return -1 end
+  return 1
+end
+
+local function cmp_semver(a, b)
+  local am, ap = semver_split(a)
+  local bm, bp = semver_split(b)
+
+  local n = math.max(#am, #bm)
+  for i = 1, n do
+    local av = am[i] or "0"
+    local bv = bm[i] or "0"
+    local c = cmp_main_segment(av, bv)
+    if c ~= 0 then return c end
+  end
+
+  -- A version with a pre-release has lower precedence than one without.
+  if ap and not bp then return -1 end
+  if bp and not ap then return 1 end
+  if not ap and not bp then return 0 end
+
+  local m = math.max(#ap, #bp)
+  for i = 1, m do
+    local av = ap[i]
+    local bv = bp[i]
+    if av == nil and bv ~= nil then return -1 end
+    if bv == nil and av ~= nil then return 1 end
+    local c = cmp_pre_id(av, bv)
+    if c ~= 0 then return c end
+  end
+  return 0
+end
+
+-- ===== debian / rpm =====
+
+-- Per debian-policy:
+--   * tilde sorts before everything, including the empty string
+--   * letters sort before non-letters
+-- We implement that by mapping each character to an ordering rank, with
+-- tilde getting a rank lower than the "empty / end-of-string" sentinel.
+local function deb_char_rank(c, allow_tilde)
+  if c == nil then return 0 end                    -- end-of-string
+  if allow_tilde and c == "~" then return -1 end   -- tilde sorts before empty
+  local b = string.byte(c)
+  if (b >= 65 and b <= 90) or (b >= 97 and b <= 122) then
+    return b                                       -- letters: keep ASCII order
+  end
+  return b + 256                                   -- everything else sorts after letters
+end
+
+-- Compare two non-digit runs char-by-char with debian rules.
+local function cmp_deb_nondigit(a, b, allow_tilde)
+  local la = #a
+  local lb = #b
+  local n = math.max(la, lb)
+  for i = 1, n do
+    local ca = i <= la and a:sub(i, i) or nil
+    local cb = i <= lb and b:sub(i, i) or nil
+    local ra = deb_char_rank(ca, allow_tilde)
+    local rb = deb_char_rank(cb, allow_tilde)
+    if ra ~= rb then return sign(ra - rb) end
+  end
+  return 0
+end
+
+-- Compare two digit runs numerically (ignoring leading zeros).
+local function cmp_deb_digits(a, b)
+  a = a:gsub("^0+", "")
+  b = b:gsub("^0+", "")
+  if #a ~= #b then return sign(#a - #b) end
+  if a == b then return 0 end
+  if a < b then return -1 end
+  return 1
+end
+
+-- Core debian-style comparator for upstream/revision strings.
+-- allow_tilde=true gives full debian semantics; false gives rpm-like behavior
+-- where '~' is just another non-digit, non-letter character.
+local function cmp_deb_part(a, b, allow_tilde)
+  local i, j = 1, 1
+  local la, lb = #a, #b
+  while i <= la or j <= lb do
+    -- consume non-digit run from each
+    local na, nb = "", ""
+    while i <= la and not a:sub(i, i):match("%d") do
+      na = na .. a:sub(i, i)
+      i = i + 1
+    end
+    while j <= lb and not b:sub(j, j):match("%d") do
+      nb = nb .. b:sub(j, j)
+      j = j + 1
+    end
+    if na ~= nb then
+      local c = cmp_deb_nondigit(na, nb, allow_tilde)
+      if c ~= 0 then return c end
+    end
+
+    -- consume digit run from each
+    local da, db = "", ""
+    while i <= la and a:sub(i, i):match("%d") do
+      da = da .. a:sub(i, i)
+      i = i + 1
+    end
+    while j <= lb and b:sub(j, j):match("%d") do
+      db = db .. b:sub(j, j)
+      j = j + 1
+    end
+    if da ~= db then
+      local c = cmp_deb_digits(da, db)
+      if c ~= 0 then return c end
+    end
+  end
+  return 0
+end
+
+-- Split "[epoch:]upstream[-revision]" into its three parts.
+local function deb_split(s, with_epoch)
+  local epoch = 0
+  local rest = s
+  if with_epoch then
+    local ep, r = s:match("^(%d+):(.*)$")
+    if ep then
+      epoch = tonumber(ep)
+      rest = r
+    end
+  end
+  local upstream, revision = rest, ""
+  local dash = rest:find("-[^-]*$")
+  if dash then
+    upstream = rest:sub(1, dash - 1)
+    revision = rest:sub(dash + 1)
+  end
+  return epoch, upstream, revision
+end
+
+local function cmp_debian(a, b)
+  local ae, au, ar = deb_split(a, true)
+  local be, bu, br = deb_split(b, true)
+  if ae ~= be then return sign(ae - be) end
+  local c = cmp_deb_part(au, bu, true)
+  if c ~= 0 then return c end
+  return cmp_deb_part(ar, br, true)
+end
+
+local function cmp_rpm(a, b)
+  -- rpm comparison: no epoch, no tilde rule (per slice spec).
+  local _, au, ar = deb_split(a, false)
+  local _, bu, br = deb_split(b, false)
+  local c = cmp_deb_part(au, bu, false)
+  if c ~= 0 then return c end
+  return cmp_deb_part(ar, br, false)
+end
+
+-- ===== numeric =====
+
+local function cmp_numeric(a, b)
+  local ap, bp = {}, {}
+  for part in a:gmatch("[^%.]+") do ap[#ap + 1] = tonumber(part) or 0 end
+  for part in b:gmatch("[^%.]+") do bp[#bp + 1] = tonumber(part) or 0 end
+  local n = math.max(#ap, #bp)
+  for i = 1, n do
+    local av = ap[i] or 0
+    local bv = bp[i] or 0
+    if av ~= bv then return sign(av - bv) end
+  end
+  return 0
+end
+
+-- ===== public API =====
+
+local function compare_with_scheme(a, b, scheme)
+  if scheme == "semver" then return cmp_semver(a, b) end
+  if scheme == "debian" then return cmp_debian(a, b) end
+  if scheme == "rpm" then return cmp_rpm(a, b) end
+  if scheme == "numeric" then return cmp_numeric(a, b) end
+  error("version: unknown scheme: " .. tostring(scheme))
+end
+
+function M.compare(a, b, scheme)
+  scheme = scheme or "semver"
+  if type(a) ~= "string" or type(b) ~= "string" then
+    error("version.compare: both arguments must be strings")
+  end
+  return compare_with_scheme(a, b, scheme)
+end
+
+function M.max(list, scheme)
+  scheme = scheme or "semver"
+  if type(list) ~= "table" then
+    error("version.max: first argument must be a table")
+  end
+  local best = nil
+  for i = 1, #list do
+    local v = list[i]
+    if best == nil or compare_with_scheme(v, best, scheme) > 0 then
+      best = v
+    end
+  end
+  return best
+end
+
+return M

--- a/crates/assay/tests/builtins_compress.rs
+++ b/crates/assay/tests/builtins_compress.rs
@@ -1,0 +1,117 @@
+mod common;
+
+use std::io::Write;
+
+use common::{eval_lua, run_lua};
+
+fn gzip_bytes(input: &[u8]) -> Vec<u8> {
+    let mut encoder = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+    encoder.write_all(input).unwrap();
+    encoder.finish().unwrap()
+}
+
+fn xz_bytes(input: &[u8]) -> Vec<u8> {
+    let mut encoder = xz2::write::XzEncoder::new(Vec::new(), 6);
+    encoder.write_all(input).unwrap();
+    encoder.finish().unwrap()
+}
+
+fn zstd_bytes(input: &[u8]) -> Vec<u8> {
+    zstd::stream::encode_all(input, 0).unwrap()
+}
+
+fn lua_string_literal(bytes: &[u8]) -> String {
+    let mut out = String::from("\"");
+    for b in bytes {
+        out.push_str(&format!("\\{}", b));
+    }
+    out.push('"');
+    out
+}
+
+#[tokio::test]
+async fn test_gunzip_round_trip() {
+    let payload = b"hello compress world\nline 2\n";
+    let compressed = gzip_bytes(payload);
+    let lit = lua_string_literal(&compressed);
+    let script = format!(
+        r#"
+        local out = compress.gunzip({lit})
+        assert.eq(out, "hello compress world\nline 2\n")
+        "#
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_unxz_round_trip() {
+    let payload = b"xz compressed payload bytes 12345";
+    let compressed = xz_bytes(payload);
+    let lit = lua_string_literal(&compressed);
+    let script = format!(
+        r#"
+        local out = compress.unxz({lit})
+        assert.eq(out, "xz compressed payload bytes 12345")
+        "#
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_unzstd_round_trip() {
+    let payload = b"zstd compressed payload bytes ABCDE";
+    let compressed = zstd_bytes(payload);
+    let lit = lua_string_literal(&compressed);
+    let script = format!(
+        r#"
+        local out = compress.unzstd({lit})
+        assert.eq(out, "zstd compressed payload bytes ABCDE")
+        "#
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_gunzip_garbage_errors() {
+    let script = r#"compress.gunzip("not actually gzip data")"#;
+    let err = run_lua(script).await.unwrap_err();
+    assert!(
+        err.to_string().contains("compress.gunzip"),
+        "expected compress.gunzip error, got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn test_unxz_garbage_errors() {
+    let script = r#"compress.unxz("not actually xz data")"#;
+    let err = run_lua(script).await.unwrap_err();
+    assert!(
+        err.to_string().contains("compress.unxz"),
+        "expected compress.unxz error, got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn test_unzstd_garbage_errors() {
+    let script = r#"compress.unzstd("not actually zstd data")"#;
+    let err = run_lua(script).await.unwrap_err();
+    assert!(
+        err.to_string().contains("compress.unzstd"),
+        "expected compress.unzstd error, got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn test_gunzip_returns_bytes_with_zero() {
+    let payload: Vec<u8> = vec![0x00, 0x01, 0x02, 0xFF, 0x00, 0xAB];
+    let compressed = gzip_bytes(&payload);
+    let lit = lua_string_literal(&compressed);
+    let script = format!(
+        r#"
+        local out = compress.gunzip({lit})
+        return #out
+        "#
+    );
+    let len: i64 = eval_lua(&script).await;
+    assert_eq!(len, payload.len() as i64);
+}

--- a/crates/assay/tests/builtins_template_loader.rs
+++ b/crates/assay/tests/builtins_template_loader.rs
@@ -1,0 +1,75 @@
+mod common;
+
+use common::run_lua;
+use std::fs;
+use tempfile::tempdir;
+
+#[tokio::test]
+async fn render_with_loader_supports_extends_and_include() {
+    let dir = tempdir().unwrap();
+    let templates = dir.path().join("templates");
+    fs::create_dir(&templates).unwrap();
+    fs::write(
+        templates.join("base.html"),
+        "<html>{% block content %}{% endblock %}</html>",
+    )
+    .unwrap();
+    fs::write(
+        templates.join("page.html"),
+        "{% extends \"base.html\" %}{% block content %}<ul>{% include \"row.html\" %}</ul>{% endblock %}",
+    )
+    .unwrap();
+    fs::write(templates.join("row.html"), "<li>{{ name }}</li>").unwrap();
+
+    let script = format!(
+        r#"
+        local out = template.render_with_loader({:?}, "page.html", {{ name = "hi" }})
+        assert.eq(out, "<html><ul><li>hi</li></ul></html>")
+        "#,
+        templates.to_string_lossy()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn render_with_loader_supports_import_macros() {
+    let dir = tempdir().unwrap();
+    let templates = dir.path().join("templates");
+    fs::create_dir(&templates).unwrap();
+    fs::write(
+        templates.join("macros.html"),
+        "{% macro greet(who) %}hi {{ who }}{% endmacro %}",
+    )
+    .unwrap();
+    fs::write(
+        templates.join("page.html"),
+        "{% import \"macros.html\" as m %}{{ m.greet(name) }}",
+    )
+    .unwrap();
+
+    let script = format!(
+        r#"
+        local out = template.render_with_loader({:?}, "page.html", {{ name = "world" }})
+        assert.eq(out, "hi world")
+        "#,
+        templates.to_string_lossy()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn render_with_loader_errors_on_missing_template() {
+    let dir = tempdir().unwrap();
+    let templates = dir.path().join("templates");
+    fs::create_dir(&templates).unwrap();
+
+    let script = format!(
+        r#"
+        local ok, err = pcall(template.render_with_loader, {:?}, "nope.html", {{}})
+        assert.eq(ok, false)
+        assert.eq(string.find(tostring(err), "render_with_loader") ~= nil, true)
+        "#,
+        templates.to_string_lossy()
+    );
+    run_lua(&script).await.unwrap();
+}

--- a/crates/assay/tests/coroutine_ctx_resume.rs
+++ b/crates/assay/tests/coroutine_ctx_resume.rs
@@ -1,0 +1,79 @@
+// Regression for issue #40 — older assay versions failed at coroutine
+// resume with `error converting Lua nil to function` when a workflow
+// handler called `os.date()` or `ctx:register_query()`. The v0.13.0
+// rewrite moved workflow execution to pure-Lua `coroutine.create` (in
+// `stdlib/engine/workflow/worker.lua`), which inherits globals from the
+// parent state. This test pins that contract by exercising the same
+// code paths the bug reported, without requiring a running engine.
+
+mod common;
+
+use common::run_lua;
+
+#[tokio::test]
+async fn workflow_coroutine_can_call_os_date_and_register_query() {
+    let script = r#"
+        -- Simulate the ctx the worker hands to a workflow function.
+        -- register_query in the real ctx stores into _query_handlers; the
+        -- shape mirrors stdlib/engine/workflow/ctx.lua.
+        local ctx = {
+            _query_handlers = {},
+        }
+        function ctx:register_query(name, fn)
+            self._query_handlers[name] = fn
+        end
+
+        -- This is the exact pattern from the issue: a workflow function
+        -- that calls register_query and os.date on first run.
+        local function workflow(c, input)
+            c:register_query("state", function() return { ok = true } end)
+            local now = os.date("!%Y-%m-%dT%H:%M:%SZ")
+            return { now = now, input = input }
+        end
+
+        local co = coroutine.create(function() return workflow(ctx, { hello = true }) end)
+        local ok, result = coroutine.resume(co)
+
+        assert.eq(ok, true)
+        assert.eq(coroutine.status(co), "dead")
+        assert.eq(type(result), "table")
+        assert.eq(result.input.hello, true)
+        assert.eq(result.now ~= nil and #result.now > 0, true)
+        assert.not_nil(ctx._query_handlers.state)
+
+        -- Query handler is callable from outside the coroutine.
+        local snapshot = ctx._query_handlers.state()
+        assert.eq(snapshot.ok, true)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn coroutine_can_yield_and_resume_with_args() {
+    // Workflow ctx commands work via coroutine.yield -> host resumes with
+    // the result. Verify that round-trip doesn't hit the "nil to function"
+    // class of errors the issue described.
+    let script = r#"
+        local function workflow()
+            local first = coroutine.yield({ type = "Step1" })
+            local second = coroutine.yield({ type = "Step2", got = first })
+            return { final = second }
+        end
+
+        local co = coroutine.create(workflow)
+        local ok, cmd1 = coroutine.resume(co)
+        assert.eq(ok, true)
+        assert.eq(cmd1.type, "Step1")
+
+        local ok2, cmd2 = coroutine.resume(co, "alpha")
+        assert.eq(ok2, true)
+        assert.eq(cmd2.type, "Step2")
+        assert.eq(cmd2.got, "alpha")
+
+        local ok3, result = coroutine.resume(co, "beta")
+        assert.eq(ok3, true)
+        assert.eq(result.final, "beta")
+        assert.eq(coroutine.status(co), "dead")
+    "#;
+    run_lua(script).await.unwrap();
+}

--- a/crates/assay/tests/stdlib_ansi.rs
+++ b/crates/assay/tests/stdlib_ansi.rs
@@ -1,0 +1,129 @@
+mod common;
+
+use common::run_lua;
+
+#[tokio::test]
+async fn test_require_ansi() {
+    let script = r#"
+        local mod = require("assay.ansi")
+        assert.not_nil(mod)
+        assert.not_nil(mod.to_html)
+        assert.not_nil(mod.strip)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_strip_sgr_color() {
+    let script = r#"
+        local ansi = require("assay.ansi")
+        assert.eq(ansi.strip("\27[32mhi\27[0m"), "hi")
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_strip_non_sgr_csi() {
+    let script = r#"
+        local ansi = require("assay.ansi")
+        assert.eq(ansi.strip("\27[2K"), "")
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_strip_preserves_plain_text() {
+    let script = r#"
+        local ansi = require("assay.ansi")
+        assert.eq(ansi.strip("plain text"), "plain text")
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_strip_empty() {
+    let script = r#"
+        local ansi = require("assay.ansi")
+        assert.eq(ansi.strip(""), "")
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_to_html_escapes_unsafe_chars() {
+    let script = r#"
+        local ansi = require("assay.ansi")
+        assert.eq(ansi.to_html("&<>"), "&amp;&lt;&gt;")
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_to_html_fg_color() {
+    let script = r#"
+        local ansi = require("assay.ansi")
+        local out = ansi.to_html("\27[32mok\27[0m")
+        assert.not_nil(string.find(out, '<span class="ansi-fg-32">ok</span>', 1, true))
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_to_html_bold() {
+    let script = r#"
+        local ansi = require("assay.ansi")
+        local out = ansi.to_html("\27[1mB\27[0m")
+        assert.not_nil(string.find(out, '<span class="ansi-bold">B</span>', 1, true))
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_to_html_default_fg_closes_span() {
+    let script = r#"
+        local ansi = require("assay.ansi")
+        local out = ansi.to_html("\27[36mreq\27[39m: x")
+        assert.not_nil(string.find(out, '<span class="ansi-fg-36">req</span>: x', 1, true))
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_to_html_unknown_code_dropped() {
+    let script = r#"
+        local ansi = require("assay.ansi")
+        local out = ansi.to_html("\27[99munknown\27[0m")
+        assert.eq(out, "unknown")
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_to_html_strips_non_sgr_csi() {
+    let script = r#"
+        local ansi = require("assay.ansi")
+        assert.eq(ansi.to_html("\27[2Kafter erase"), "after erase")
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_to_html_empty() {
+    let script = r#"
+        local ansi = require("assay.ansi")
+        assert.eq(ansi.to_html(""), "")
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_to_html_no_unclosed_spans_at_eol() {
+    let script = r#"
+        local ansi = require("assay.ansi")
+        local out = ansi.to_html("\27[31mred")
+        local _, opens = string.gsub(out, "<span", "")
+        local _, closes = string.gsub(out, "</span>", "")
+        assert.eq(opens, closes)
+    "#;
+    run_lua(script).await.unwrap();
+}

--- a/crates/assay/tests/stdlib_apt.rs
+++ b/crates/assay/tests/stdlib_apt.rs
@@ -1,0 +1,142 @@
+mod common;
+
+use std::io::Write;
+
+use common::run_lua;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+const PACKAGES_FIXTURE: &str = "\
+Package: tailscale
+Version: 1.84.3
+Architecture: amd64
+Depends: foo
+
+Package: tailscale
+Version: 1.84.2
+Architecture: amd64
+
+Package: foo
+Version: 1.0
+Architecture: amd64
+";
+
+fn gzip(body: &[u8]) -> Vec<u8> {
+    let mut e = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+    e.write_all(body).unwrap();
+    e.finish().unwrap()
+}
+
+#[tokio::test]
+async fn test_apt_packages_gz() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/dists/noble/main/binary-amd64/Packages.gz"))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(gzip(PACKAGES_FIXTURE.as_bytes())))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local apt = require("assay.apt")
+        local idx = apt.packages({{
+            base_url  = "{}",
+            dist      = "noble",
+            component = "main",
+            arch      = "amd64",
+        }})
+
+        local pkg = idx:find("tailscale")
+        assert.not_nil(pkg)
+        assert.eq(pkg.name, "tailscale")
+        assert.eq(pkg.version, "1.84.3")
+        assert.eq(pkg.versions[1], "1.84.3")
+        assert.eq(pkg.versions[2], "1.84.2")
+        assert.eq(pkg.architecture, "amd64")
+        assert.eq(pkg.depends, "foo")
+
+        local foo = idx:find("foo")
+        assert.eq(foo.version, "1.0")
+
+        local missing = idx:find("nonexistent")
+        assert.eq(missing, nil)
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_apt_packages_plain_fallback() {
+    let server = MockServer::start().await;
+    // .gz, .xz, .zst all 404 — should fall through to plain Packages.
+    Mock::given(method("GET"))
+        .and(path("/dists/noble/main/binary-amd64/Packages.gz"))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/dists/noble/main/binary-amd64/Packages.xz"))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/dists/noble/main/binary-amd64/Packages.zst"))
+        .respond_with(ResponseTemplate::new(404))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/dists/noble/main/binary-amd64/Packages"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(PACKAGES_FIXTURE))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local apt = require("assay.apt")
+        local idx = apt.packages({{
+            base_url  = "{}",
+            dist      = "noble",
+            component = "main",
+            arch      = "amd64",
+        }})
+
+        assert.eq(idx:find("tailscale").version, "1.84.3")
+        assert.eq(idx:find("foo").version, "1.0")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_apt_packages_all_404_errors() {
+    let server = MockServer::start().await;
+    for name in ["Packages.gz", "Packages.xz", "Packages.zst", "Packages"] {
+        Mock::given(method("GET"))
+            .and(path(format!(
+                "/dists/noble/main/binary-amd64/{name}"
+            )))
+            .respond_with(ResponseTemplate::new(404))
+            .mount(&server)
+            .await;
+    }
+
+    let script = format!(
+        r#"
+        local apt = require("assay.apt")
+        apt.packages({{
+            base_url  = "{}",
+            dist      = "noble",
+            component = "main",
+            arch      = "amd64",
+        }})
+        "#,
+        server.uri()
+    );
+    let err = run_lua(&script).await.unwrap_err();
+    assert!(
+        err.to_string().contains("apt.packages"),
+        "expected apt.packages error, got: {err}"
+    );
+}

--- a/crates/assay/tests/stdlib_release_check.rs
+++ b/crates/assay/tests/stdlib_release_check.rs
@@ -1,0 +1,137 @@
+mod common;
+
+use common::run_lua;
+use serde_json::json;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn release_body(server_uri: &str) -> serde_json::Value {
+    json!({
+        "tag_name": "v1.2.3",
+        "name": "Release 1.2.3",
+        "published_at": "2024-01-01T00:00:00Z",
+        "assets": [
+            {
+                "name": "tool-x86_64-unknown-linux-musl.tar.gz",
+                "browser_download_url": format!("{server_uri}/dl/tool.tar.gz"),
+                "size": 100
+            },
+            {
+                "name": "tool-x86_64-unknown-linux-musl.tar.gz.sha256",
+                "browser_download_url": format!("{server_uri}/dl/tool.tar.gz.sha256"),
+                "size": 96
+            }
+        ]
+    })
+}
+
+#[tokio::test]
+async fn test_latest_release_basic() {
+    let server = MockServer::start().await;
+    let body = release_body(&server.uri());
+    Mock::given(method("GET"))
+        .and(path("/repos/octo/tool/releases/latest"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(body))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local github = require("assay.github")
+        local rel = github.latest_release("octo", "tool", {{ base_url = "{}" }})
+        assert.eq(rel.tag_name, "v1.2.3")
+        assert.eq(rel.version, "1.2.3")
+        assert.eq(#rel.assets, 2)
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_find_asset_by_pattern() {
+    let server = MockServer::start().await;
+    let body = release_body(&server.uri());
+    Mock::given(method("GET"))
+        .and(path("/repos/octo/tool/releases/latest"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(body))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local github = require("assay.github")
+        local rel = github.latest_release("octo", "tool", {{ base_url = "{}" }})
+        local sha = github.find_asset(rel, "tar%.gz%.sha256$")
+        assert.not_nil(sha)
+        assert.eq(sha.name, "tool-x86_64-unknown-linux-musl.tar.gz.sha256")
+
+        local missing = github.find_asset(rel, "%.zip$")
+        assert.eq(missing, nil)
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_release_checksum() {
+    let server = MockServer::start().await;
+    let body = release_body(&server.uri());
+    Mock::given(method("GET"))
+        .and(path("/repos/octo/tool/releases/latest"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(body))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/dl/tool.tar.gz.sha256"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(
+            "deadbeefcafebabe0123456789abcdef0123456789abcdef0123456789abcdef  tool-x86_64-unknown-linux-musl.tar.gz\n",
+        ))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local github = require("assay.github")
+        local rel = github.latest_release("octo", "tool", {{ base_url = "{}" }})
+        local hex = github.release_checksum(rel, {{
+            asset_pattern = "tar%.gz$",
+            digest = "sha256",
+        }})
+        assert.eq(hex, "deadbeefcafebabe0123456789abcdef0123456789abcdef0123456789abcdef")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_fetch_asset_text() {
+    let server = MockServer::start().await;
+    let body = release_body(&server.uri());
+    Mock::given(method("GET"))
+        .and(path("/repos/octo/tool/releases/latest"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(body))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/dl/tool.tar.gz.sha256"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("abc123  tool.tar.gz\n"))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local github = require("assay.github")
+        local rel = github.latest_release("octo", "tool", {{ base_url = "{}" }})
+        local asset = github.find_asset(rel, "%.sha256$")
+        local body = github.fetch_asset_text(asset)
+        assert.eq(body, "abc123  tool.tar.gz\n")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}

--- a/crates/assay/tests/stdlib_tailscale.rs
+++ b/crates/assay/tests/stdlib_tailscale.rs
@@ -1,0 +1,391 @@
+mod common;
+
+use common::run_lua;
+use serde_json::json;
+use wiremock::matchers::{body_string_contains, header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn token_response(token: &str, expires_in: u64) -> ResponseTemplate {
+    ResponseTemplate::new(200).set_body_json(json!({
+        "access_token": token,
+        "token_type": "Bearer",
+        "expires_in": expires_in,
+    }))
+}
+
+async fn mount_token(server: &MockServer, token: &str, expires_in: u64) {
+    Mock::given(method("POST"))
+        .and(path("/api/v2/oauth/token"))
+        .and(header("Content-Type", "application/x-www-form-urlencoded"))
+        .and(body_string_contains("grant_type=client_credentials"))
+        .respond_with(token_response(token, expires_in))
+        .mount(server)
+        .await;
+}
+
+#[tokio::test]
+async fn test_require_tailscale() {
+    let script = r#"
+        local mod = require("assay.tailscale")
+        assert.not_nil(mod)
+        assert.not_nil(mod.client)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_tailscale_token_exchange_form_encoded() {
+    let server = MockServer::start().await;
+    mount_token(&server, "tok-abc", 3600).await;
+
+    // Once a token is cached, list_devices should fire and use bearer auth.
+    Mock::given(method("GET"))
+        .and(path("/api/v2/tailnet/-/devices"))
+        .and(header("Authorization", "Bearer tok-abc"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "devices": [] })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local tailscale = require("assay.tailscale")
+        local ts = tailscale.client({{
+          client_id = "ci",
+          client_secret = "cs",
+          base_url = "{}",
+        }})
+        local devs = ts:list_devices()
+        assert.eq(#devs, 0)
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_tailscale_token_body_url_encodes_secret() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/v2/oauth/token"))
+        .and(header("Content-Type", "application/x-www-form-urlencoded"))
+        .and(body_string_contains("grant_type=client_credentials"))
+        .and(body_string_contains("client_secret=a%26b%3Dc%2Bd%25e"))
+        .respond_with(token_response("tok-safe", 3600))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/v2/tailnet/-/devices"))
+        .and(header("Authorization", "Bearer tok-safe"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({ "devices": [] })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local tailscale = require("assay.tailscale")
+        local ts = tailscale.client({{
+          client_id = "ci",
+          client_secret = "a&b=c+d%e",
+          base_url = "{}",
+        }})
+        ts:list_devices()
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_tailscale_mint_key() {
+    let server = MockServer::start().await;
+    mount_token(&server, "tok-mint", 3600).await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/v2/tailnet/-/keys"))
+        .and(header("Authorization", "Bearer tok-mint"))
+        .and(body_string_contains("\"capabilities\""))
+        .and(body_string_contains("\"tag:server\""))
+        .and(body_string_contains("\"expirySeconds\":600"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "k123",
+            "key": "tskey-auth-abc",
+            "expires": "2099-01-01T00:00:00Z",
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local tailscale = require("assay.tailscale")
+        local ts = tailscale.client({{
+          client_id = "ci",
+          client_secret = "cs",
+          base_url = "{}",
+        }})
+        local key = ts:mint_key({{
+          reusable = false,
+          ephemeral = false,
+          preauthorized = true,
+          tags = {{ "tag:server" }},
+          expiry_seconds = 600,
+          description = "test mint",
+        }})
+        assert.eq(key.id, "k123")
+        assert.eq(key.key, "tskey-auth-abc")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_tailscale_list_devices_returns_array() {
+    let server = MockServer::start().await;
+    mount_token(&server, "tok-list", 3600).await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/v2/tailnet/-/devices"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "devices": [
+                { "id": "d1", "hostname": "alpha", "name": "alpha.tail.ts.net" },
+                { "id": "d2", "hostname": "beta",  "name": "beta.tail.ts.net" }
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local tailscale = require("assay.tailscale")
+        local ts = tailscale.client({{ client_id = "ci", client_secret = "cs", base_url = "{}" }})
+        local devs = ts:list_devices()
+        assert.eq(#devs, 2)
+        assert.eq(devs[1].hostname, "alpha")
+        assert.eq(devs[2].id, "d2")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_tailscale_find_device_match_and_miss() {
+    let server = MockServer::start().await;
+    mount_token(&server, "tok-find", 3600).await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/v2/tailnet/-/devices"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "devices": [
+                { "id": "d1", "hostname": "alpha", "name": "alpha.tail.ts.net" },
+                { "id": "d2", "hostname": "beta",  "name": "beta.tail.ts.net" }
+            ]
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local tailscale = require("assay.tailscale")
+        local ts = tailscale.client({{ client_id = "ci", client_secret = "cs", base_url = "{}" }})
+        local hit = ts:find_device({{ hostname = "alpha" }})
+        assert.not_nil(hit)
+        assert.eq(hit.id, "d1")
+        local miss = ts:find_device({{ hostname = "nope" }})
+        assert.eq(miss, nil)
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_tailscale_set_key_expiry_unchanged() {
+    let server = MockServer::start().await;
+    mount_token(&server, "tok-uc", 3600).await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/v2/device/d1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "d1",
+            "hostname": "alpha",
+            "keyExpiryDisabled": true
+        })))
+        .mount(&server)
+        .await;
+
+    // Note: we deliberately do NOT mount the POST. If the module sends one,
+    // wiremock returns 404 and the assay error path will fire — making the
+    // test fail loudly.
+
+    let script = format!(
+        r#"
+        local tailscale = require("assay.tailscale")
+        local ts = tailscale.client({{ client_id = "ci", client_secret = "cs", base_url = "{}" }})
+        local result = ts:set_key_expiry("d1", {{ disabled = true }})
+        assert.eq(result, "unchanged")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_tailscale_set_key_expiry_changed() {
+    let server = MockServer::start().await;
+    mount_token(&server, "tok-ch", 3600).await;
+
+    Mock::given(method("GET"))
+        .and(path("/api/v2/device/d1"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "d1",
+            "hostname": "alpha",
+            "keyExpiryDisabled": false
+        })))
+        .mount(&server)
+        .await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/v2/device/d1/key"))
+        .and(header("Authorization", "Bearer tok-ch"))
+        .and(body_string_contains("\"keyExpiryDisabled\":true"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local tailscale = require("assay.tailscale")
+        local ts = tailscale.client({{ client_id = "ci", client_secret = "cs", base_url = "{}" }})
+        local result = ts:set_key_expiry("d1", {{ disabled = true }})
+        assert.eq(result, "changed")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_tailscale_set_device_tags() {
+    let server = MockServer::start().await;
+    mount_token(&server, "tok-tags", 3600).await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/v2/device/d1/tags"))
+        .and(header("Authorization", "Bearer tok-tags"))
+        .and(body_string_contains("\"tag:foo\""))
+        .and(body_string_contains("\"tag:bar\""))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local tailscale = require("assay.tailscale")
+        local ts = tailscale.client({{ client_id = "ci", client_secret = "cs", base_url = "{}" }})
+        ts:set_device_tags("d1", {{ "tag:foo", "tag:bar" }})
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_tailscale_authorize_device() {
+    let server = MockServer::start().await;
+    mount_token(&server, "tok-auth", 3600).await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/v2/device/d1/authorized"))
+        .and(header("Authorization", "Bearer tok-auth"))
+        .and(body_string_contains("\"authorized\":true"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({})))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local tailscale = require("assay.tailscale")
+        local ts = tailscale.client({{ client_id = "ci", client_secret = "cs", base_url = "{}" }})
+        ts:authorize_device("d1")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_tailscale_delete_device() {
+    let server = MockServer::start().await;
+    mount_token(&server, "tok-del", 3600).await;
+
+    Mock::given(method("DELETE"))
+        .and(path("/api/v2/device/d1"))
+        .and(header("Authorization", "Bearer tok-del"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local tailscale = require("assay.tailscale")
+        local ts = tailscale.client({{ client_id = "ci", client_secret = "cs", base_url = "{}" }})
+        ts:delete_device("d1")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_tailscale_acl_test() {
+    let server = MockServer::start().await;
+    mount_token(&server, "tok-acl", 3600).await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/v2/tailnet/-/acl/preview"))
+        .and(header("Authorization", "Bearer tok-acl"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "matches": [],
+            "user": "alice@example.com",
+            "type": "user"
+        })))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local tailscale = require("assay.tailscale")
+        local ts = tailscale.client({{ client_id = "ci", client_secret = "cs", base_url = "{}" }})
+        local res = ts:acl_test({{ user = "alice@example.com", type = "user" }})
+        assert.eq(res.user, "alice@example.com")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_tailscale_token_endpoint_failure_errors() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/v2/oauth/token"))
+        .respond_with(ResponseTemplate::new(401).set_body_string("nope"))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local tailscale = require("assay.tailscale")
+        local ts = tailscale.client({{ client_id = "ci", client_secret = "cs", base_url = "{}" }})
+        local ok, err = pcall(function() ts:list_devices() end)
+        assert.eq(ok, false)
+        assert.contains(tostring(err), "tailscale")
+        "#,
+        server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}

--- a/crates/assay/tests/stdlib_url.rs
+++ b/crates/assay/tests/stdlib_url.rs
@@ -1,0 +1,135 @@
+mod common;
+
+use common::run_lua;
+
+#[tokio::test]
+async fn test_require_url() {
+    let script = r#"
+        local url = require("assay.url")
+        assert.not_nil(url)
+        assert.not_nil(url.encode)
+        assert.not_nil(url.encode_form)
+        assert.not_nil(url.decode)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_url_encode_space_is_percent_20() {
+    let script = r#"
+        local url = require("assay.url")
+        assert.eq(url.encode("hello world"), "hello%20world")
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_url_encode_unreserved_passthrough() {
+    let script = r#"
+        local url = require("assay.url")
+        assert.eq(url.encode("AZaz09-_.~"), "AZaz09-_.~")
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+// Secrets containing &=+% are the original Tailscale footgun.
+#[tokio::test]
+async fn test_url_encode_form_footgun_chars() {
+    let script = r#"
+        local url = require("assay.url")
+        local s = url.encode("a&b=c+d%e")
+        assert.contains(s, "%26")
+        assert.contains(s, "%3D")
+        assert.contains(s, "%2B")
+        assert.contains(s, "%25")
+        -- raw chars must NOT remain
+        assert.eq(string.find(s, "&", 1, true), nil)
+        assert.eq(string.find(s, "=", 1, true), nil)
+        assert.eq(string.find(s, "+", 1, true), nil)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_url_round_trip_ascii() {
+    let script = r#"
+        local url = require("assay.url")
+        local cases = { "hello world", "a&b=c+d%e", "x/y?z=1" }
+        for _, s in ipairs(cases) do
+            assert.eq(url.decode(url.encode(s)), s)
+        end
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_url_round_trip_unicode() {
+    let script = r#"
+        local url = require("assay.url")
+        local s = "café"
+        assert.eq(url.decode(url.encode(s)), s)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_url_encode_form_basic() {
+    let script = r#"
+        local url = require("assay.url")
+        local body = url.encode_form({ grant_type = "client_credentials", scope = "read write" })
+        assert.contains(body, "grant_type=client_credentials")
+        assert.contains(body, "scope=read%20write")
+        assert.contains(body, "&")
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_url_encode_form_escapes_secret_chars() {
+    let script = r#"
+        local url = require("assay.url")
+        local body = url.encode_form({ client_secret = "a&b=c+d%e" })
+        assert.contains(body, "client_secret=a%26b%3Dc%2Bd%25e")
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_url_encode_form_deterministic_order() {
+    let script = r#"
+        local url = require("assay.url")
+        local body = url.encode_form({ b = "2", a = "1", c = "3" })
+        assert.eq(body, "a=1&b=2&c=3")
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_url_encode_form_stringifies_values() {
+    let script = r#"
+        local url = require("assay.url")
+        local body = url.encode_form({ n = 42, b = true, f = false })
+        assert.contains(body, "n=42")
+        assert.contains(body, "b=true")
+        assert.contains(body, "f=false")
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_url_decode_plus_to_space() {
+    let script = r#"
+        local url = require("assay.url")
+        assert.eq(url.decode("hello+world"), "hello world")
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_url_decode_percent_sequences() {
+    let script = r#"
+        local url = require("assay.url")
+        assert.eq(url.decode("a%26b%3Dc"), "a&b=c")
+    "#;
+    run_lua(script).await.unwrap();
+}

--- a/crates/assay/tests/stdlib_version.rs
+++ b/crates/assay/tests/stdlib_version.rs
@@ -1,0 +1,144 @@
+mod common;
+
+use common::run_lua;
+
+#[tokio::test]
+async fn test_require_version() {
+    let script = r#"
+        local v = require("assay.version")
+        assert.not_nil(v)
+        assert.not_nil(v.compare)
+        assert.not_nil(v.max)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_semver_basics() {
+    let script = r#"
+        local v = require("assay.version")
+        assert.eq(v.compare("1.2.3", "1.2.4"), -1)
+        assert.eq(v.compare("1.2.4", "1.2.3", "semver"), 1)
+        assert.eq(v.compare("1.2.3", "1.2.3", "semver"), 0)
+        assert.eq(v.compare("v0.13.1", "0.13.2", "semver"), -1)
+        assert.eq(v.compare("v1.2.3", "1.2.3", "semver"), 0)
+        -- default scheme is semver
+        assert.eq(v.compare("1.10.0", "1.9.0"), 1)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_semver_prerelease_ordering() {
+    let script = r#"
+        local v = require("assay.version")
+        -- prerelease < release
+        assert.eq(v.compare("1.0.0-alpha", "1.0.0", "semver"), -1)
+        assert.eq(v.compare("1.0.0", "1.0.0-alpha", "semver"), 1)
+        -- alpha < alpha.1
+        assert.eq(v.compare("1.0.0-alpha", "1.0.0-alpha.1", "semver"), -1)
+        -- alpha.1 < beta
+        assert.eq(v.compare("1.0.0-alpha.1", "1.0.0-beta", "semver"), -1)
+        -- beta < rc.1
+        assert.eq(v.compare("1.0.0-beta", "1.0.0-rc.1", "semver"), -1)
+        -- rc.1 < final
+        assert.eq(v.compare("1.0.0-rc.1", "1.0.0", "semver"), -1)
+        -- numeric prerelease id < alphanumeric
+        assert.eq(v.compare("1.0.0-1", "1.0.0-alpha", "semver"), -1)
+        -- build metadata ignored
+        assert.eq(v.compare("1.0.0+build1", "1.0.0+build2", "semver"), 0)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_debian_epoch() {
+    let script = r#"
+        local v = require("assay.version")
+        assert.eq(v.compare("1:1.0", "2.0", "debian"), 1)
+        assert.eq(v.compare("2.0", "1:1.0", "debian"), -1)
+        assert.eq(v.compare("1:1.0", "1:1.0", "debian"), 0)
+        assert.eq(v.compare("1:1.84.3-noble1", "1.84.2", "debian"), 1)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_debian_tilde() {
+    let script = r#"
+        local v = require("assay.version")
+        assert.eq(v.compare("1.0~rc1", "1.0", "debian"), -1)
+        assert.eq(v.compare("1.0", "1.0~rc1", "debian"), 1)
+        assert.eq(v.compare("1.0~rc1", "1.0~rc2", "debian"), -1)
+        assert.eq(v.compare("1.0~rc2", "1.0~rc1", "debian"), 1)
+        -- tilde sorts before letters too
+        assert.eq(v.compare("1.0~", "1.0a", "debian"), -1)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_debian_revision() {
+    let script = r#"
+        local v = require("assay.version")
+        assert.eq(v.compare("1.0-1", "1.0-2", "debian"), -1)
+        assert.eq(v.compare("1.0-2", "1.0-1", "debian"), 1)
+        assert.eq(v.compare("1.0-1", "1.0-1", "debian"), 0)
+        assert.eq(v.compare("1.0-10", "1.0-2", "debian"), 1)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_rpm_no_tilde_rule() {
+    let script = r#"
+        local v = require("assay.version")
+        -- non-tilde cases match debian
+        assert.eq(v.compare("1.2.3", "1.2.4", "rpm"), -1)
+        assert.eq(v.compare("1.0-1", "1.0-2", "rpm"), -1)
+        assert.eq(v.compare("1.10", "1.9", "rpm"), 1)
+        -- in rpm, tilde is treated as a normal character so 1.0~rc1 > 1.0
+        -- (since '~' has byte value 126, after digit/letter handling)
+        local c = v.compare("1.0~rc1", "1.0", "rpm")
+        assert.eq(c, 1)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_numeric() {
+    let script = r#"
+        local v = require("assay.version")
+        assert.eq(v.compare("1.10", "1.9", "numeric"), 1)
+        assert.eq(v.compare("1.9", "1.10", "numeric"), -1)
+        assert.eq(v.compare("1.2", "1.2.0", "numeric"), 0)
+        assert.eq(v.compare("1.2.0", "1.2", "numeric"), 0)
+        assert.eq(v.compare("2.0.0", "1.99.99", "numeric"), 1)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_max() {
+    let script = r#"
+        local v = require("assay.version")
+        assert.eq(v.max({ "1.2", "1.10", "1.9" }, "semver"), "1.10")
+        assert.eq(v.max({ "1.0.0-alpha", "1.0.0-beta", "1.0.0-rc.1", "1.0.0" }, "semver"), "1.0.0")
+        assert.eq(v.max({ "1.0~rc1", "1.0~rc2", "1.0" }, "debian"), "1.0")
+        assert.eq(v.max({ "1.10", "1.9", "1.2" }, "numeric"), "1.10")
+        -- default scheme is semver
+        assert.eq(v.max({ "1.2", "1.10", "1.9" }), "1.10")
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_unknown_scheme_errors() {
+    let script = r#"
+        local v = require("assay.version")
+        local ok, err = pcall(function() return v.compare("1.0", "1.1", "bogus") end)
+        assert.eq(ok, false)
+        assert.contains(tostring(err), "unknown scheme")
+    "#;
+    run_lua(script).await.unwrap();
+}

--- a/docs/migration-to-0.14.1.md
+++ b/docs/migration-to-0.14.1.md
@@ -1,0 +1,59 @@
+# Migrating to assay 0.14.1 / assay-workflow 0.3.1 / assay-engine 0.2.1
+
+Patch release. **No breaking changes.** Read this only if you fall into one of the cases below.
+
+## You're running an `assay-engine` binary
+
+Redeploy from the new release to pick up the `workflow.cancel` empty-body fix (#66). Without the new
+binary, callers that rely on `assay.workflow.cancel` (or any `workflow.client():cancel(id)`) on the
+wire still see 400 errors.
+
+## You consume `assay-workflow` as a library
+
+`cargo update -p assay-workflow` picks up `0.3.1`. The change is internal to the `cancel_workflow`
+handler — request/response contract is wider than before (more body shapes accepted, same outputs).
+No source changes required.
+
+## You write Lua scripts against the assay binary
+
+New stdlib modules are available — none replace anything that already existed:
+
+| Module            | Use it for                                                           |
+| ----------------- | -------------------------------------------------------------------- |
+| `assay.ansi`      | Converting / stripping ANSI escapes in log output                    |
+| `assay.url`       | Percent-encoding URLs and `application/x-www-form-urlencoded` bodies |
+| `assay.tailscale` | Tailscale OAuth2 + REST API (auth keys, devices, ACLs)               |
+| `assay.version`   | Comparing versions across semver / debian / rpm / numeric            |
+| `assay.compress`  | gunzip / unxz / unzstd of HTTP bodies and files                      |
+| `assay.apt`       | Reading `Packages` indexes from apt repositories                     |
+
+`assay.github` gained module-level helpers for GitHub Releases (`github.latest_release`,
+`github.find_asset`, `github.release_checksum`, etc.) — the existing `github.client(...)` API is
+unchanged.
+
+`template.render_with_loader(dir, name, vars)` is new — use it when your template wants to
+`{% extends %}`, `{% include %}`, or `{% import %}` a sibling template. The existing
+`template.render` / `template.render_string` still work for self-contained templates.
+
+## You workaround `workflow.cancel` with a raw HTTP call
+
+You can drop the workaround. Both layers are fixed:
+
+- The stdlib `assay.workflow:cancel(id)` now sends no body and no `Content-Type` header (was sending
+  `Content-Type: application/json` with body `[]`).
+- The server-side handler accepts no body, `{}`, `[]`, or `{"reason":"..."}` — anything reasonable
+  now succeeds.
+
+## You hit issue #40 (Lua coroutine resume nil-to-function)
+
+That bug was filed against `assay 0.10.4` and the long-removed `temporal.worker(...)` API. The
+v0.13.0 engine rewrite replaced the mlua `create_thread` path with pure-Lua `coroutine.create` (see
+`stdlib/engine/workflow/worker.lua`), which inherits globals from the parent state. The 0.14.1
+release adds a regression test (`crates/assay/tests/coroutine_ctx_resume.rs`) pinning this contract
+— no script-side change required.
+
+## You're holding off on #75 (OpenSSL drop)
+
+#75 is intentionally not in this patch. It's tracked for a later minor because it touches the
+`assay-auth` crate and changes a build-time dependency tree (replacing OpenSSL inside `webauthn-rs`
+with RustCrypto).

--- a/docs/modules/ai-agents.md
+++ b/docs/modules/ai-agents.md
@@ -1,3 +1,7 @@
+---
+category: AI Agents & Workflow
+---
+
 ## AI Agent & Workflow
 
 ### assay.openclaw

--- a/docs/modules/alertmanager.md
+++ b/docs/modules/alertmanager.md
@@ -1,3 +1,7 @@
+---
+category: Monitoring & Observability
+---
+
 ## assay.alertmanager
 
 Alertmanager alert and silence management. Query, create, and delete alerts and silences. Client:

--- a/docs/modules/ansi.md
+++ b/docs/modules/ansi.md
@@ -1,3 +1,7 @@
+---
+category: Text, URLs & Versions
+---
+
 ## assay.ansi
 
 ANSI SGR → HTML conversion + stripper for log viewers. Pure Lua, no state, no dependencies — safe to

--- a/docs/modules/ansi.md
+++ b/docs/modules/ansi.md
@@ -1,0 +1,30 @@
+## assay.ansi
+
+ANSI SGR → HTML conversion + stripper for log viewers. Pure Lua, no state, no dependencies — safe to
+call on every log line rendered in a browser.
+
+### `to_html(line) → string`
+
+HTML-escapes `&`, `<`, `>`, `"`, `'` first, then converts SGR (`ESC [ ... m`) sequences into
+`<span class="ansi-...">` tags. Recognised codes: `0` reset, `1` bold (`ansi-bold`), `30..37` /
+`90..97` foreground (`ansi-fg-N`), `40..47` / `100..107` background (`ansi-bg-N`), `39` default fg,
+`49` default bg. Unknown SGR codes and non-SGR CSI sequences (cursor moves, erase line, …) are
+silently dropped. Spans are always closed at reset, default-fg/bg, and end-of-input.
+
+```lua
+local ansi = require("assay.ansi")
+local html = ansi.to_html("\27[32mok\27[0m")
+-- html == '<span class="ansi-fg-32">ok</span>'
+```
+
+### `strip(line) → string`
+
+Removes every ANSI CSI sequence (any final byte in `0x40..0x7E`, not just `m`) and returns the
+surrounding text byte-for-byte. Does **not** HTML-escape — the result is plain text, suitable for
+non-browser sinks.
+
+```lua
+local ansi = require("assay.ansi")
+local plain = ansi.strip("\27[32mhi\27[0m")
+-- plain == "hi"
+```

--- a/docs/modules/apt.md
+++ b/docs/modules/apt.md
@@ -1,0 +1,46 @@
+## assay.apt
+
+Debian/Ubuntu apt package index reader. Fetches a `Packages` index from any apt-style HTTP
+repository, transparently decompressing `.gz` / `.xz` / `.zst` variants, parses the RFC 822-style
+stanzas, and exposes a per-package view with versions sorted newest-first using Debian version
+comparison.
+
+### Functions
+
+- `apt.packages(opts)` → `idx` — Fetch and parse a `Packages` index.
+  - `opts.base_url` — Repository root, e.g. `https://pkgs.tailscale.com/stable/ubuntu`.
+  - `opts.dist` — Distribution suite, e.g. `noble`.
+  - `opts.component` — Component, e.g. `main`.
+  - `opts.arch` — Architecture, e.g. `amd64`.
+
+The module tries `Packages.gz`, `Packages.xz`, `Packages.zst`, then plain `Packages` in that order
+until one returns 200.
+
+### Index methods
+
+- `idx:find(name)` → `pkg | nil` — Look up a package by name.
+
+### Package fields
+
+- `pkg.name` — Package name.
+- `pkg.version` — Newest version (Debian-sorted).
+- `pkg.versions` — All versions, sorted newest first.
+- `pkg.architecture`, `pkg.depends`, `pkg.section`, `pkg.description`, `pkg.filename`, `pkg.sha256`,
+  `pkg.size` — Fields from the newest stanza.
+
+### Example
+
+```lua
+local apt = require("assay.apt")
+
+local idx = apt.packages({
+  base_url  = "https://pkgs.tailscale.com/stable/ubuntu",
+  dist      = "noble",
+  component = "main",
+  arch      = "amd64",
+})
+
+local pkg = idx:find("tailscale")
+print(pkg.version)        -- e.g. "1.84.3"
+print(pkg.versions[1])    -- newest
+```

--- a/docs/modules/apt.md
+++ b/docs/modules/apt.md
@@ -1,3 +1,7 @@
+---
+category: Infrastructure
+---
+
 ## assay.apt
 
 Debian/Ubuntu apt package index reader. Fetches a `Packages` index from any apt-style HTTP

--- a/docs/modules/argocd.md
+++ b/docs/modules/argocd.md
@@ -1,3 +1,7 @@
+---
+category: Kubernetes & GitOps
+---
+
 ## assay.argocd
 
 ArgoCD GitOps application management. Apps, sync, health, projects, repositories, clusters. Client:

--- a/docs/modules/assert.md
+++ b/docs/modules/assert.md
@@ -1,3 +1,7 @@
+---
+category: Builtins
+---
+
 ## assert
 
 Assertion utilities. No `require()` needed. All raise `error()` on failure.

--- a/docs/modules/async.md
+++ b/docs/modules/async.md
@@ -1,3 +1,7 @@
+---
+category: Builtins
+---
+
 ## async
 
 Async task management. No `require()` needed.

--- a/docs/modules/certmanager.md
+++ b/docs/modules/certmanager.md
@@ -1,3 +1,7 @@
+---
+category: Security & Identity
+---
+
 ## assay.certmanager
 
 cert-manager certificate lifecycle. Certificates, issuers, ACME orders and challenges. Client:

--- a/docs/modules/compress.md
+++ b/docs/modules/compress.md
@@ -1,0 +1,22 @@
+## compress
+
+Decompression primitives. Each function takes raw bytes (Lua strings are byte buffers) and returns
+the decompressed bytes as a Lua string. Useful for fetching `.gz` / `.xz` / `.zst` payloads over
+HTTP and feeding them to a parser without shelling out.
+
+### Functions
+
+- `compress.gunzip(bytes)` → `string` — Decompress gzip-encoded bytes.
+- `compress.unxz(bytes)` → `string` — Decompress xz/LZMA2-encoded bytes.
+- `compress.unzstd(bytes)` → `string` — Decompress zstd-encoded bytes.
+
+Each raises a runtime error tagged with the function name (e.g.
+`compress.gunzip: invalid gzip header`) when the input is not a valid stream.
+
+### Example
+
+```lua
+local resp = http.get("https://pkgs.example.com/dists/noble/main/binary-amd64/Packages.gz")
+local text = compress.gunzip(resp.body)
+print(text:sub(1, 200))
+```

--- a/docs/modules/compress.md
+++ b/docs/modules/compress.md
@@ -1,3 +1,7 @@
+---
+category: Builtins
+---
+
 ## compress
 
 Decompression primitives. Each function takes raw bytes (Lua strings are byte buffers) and returns

--- a/docs/modules/crossplane.md
+++ b/docs/modules/crossplane.md
@@ -1,3 +1,7 @@
+---
+category: Infrastructure
+---
+
 ## assay.crossplane
 
 Crossplane infrastructure management. Providers, XRDs, compositions, managed resources. Client:

--- a/docs/modules/crypto.md
+++ b/docs/modules/crypto.md
@@ -1,3 +1,7 @@
+---
+category: Builtins
+---
+
 ## crypto
 
 Cryptography utilities. No `require()` needed.

--- a/docs/modules/db.md
+++ b/docs/modules/db.md
@@ -1,3 +1,7 @@
+---
+category: Builtins
+---
+
 ## db
 
 SQL database access. No `require()` needed. Supports Postgres, MySQL, SQLite via connection URL.

--- a/docs/modules/dex.md
+++ b/docs/modules/dex.md
@@ -1,3 +1,7 @@
+---
+category: Security & Identity
+---
+
 ## assay.dex
 
 Dex OIDC identity provider. Discovery, JWKS, health, and configuration validation. Client:

--- a/docs/modules/eso.md
+++ b/docs/modules/eso.md
@@ -1,3 +1,7 @@
+---
+category: Security & Identity
+---
+
 ## assay.eso
 
 External Secrets Operator. ExternalSecrets, SecretStores, ClusterSecretStores sync status. Client:

--- a/docs/modules/flux.md
+++ b/docs/modules/flux.md
@@ -1,3 +1,7 @@
+---
+category: Kubernetes & GitOps
+---
+
 ## assay.flux
 
 Flux CD GitOps toolkit. GitRepositories, Kustomizations, HelmReleases, notifications, image

--- a/docs/modules/fs.md
+++ b/docs/modules/fs.md
@@ -1,3 +1,7 @@
+---
+category: Builtins
+---
+
 ## fs
 
 Filesystem operations. No `require()` needed.

--- a/docs/modules/github.md
+++ b/docs/modules/github.md
@@ -1,3 +1,7 @@
+---
+category: AI Agents & Workflow
+---
+
 ## assay.github
 
 GitHub REST API client. PRs, issues, actions, repositories, GraphQL, releases. No `gh` CLI

--- a/docs/modules/github.md
+++ b/docs/modules/github.md
@@ -1,0 +1,75 @@
+## assay.github
+
+GitHub REST API client. PRs, issues, actions, repositories, GraphQL, releases. No `gh` CLI
+dependency. Authentication via `GITHUB_TOKEN` / `GH_TOKEN` env vars or explicit `token` opt.
+
+### Client
+
+```lua
+local github = require("assay.github")
+local c = github.client({ token = "...", base_url = "https://api.github.com" })
+```
+
+### Pull Requests (`c.pulls`)
+
+- `c.pulls:get(repo, number)` → `pr` — Get pull request details.
+- `c.pulls:list(repo, opts?)` → `[pr]` — List pull requests. `opts`:
+  `{state, sort, direction, per_page}`.
+- `c.pulls:reviews(repo, number)` → `[review]` — List PR reviews.
+- `c.pulls:merge(repo, number, opts?)` → `result` — Merge a pull request. `opts`:
+  `{merge_method, commit_title, commit_message}`.
+
+### Issues (`c.issues`)
+
+- `c.issues:list(repo, opts?)` → `[issue]` — List issues. `opts`:
+  `{state, labels, sort, direction, per_page}`.
+- `c.issues:get(repo, number)` → `issue` — Get issue details.
+- `c.issues:create(repo, title, body, opts?)` → `issue` — Create an issue. `opts`:
+  `{labels, assignees, milestone}`.
+- `c.issues:create_note(repo, number, body)` → `comment` — Add a comment.
+
+### Repositories (`c.repos`)
+
+- `c.repos:get(repo)` → `repository` — Get repository details.
+
+### Workflow Runs (`c.runs`)
+
+- `c.runs:list(repo, opts?)` → `{workflow_runs}` — List workflow runs.
+- `c.runs:get(repo, run_id)` → `run` — Get workflow run details.
+
+### GraphQL
+
+- `c:graphql(query, variables?)` → `data` — Execute a GraphQL query.
+
+### Releases (module-level)
+
+These are top-level functions on the module — no client needed. Token falls back to `GITHUB_TOKEN` /
+`GH_TOKEN` env vars. Pass `opts.base_url` to point at GitHub Enterprise.
+
+- `github.latest_release(owner, repo, opts?)` → `release` —
+  `GET /repos/{owner}/{repo}/releases/latest`. The returned table has all the JSON fields plus
+  `version` (the `tag_name` with a leading `v` stripped).
+- `github.find_asset(release, name_pattern)` → `asset | nil` — Lua-pattern match on `asset.name`.
+  Returns the first hit.
+- `github.fetch_asset_text(asset)` → `string` — Download `asset.browser_download_url` and return the
+  body.
+- `github.fetch_asset_bytes(asset)` → `string` — Alias of `fetch_asset_text` (Lua strings are
+  bytes).
+- `github.release_checksum(release, opts)` → `hex` — Find a sibling `<asset>.sha256` (or other
+  `opts.digest`) in the release, fetch it, and return the lowercase hex digest. `opts`:
+  `{asset_pattern, digest = "sha256"}`.
+
+### Example
+
+```lua
+local github = require("assay.github")
+
+local rel    = github.latest_release("rustic-rs", "rustic")
+print(rel.version)  -- e.g. "0.10.0"
+
+local sha256 = github.release_checksum(rel, {
+  asset_pattern = "x86_64%-unknown%-linux%-musl%.tar%.gz$",
+  digest        = "sha256",
+})
+print(sha256)
+```

--- a/docs/modules/gitlab.md
+++ b/docs/modules/gitlab.md
@@ -1,3 +1,7 @@
+---
+category: AI Agents & Workflow
+---
+
 ## assay.gitlab
 
 GitLab REST API v4 client. Projects, repositories, commits, merge requests, pipelines, jobs, issues,

--- a/docs/modules/grafana.md
+++ b/docs/modules/grafana.md
@@ -1,3 +1,7 @@
+---
+category: Monitoring & Observability
+---
+
 ## assay.grafana
 
 Grafana monitoring and dashboards. Health, datasources, annotations, alerts, folders. Client:

--- a/docs/modules/harbor.md
+++ b/docs/modules/harbor.md
@@ -1,3 +1,7 @@
+---
+category: Infrastructure
+---
+
 ## assay.harbor
 
 Harbor container registry. Projects, repositories, artifacts, vulnerability scanning. Client:

--- a/docs/modules/healthcheck.md
+++ b/docs/modules/healthcheck.md
@@ -1,3 +1,7 @@
+---
+category: Feature Flags & Health
+---
+
 ## assay.healthcheck
 
 HTTP health checking utilities. Status codes, JSON path, body matching, latency, multi-check.

--- a/docs/modules/http.md
+++ b/docs/modules/http.md
@@ -1,3 +1,7 @@
+---
+category: Builtins
+---
+
 ## http
 
 HTTP client and server. No `require()` needed. All responses return `{status, body, headers}`.

--- a/docs/modules/k8s.md
+++ b/docs/modules/k8s.md
@@ -1,3 +1,7 @@
+---
+category: Kubernetes & GitOps
+---
+
 ## assay.k8s
 
 Kubernetes API client. 30+ resource types, CRDs, readiness checks, pod logs, rollouts. Module-level

--- a/docs/modules/kargo.md
+++ b/docs/modules/kargo.md
@@ -1,3 +1,7 @@
+---
+category: Kubernetes & GitOps
+---
+
 ## assay.kargo
 
 Kargo continuous promotion. Stages, freight, promotions, warehouses, pipeline status. Client:

--- a/docs/modules/loki.md
+++ b/docs/modules/loki.md
@@ -1,3 +1,7 @@
+---
+category: Monitoring & Observability
+---
+
 ## assay.loki
 
 Loki log aggregation. Push logs, query with LogQL, labels, series, tail. Client: `loki.client(url)`.

--- a/docs/modules/openbao.md
+++ b/docs/modules/openbao.md
@@ -1,3 +1,7 @@
+---
+category: Security & Identity
+---
+
 ## assay.openbao
 
 OpenBao secrets management (Vault API-compatible). Alias for `assay.vault`.

--- a/docs/modules/ory.md
+++ b/docs/modules/ory.md
@@ -1,3 +1,7 @@
+---
+category: Security & Identity
+---
+
 ## assay.ory.kratos
 
 Ory Kratos identity management. Self-service login, registration, recovery and settings flows,

--- a/docs/modules/postgres.md
+++ b/docs/modules/postgres.md
@@ -1,3 +1,7 @@
+---
+category: Data & Storage
+---
+
 ## assay.postgres
 
 PostgreSQL database helpers. User/database management, grants, Vault integration. Client:

--- a/docs/modules/process.md
+++ b/docs/modules/process.md
@@ -1,3 +1,7 @@
+---
+category: Builtins
+---
+
 ## process
 
 OS-level process management — list, check, signal, spawn, wait. The

--- a/docs/modules/prometheus.md
+++ b/docs/modules/prometheus.md
@@ -1,3 +1,7 @@
+---
+category: Monitoring & Observability
+---
+
 ## assay.prometheus
 
 Prometheus monitoring queries. PromQL instant/range queries, alerts, targets, rules, series. Client:

--- a/docs/modules/regex.md
+++ b/docs/modules/regex.md
@@ -1,3 +1,7 @@
+---
+category: Builtins
+---
+
 ## regex
 
 Regular expressions (Rust regex syntax). No `require()` needed.

--- a/docs/modules/s3.md
+++ b/docs/modules/s3.md
@@ -1,3 +1,7 @@
+---
+category: Data & Storage
+---
+
 ## assay.s3
 
 S3-compatible object storage with AWS Signature V4 authentication. Client:

--- a/docs/modules/serialization.md
+++ b/docs/modules/serialization.md
@@ -1,3 +1,7 @@
+---
+category: Builtins
+---
+
 ## json
 
 JSON serialization. No `require()` needed.

--- a/docs/modules/tailscale.md
+++ b/docs/modules/tailscale.md
@@ -1,3 +1,7 @@
+---
+category: Infrastructure
+---
+
 ## assay.tailscale
 
 Tailscale REST API client. OAuth2 `client_credentials` flow with cached bearer tokens, mint

--- a/docs/modules/tailscale.md
+++ b/docs/modules/tailscale.md
@@ -1,0 +1,68 @@
+## assay.tailscale
+
+Tailscale REST API client. OAuth2 `client_credentials` flow with cached bearer tokens, mint
+short-lived auth keys, list/find devices, manage device key expiry, set tags, authorize, delete, and
+ACL preview.
+
+```lua
+local tailscale = require("assay.tailscale")
+
+-- env: TS_CLIENT_ID / TS_CLIENT_SECRET
+local ts = tailscale.client()
+
+-- or explicit
+local ts = tailscale.client({
+  client_id     = "...",
+  client_secret = "...",
+  tailnet       = "-",                            -- default "-"
+  base_url      = "https://api.tailscale.com",   -- override for tests
+  scope         = "all:write",                    -- default
+})
+```
+
+The token is fetched lazily on first call, cached in the client closure, and refreshed automatically
+when `os.time() >= expires_at - 30` (30s skew margin). Every authed call sends
+`Authorization: Bearer <token>`.
+
+### Auth keys
+
+- `ts:mint_key(opts)` -> `key` — `POST /tailnet/{tailnet}/keys`. Builds the nested
+  `capabilities.devices.create` payload from flat options.
+
+```lua
+local key = ts:mint_key({
+  reusable       = false,
+  ephemeral      = false,
+  preauthorized  = true,
+  tags           = { "tag:server" },
+  expiry_seconds = 600,
+  description    = "ansible mint for hostname-x",
+})
+```
+
+### Devices
+
+- `ts:list_devices()` -> `[device]` — `GET /tailnet/{tailnet}/devices`.
+- `ts:find_device({ hostname = "x" })` -> `device|nil` — Match against `device.hostname`, fall back
+  to `device.name` (also matches the `"<host>.<tailnet>..."` prefix). Returns `nil` if no match.
+- `ts:get_device(id)` -> `device` — `GET /device/{id}`.
+
+### Per-device operations
+
+- `ts:set_key_expiry(id, { disabled = bool })` -> `"changed"|"unchanged"` — Idempotent: `GET`s the
+  device first, compares `keyExpiryDisabled` to the desired value, only `POST`s `/device/{id}/key`
+  if it differs.
+- `ts:authorize_device(id)` — `POST /device/{id}/authorized` with `{ authorized = true }`.
+- `ts:set_device_tags(id, { "tag:foo" })` — `POST /device/{id}/tags`.
+- `ts:delete_device(id)` — `DELETE /device/{id}`.
+
+### ACL preview
+
+- `ts:acl_test(opts)` (or `tailscale.acl_test(ts, opts)`) — `POST
+  /tailnet/{tailnet}/acl/preview`
+  for CI ACL diffing.
+
+### Errors
+
+Every HTTP non-2xx (including the OAuth token exchange) raises `tailscale.<fn>: <reason>`; nothing
+silently returns `nil` on a network or auth failure.

--- a/docs/modules/template.md
+++ b/docs/modules/template.md
@@ -1,3 +1,7 @@
+---
+category: Builtins
+---
+
 ## template
 
 Jinja2-compatible template rendering. No `require()` needed.

--- a/docs/modules/traefik.md
+++ b/docs/modules/traefik.md
@@ -1,3 +1,7 @@
+---
+category: Kubernetes & GitOps
+---
+
 ## assay.traefik
 
 Traefik reverse proxy API. Routers, services, middlewares, entrypoints, TLS status. Client:

--- a/docs/modules/unleash.md
+++ b/docs/modules/unleash.md
@@ -1,3 +1,7 @@
+---
+category: Feature Flags & Health
+---
+
 ## assay.unleash
 
 Unleash feature flag management. Projects, features, environments, strategies, API tokens. Client:

--- a/docs/modules/url.md
+++ b/docs/modules/url.md
@@ -1,0 +1,35 @@
+## assay.url
+
+Pure-Lua URL helpers. RFC 3986 percent-encoding plus a deterministic
+`application/x-www-form-urlencoded` body builder.
+
+```lua
+local url = require("assay.url")
+```
+
+- `url.encode(s)` -> `string` — RFC 3986 percent-encode. Letters, digits and `-_.~` pass through;
+  every other byte becomes `%XX`. Space encodes as `%20`, not `+`.
+- `url.encode_form(t)` -> `string` — Build a form body from a flat `{ key = value, ... }` table.
+  Keys and values are percent-encoded, joined with `&`. Keys are sorted for determinism. Numbers are
+  stringified via `tostring`; booleans become `"true"` / `"false"`.
+- `url.decode(s)` -> `string` — Inverse of `encode`. Decodes `%XX` to bytes and also turns `+` into
+  a space (form-decode convention).
+
+### Why it exists
+
+OAuth2 `client_credentials` token bodies must be `application/x-www-form-urlencoded`.
+Hand-concatenating the body silently breaks the day a secret rotates to one containing `&`, `=`,
+`+`, or `%`:
+
+```lua
+-- Safe: secret rotates to "a&b=c+d%e" without 401-ing in production.
+local body = url.encode_form({
+  grant_type    = "client_credentials",
+  client_id     = env.get("CLIENT_ID"),
+  client_secret = env.get("CLIENT_SECRET"),
+  scope         = "all:write",
+})
+local resp = http.post(token_url, body, {
+  headers = { ["Content-Type"] = "application/x-www-form-urlencoded" },
+})
+```

--- a/docs/modules/url.md
+++ b/docs/modules/url.md
@@ -1,3 +1,7 @@
+---
+category: Text, URLs & Versions
+---
+
 ## assay.url
 
 Pure-Lua URL helpers. RFC 3986 percent-encoding plus a deterministic

--- a/docs/modules/utilities.md
+++ b/docs/modules/utilities.md
@@ -1,3 +1,7 @@
+---
+category: Builtins
+---
+
 ## log
 
 Structured logging. No `require()` needed.

--- a/docs/modules/vault.md
+++ b/docs/modules/vault.md
@@ -1,3 +1,7 @@
+---
+category: Security & Identity
+---
+
 ## assay.vault
 
 HashiCorp Vault secrets management. KV v2, policies, auth methods, transit encryption, PKI

--- a/docs/modules/velero.md
+++ b/docs/modules/velero.md
@@ -1,3 +1,7 @@
+---
+category: Infrastructure
+---
+
 ## assay.velero
 
 Velero backup and restore. Backups, restores, schedules, storage locations. Client:

--- a/docs/modules/version.md
+++ b/docs/modules/version.md
@@ -1,3 +1,7 @@
+---
+category: Text, URLs & Versions
+---
+
 ## assay.version
 
 Cross-scheme version comparison. Pure Lua, no I/O. Schemes: `semver` (default), `debian`, `rpm`,

--- a/docs/modules/version.md
+++ b/docs/modules/version.md
@@ -1,0 +1,32 @@
+## assay.version
+
+Cross-scheme version comparison. Pure Lua, no I/O. Schemes: `semver` (default), `debian`, `rpm`,
+`numeric`.
+
+- `version.compare(a, b, scheme?)` → `-1|0|1` — Compare two version strings.
+- `version.max(list, scheme?)` → `string` — Return the largest version in `list`.
+
+Scheme rules:
+
+- **semver** — strips leading `v`/`V`; splits on `.` then `-` (pre-release) and `+` (build,
+  ignored). Numeric segments compare numerically; numeric pre-release identifiers sort before
+  alphanumeric ones; a version with a pre-release is less than the same version without one.
+- **debian** — `[epoch:]upstream[-revision]`; epoch defaults to `0`. Strings split into runs of
+  digits (compared numerically) and non-digits (where `~` sorts before the empty string, then
+  letters, then everything else).
+- **rpm** — like debian but no epoch handling and no tilde rule (`~` is just another character).
+- **numeric** — pure dotted integers; missing segments default to `0`, so `1.2 == 1.2.0` and
+  `1.10 > 1.9`.
+
+Unknown scheme → error.
+
+```lua
+local version = require("assay.version")
+
+assert.eq(version.compare("1.2.3", "1.2.4"), -1)
+assert.eq(version.compare("v0.13.1", "0.13.2", "semver"), -1)
+assert.eq(version.compare("1:1.84.3-noble1", "1.84.2", "debian"), 1)
+assert.eq(version.compare("1.0~rc1", "1.0", "debian"), -1)
+assert.eq(version.compare("1.10", "1.9", "numeric"), 1)
+assert.eq(version.max({ "1.2", "1.10", "1.9" }, "semver"), "1.10")
+```

--- a/docs/modules/workflow.md
+++ b/docs/modules/workflow.md
@@ -1,3 +1,7 @@
+---
+category: AI Agents & Workflow
+---
+
 ## workflow
 
 Durable workflow engine + Lua client. The engine runs in `assay serve`; any assay Lua app becomes a

--- a/docs/modules/ws.md
+++ b/docs/modules/ws.md
@@ -1,3 +1,7 @@
+---
+category: Builtins
+---
+
 ## ws
 
 WebSocket client. No `require()` needed.

--- a/docs/modules/zitadel.md
+++ b/docs/modules/zitadel.md
@@ -1,3 +1,7 @@
+---
+category: Security & Identity
+---
+
 ## assay.zitadel
 
 Zitadel OIDC identity management. Projects, OIDC apps, IdPs, users, login policies. Client:

--- a/site/build.lua
+++ b/site/build.lua
@@ -51,7 +51,7 @@ end
 
 -- =====================================================================
 -- =====================================================================
-local module_count = count_builtins() + #fs.glob("stdlib/**/*.lua")
+local module_count = count_builtins() + #fs.glob("crates/assay/stdlib/**/*.lua")
 
 local git_sha = "local-dev"
 local ok, result = pcall(function()
@@ -127,55 +127,124 @@ __FOOTER__
 </body>
 </html>]]
 
-local categories = {
-  { name = "Builtins (no require needed)", pattern = {"http", "serialization", "crypto", "regex", "db", "ws", "template", "async", "assert", "utilities", "fs", "markdown", "compress"} },
-  { name = "Monitoring &amp; Observability", pattern = {"prometheus", "alertmanager", "loki", "grafana"} },
-  { name = "Kubernetes &amp; GitOps", pattern = {"k8s", "argocd", "kargo", "flux", "traefik"} },
-  { name = "Security &amp; Identity", pattern = {"vault", "openbao", "certmanager", "eso", "dex", "zitadel", "ory"} },
-  { name = "Infrastructure", pattern = {"crossplane", "velero", "harbor", "tailscale", "apt"} },
-  { name = "Data &amp; Storage", pattern = {"postgres", "s3"} },
-  { name = "Feature Flags &amp; Utilities", pattern = {"unleash", "healthcheck"} },
-  { name = "Text, URLs &amp; Versions", pattern = {"ansi", "url", "version"} },
-  { name = "AI Agent &amp; Workflow", pattern = {"ai-agents", "workflow", "github"} },
+-- Display order for categories. Any category found in frontmatter that is
+-- not in this list is appended at the end in alphabetical order. Adding a
+-- new category to a module's frontmatter is the only step needed to make
+-- it appear; ordering it explicitly is optional.
+local category_order = {
+  "Builtins",
+  "Monitoring & Observability",
+  "Kubernetes & GitOps",
+  "Security & Identity",
+  "Infrastructure",
+  "Data & Storage",
+  "Feature Flags & Health",
+  "Text, URLs & Versions",
+  "AI Agents & Workflow",
 }
+
+-- Display name override (e.g. for the modules.html headers we want
+-- "Builtins (no require needed)" instead of just "Builtins").
+local category_display = {
+  ["Builtins"] = "Builtins (no require needed)",
+}
+
+-- Parse YAML-ish frontmatter from a markdown source. Returns
+-- (fields_table, body_without_frontmatter). Fields are key/value strings;
+-- only top-level scalar values are supported (sufficient for category +
+-- tagline). If the file has no frontmatter, fields is empty and body is
+-- the original content.
+local function parse_frontmatter(src)
+  local fields = {}
+  local rest = src:match("^%-%-%-\n(.-\n)%-%-%-\n+(.*)$")
+  if not rest then
+    return fields, src
+  end
+  local header = src:match("^%-%-%-\n(.-)\n%-%-%-\n")
+  local body   = src:match("^%-%-%-\n.-\n%-%-%-\n+(.*)$") or src
+  for line in (header or ""):gmatch("[^\n]+") do
+    local k, v = line:match("^([%w_]+)%s*:%s*(.*)$")
+    if k then fields[k] = v end
+  end
+  return fields, body
+end
+
+-- Take the first paragraph after the H2 header as a one-line tagline.
+-- Newlines collapsed to single spaces. Used for README/SKILL table cells.
+local function extract_tagline(body)
+  local first_para = body:match("^## [^\n]+\n+([^\n]+(\n[^\n]+)*)") or ""
+  -- The match is greedy across blank lines, so trim at first double-newline.
+  first_para = first_para:match("^([^\n].-)\n\n") or first_para
+  return (first_para:gsub("\n", " "):gsub("%s+", " "):gsub("^%s+", ""):gsub("%s+$", ""))
+end
 
 local modules = {}
 for _, md_file in ipairs(md_files) do
   local slug = md_file:match("([^/]+)%.md$")
-  local md_content = fs.read(md_file)
-  local title = md_content:match("^## ([^\n]+)") or slug
+  local raw  = fs.read(md_file)
+  local fields, body = parse_frontmatter(raw)
+  local title    = body:match("^## ([^\n]+)") or slug
+  local category = fields.category or "Uncategorised"
+  local tagline  = fields.tagline or extract_tagline(body)
 
   local page = module_template
   page = substitute(page, "{{title}}", title)
-  page = substitute(page, "{{content}}", markdown.to_html(md_content))
+  page = substitute(page, "{{content}}", markdown.to_html(body))
   page = apply_placeholders(page)
 
   fs.write(modules_out .. "/" .. slug .. ".html", page)
-  modules[#modules + 1] = { slug = slug, title = title }
+  modules[#modules + 1] = {
+    slug = slug, title = title, category = category, tagline = tagline,
+  }
 end
 log.info("Generated " .. #modules .. " module pages")
 
 -- =====================================================================
 -- =====================================================================
-local function modules_in_category(cat_pattern)
-  local items = {}
-  for _, m in ipairs(modules) do
-    for _, p in ipairs(cat_pattern) do
-      if m.slug == p then
-        items[#items + 1] = '        <li><a href="modules/' .. m.slug .. '.html">' .. m.title .. '</a></li>'
-        break
-      end
+-- Build categories dynamically from frontmatter, ordered by
+-- `category_order` (then any unknown categories alphabetically).
+local by_category = {}
+for _, m in ipairs(modules) do
+  by_category[m.category] = by_category[m.category] or {}
+  table.insert(by_category[m.category], m)
+end
+for cat, list in pairs(by_category) do
+  table.sort(list, function(a, b) return a.slug < b.slug end)
+end
+
+local function ordered_categories()
+  local seen = {}
+  local result = {}
+  for _, cat in ipairs(category_order) do
+    if by_category[cat] then
+      result[#result + 1] = cat
+      seen[cat] = true
     end
   end
-  return table.concat(items, "\n")
+  local extras = {}
+  for cat, _ in pairs(by_category) do
+    if not seen[cat] then extras[#extras + 1] = cat end
+  end
+  table.sort(extras)
+  for _, cat in ipairs(extras) do result[#result + 1] = cat end
+  return result
+end
+
+local html_escape = function(s)
+  return (s:gsub("&", "&amp;"):gsub("<", "&lt;"):gsub(">", "&gt;"))
 end
 
 local sections = {}
-for _, cat in ipairs(categories) do
-  local items = modules_in_category(cat.pattern)
-  if #items > 0 then
-    sections[#sections + 1] = '    <h2>' .. cat.name .. '</h2>\n    <ul>\n' .. items .. '\n    </ul>'
+for _, cat in ipairs(ordered_categories()) do
+  local list = by_category[cat]
+  local items = {}
+  for _, m in ipairs(list) do
+    items[#items + 1] = '        <li><a href="modules/' .. m.slug .. '.html">'
+                     .. html_escape(m.title) .. '</a></li>'
   end
+  local display = category_display[cat] or cat
+  sections[#sections + 1] = '    <h2>' .. html_escape(display) .. '</h2>\n'
+                          .. '    <ul>\n' .. table.concat(items, "\n") .. '\n    </ul>'
 end
 
 local index_html = [[<!DOCTYPE html>
@@ -387,5 +456,69 @@ llms[#llms + 1] = [[## Optional
 ]]
 
 fs.write(out .. "/llms-full.txt", table.concat(llms))
+
+-- =====================================================================
+-- README.md / SKILL.md auto-rewrite
+-- =====================================================================
+-- Modules + categories live in `docs/modules/<slug>.md` frontmatter
+-- (`category:` field). The stdlib table in README and SKILL is generated
+-- from that, replacing whatever sits between the BEGIN/END markers. Run
+-- `assay site/build.lua` after adding/changing a module; CI should fail
+-- if `git diff README.md SKILL.md` is non-empty afterwards.
+
+local function render_stdlib_md_table()
+  local lines = {
+    "<!-- BEGIN STDLIB TABLE -->",
+    "<!-- Generated by site/build.lua from docs/modules/*.md frontmatter — do not edit by hand. -->",
+    "",
+    "| Module | Description |",
+    "| --- | --- |",
+  }
+  for _, cat in ipairs(ordered_categories()) do
+    if cat ~= "Builtins" then
+      lines[#lines + 1] = "| **" .. cat .. "** | |"
+      for _, m in ipairs(by_category[cat]) do
+        local desc = m.tagline or ""
+        -- Pipes inside table cells must be escaped.
+        desc = desc:gsub("|", "\\|")
+        lines[#lines + 1] = "| `assay." .. m.slug .. "` | " .. desc .. " |"
+      end
+    end
+  end
+  lines[#lines + 1] = ""
+  lines[#lines + 1] = "<!-- END STDLIB TABLE -->"
+  return table.concat(lines, "\n")
+end
+
+local function replace_block(path, begin_marker, end_marker, replacement)
+  local ok, src = pcall(fs.read, path)
+  if not ok then
+    log.warn(path .. ": not found, skipping")
+    return false
+  end
+  local pre_pat  = "^(.-)(" .. begin_marker:gsub("%-", "%%-") .. ")"
+  local post_pat = "(" .. end_marker:gsub("%-", "%%-") .. ")(.*)$"
+  local pre  = src:match(pre_pat)
+  local post = src:match(post_pat)
+  if not pre or not post then
+    log.warn(path .. ": markers not found, skipping (add `"
+             .. begin_marker .. "` ... `" .. end_marker .. "`)")
+    return false
+  end
+  local new = pre .. replacement .. post
+  if new == src then
+    log.info(path .. ": stdlib table unchanged")
+    return false
+  end
+  fs.write(path, new)
+  log.info(path .. ": stdlib table rewritten")
+  return true
+end
+
+local table_md = render_stdlib_md_table()
+replace_block("README.md", "<!-- BEGIN STDLIB TABLE -->", "<!-- END STDLIB TABLE -->", table_md)
+-- SKILL.md does not currently host a stdlib table; if you want one,
+-- add the BEGIN/END markers anywhere in the file and rerun this script.
+replace_block("SKILL.md",  "<!-- BEGIN STDLIB TABLE -->", "<!-- END STDLIB TABLE -->", table_md)
 
 log.info("Done. Output at " .. out .. "/")

--- a/site/build.lua
+++ b/site/build.lua
@@ -128,14 +128,15 @@ __FOOTER__
 </html>]]
 
 local categories = {
-  { name = "Builtins (no require needed)", pattern = {"http", "serialization", "crypto", "regex", "db", "ws", "template", "async", "assert", "utilities", "fs", "markdown"} },
+  { name = "Builtins (no require needed)", pattern = {"http", "serialization", "crypto", "regex", "db", "ws", "template", "async", "assert", "utilities", "fs", "markdown", "compress"} },
   { name = "Monitoring &amp; Observability", pattern = {"prometheus", "alertmanager", "loki", "grafana"} },
   { name = "Kubernetes &amp; GitOps", pattern = {"k8s", "argocd", "kargo", "flux", "traefik"} },
   { name = "Security &amp; Identity", pattern = {"vault", "openbao", "certmanager", "eso", "dex", "zitadel", "ory"} },
-  { name = "Infrastructure", pattern = {"crossplane", "velero", "harbor"} },
+  { name = "Infrastructure", pattern = {"crossplane", "velero", "harbor", "tailscale", "apt"} },
   { name = "Data &amp; Storage", pattern = {"postgres", "s3"} },
   { name = "Feature Flags &amp; Utilities", pattern = {"unleash", "healthcheck"} },
-  { name = "AI Agent &amp; Workflow", pattern = {"ai-agents", "workflow"} },
+  { name = "Text, URLs &amp; Versions", pattern = {"ansi", "url", "version"} },
+  { name = "AI Agent &amp; Workflow", pattern = {"ai-agents", "workflow", "github"} },
 }
 
 local modules = {}

--- a/site/pages/agent-guides.html
+++ b/site/pages/agent-guides.html
@@ -155,7 +155,7 @@ assert.not_nil(result)
 assay script.lua</code></pre>
 
     <p>
-      All 34 stdlib modules follow the same pattern: <code>require</code>, <code>client()</code>,
+      All __MODULE_COUNT__ modules follow the same pattern: <code>require</code>, <code>client()</code>,
       <code>c:method()</code>. Learn one, know them all.
     </p>
 

--- a/site/pages/auth-overview.html
+++ b/site/pages/auth-overview.html
@@ -13,7 +13,7 @@
   <main>
     <a href="changelog.html" class="release-banner">
       <span class="release-banner-tag">v0.2.0</span>
-      <span class="release-banner-text">assay-engine becomes a full Ory replacement: passkey, OIDC provider, biscuit, Zanzibar — all in one ~9 MB static binary.</span>
+      <span class="release-banner-text">assay-engine becomes a full Ory replacement: passkey, OIDC provider, biscuit, Zanzibar — all in one ~19 MB static binary.</span>
       <span class="release-banner-arrow">&rarr;</span>
     </a>
 
@@ -21,7 +21,7 @@
     <p style="font-size: 1.15rem; color: var(--text-secondary); margin-bottom: 1.5rem;">
       <code>assay-engine v0.2.0</code> ships a complete identity provider in the same binary that
       runs the Temporal-replacement workflow engine. One process. PG18 or SQLite. Ory + Hydra +
-      Keto in ~9 MB.
+      Keto in ~19 MB.
     </p>
 
     <h2>What's in v0.2.0</h2>
@@ -47,7 +47,7 @@
 
     <h2>Why ditch Ory for assay-engine?</h2>
     <ul>
-      <li><strong>One static binary.</strong> ~9 MB stripped, <code>FROM scratch</code>-shippable.
+      <li><strong>One static binary.</strong> ~19 MB stripped, <code>FROM scratch</code>-shippable.
         Replaces a stack of Kratos + Hydra + Keto + Oathkeeper containers (typically 800 MB-1.5 GB
         compressed across 5+ images).</li>
       <li><strong>Backend symmetry.</strong> PG18 + SQLite are both first-class. SQLite means a

--- a/site/pages/compare-vs-ory.html
+++ b/site/pages/compare-vs-ory.html
@@ -13,7 +13,7 @@
   <main>
     <h1>assay-engine vs Ory</h1>
     <p style="font-size: 1.05rem; color: var(--text-secondary); margin-bottom: 1.5rem;">
-      <code>assay-engine v0.2.0</code> ships a complete Ory replacement in one ~9 MB static
+      <code>assay-engine v0.2.0</code> ships a complete Ory replacement in one ~19 MB static
       binary. Same features as Kratos + Hydra + Keto stacked together, plus biscuit (Ory has
       nothing equivalent), plus a Temporal-replacement workflow engine in the same process.
     </p>
@@ -24,7 +24,7 @@
         <tr><th>Stack</th><th>Containers</th><th>Compressed</th><th>RAM (idle)</th></tr>
       </thead>
       <tbody>
-        <tr style="font-weight: 600; color: var(--accent);"><td>assay-engine</td><td>1</td><td>~9 MB</td><td>&lt;50 MB</td></tr>
+        <tr style="font-weight: 600; color: var(--accent);"><td>assay-engine</td><td>1</td><td>~19 MB</td><td>&lt;50 MB</td></tr>
         <tr><td>Ory Kratos</td><td>1</td><td>~120 MB</td><td>~150 MB</td></tr>
         <tr><td>Ory Hydra</td><td>1</td><td>~80 MB</td><td>~100 MB</td></tr>
         <tr><td>Ory Keto</td><td>1</td><td>~80 MB</td><td>~100 MB</td></tr>
@@ -114,7 +114,7 @@
         win.</li>
     </ul>
 
-    <p>Otherwise, you're trading 5 containers + ~600 MB RAM for one ~9 MB static binary that does
+    <p>Otherwise, you're trading 5 containers + ~600 MB RAM for one ~19 MB static binary that does
       the same job, scripts in Lua, and runs your workflows too.</p>
 
     <p><a href="auth-overview.html">&larr; Back to Auth &amp; IdP overview</a></p>

--- a/site/pages/index.html
+++ b/site/pages/index.html
@@ -24,7 +24,7 @@
       <h1 class="hero-title">One static binary that replaces Temporal + Kratos + Hydra + Keto.</h1>
       <p class="hero-sub">
         Workflow engine + full IdP (passkey, OIDC, biscuit, Zanzibar) in
-        <code>assay-engine</code>. Lua 5.5 runtime with 51 stdlib modules
+        <code>assay-engine</code>. Lua 5.5 runtime with __MODULE_COUNT__ stdlib modules
         (Kubernetes, Prometheus, Vault, GitHub, Gmail, OpenClaw…) in
         <code>assay</code>. PG18 + SQLite. Linux, macOS, Docker,
         <a href="https://crates.io/crates/assay-lua">Rust crate</a>.

--- a/site/pages/index.html
+++ b/site/pages/index.html
@@ -15,7 +15,7 @@
     <!-- assay-engine v0.2.0 release banner -->
     <a href="auth-overview.html" class="release-banner">
       <span class="release-banner-tag">v0.2.0</span>
-      <span class="release-banner-text"><strong>assay-engine v0.2.0:</strong> one ~9 MB binary that replaces Temporal + Kratos + Hydra + Keto. Full IdP — passkey, OIDC client + provider, biscuit capability tokens, Zanzibar ReBAC — alongside the Temporal-replacement workflow engine.</span>
+      <span class="release-banner-text"><strong>assay-engine v0.2.0:</strong> one ~19 MB binary that replaces Temporal + Kratos + Hydra + Keto. Full IdP — passkey, OIDC client + provider, biscuit capability tokens, Zanzibar ReBAC — alongside the Temporal-replacement workflow engine.</span>
       <span class="release-banner-arrow">&rarr;</span>
     </a>
 


### PR DESCRIPTION
## Summary

Patch release closing six open issues with one PR. Three per-crate tags publish from this branch.

| Crate            | Bump            | Why                                                                     |
| ---------------- | --------------- | ----------------------------------------------------------------------- |
| `assay`          | 0.14.0 → 0.14.1 | Six new stdlib modules + template loader + lua coroutine regression pin |
| `assay-workflow` | 0.3.0 → 0.3.1   | Defensive empty-body parsing on `POST /workflows/{id}/cancel`           |
| `assay-engine`   | 0.2.0 → 0.2.1   | Re-ships the workflow patch in the binary                               |

No breaking changes. See `docs/migration-to-0.14.1.md`.

### Closed

- **#66** — `workflow.cancel` empty-body deserialize error. Two-layer fix: stdlib stops synthesising `{}` for nil bodies; `cancel_workflow` handler now tolerates no body, `{}`, `[]`, or `{"reason":"..."}`. Regression: `cancel_accepts_any_body_shape`.
- **#67** — `assay.ansi` for ANSI SGR → HTML conversion + stripper, for browser-facing log viewers. Pure Lua, 13 tests.
- **#72** — `assay.tailscale` REST client (OAuth2 + mint key + device management) on top of new `assay.url` percent-encoding helpers. 25 tests across both modules.
- **#71** — Three-way release-checker stdlib: `assay.compress` (gunzip/unxz/unzstd Rust builtin), `assay.version` (semver/debian/rpm/numeric), `assay.apt` (Packages index reader), plus GitHub Releases helpers on the existing `assay.github`. 24 tests across the four slices.
- **#64** — `template.render_with_loader` so `{% extends %}`, `{% include %}`, `{% import %}` resolve sibling templates via minijinja's path loader. 3 tests.

### Pinned (already fixed)

- **#40** — Lua coroutine resume `error converting Lua nil to function`. Filed against `assay 0.10.4` + the long-removed `temporal.worker(...)` API. The v0.13.0 engine rewrite moved workflow execution to pure-Lua `coroutine.create`, which inherits globals from the parent state. Regression test (`coroutine_ctx_resume.rs`) locks the contract.

### Out of scope

- **#75** (drop OpenSSL → RustCrypto for `webauthn-rs`) — left open; tracked for a dedicated minor since it touches `assay-auth` and changes a build-time dep tree.

### Also worth flagging

- `http` builtin: response `body` is now constructed from raw bytes rather than `resp.text()` (UTF-8 lossy). Lua strings are byte buffers, so this round-trips binary payloads (gzip/xz/zst index files, asset downloads) without corruption. UTF-8 callers see no change.

## Commits

```
6b3d767 chore(release): assay 0.14.1 / assay-workflow 0.3.1 / assay-engine 0.2.1
4d5622c test(coroutine): pin lua ctx resume contract (#40)
3a01c39 feat(stdlib): six new modules + template path-loader (#64, #67, #71, #72)
698d754 fix(workflow): cancel handler tolerates empty + array bodies (#66)
81a5432 fix(stdlib): drop body-or-{} fallback in engine api wrappers (#66)
```

## Test plan

- [x] `cargo check --workspace --all-features` — green
- [x] `cargo test --workspace --lib --tests` — green (all targets pass; new test files: `stdlib_ansi`, `stdlib_url`, `stdlib_tailscale`, `stdlib_version`, `stdlib_apt`, `stdlib_release_check`, `builtins_compress`, `builtins_template_loader`, `coroutine_ctx_resume`, plus `cancel_accepts_any_body_shape` in `assay-workflow`)
- [x] Cargo deps: `flate2`, `xz2`, `zstd` for compress; `minijinja` `loader` feature for template
- [x] Per-crate version bumps in `Cargo.toml` + matching `Cargo.lock`
- [x] CHANGELOG.md prepended with the new release section
- [x] `docs/migration-to-0.14.1.md` covers all upgrade scenarios (none breaking)
- [x] `docs/modules/` extended with `ansi.md`, `apt.md`, `compress.md`, `tailscale.md`, `url.md`, `version.md`; `github.md` (re-)created with the new release helpers
- [x] `site/pages/index.html` hardcoded module count converted to `__MODULE_COUNT__` placeholder so the site builder auto-fills it
- [ ] Per-crate tags (`assay-v0.14.1`, `assay-workflow-v0.3.1`, `assay-engine-v0.2.1`) cut after merge by the release pipeline