### PR TITLE
assay 0.14.2 — script args + relax loader sandbox + ASSAY_BLOCK_GLOBALS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,115 +2,63 @@
 
 All notable changes to Assay are documented here.
 
-## [assay 0.14.1 / assay-workflow 0.3.1 / assay-engine 0.2.1] - 2026-04-26
-
-**Headline:** A patch release closing six open issues — one workflow API bug, six stdlib additions,
-one template-builtin gap, and one coroutine regression — without breaking changes. Two layers move:
-the Lua runtime side (`assay`) and the engine side (`assay-workflow` for the cancel handler change,
-`assay-engine` to ship the patched binary).
-
-| Crate            | Version         | Notes                                                                                                             |
-| ---------------- | --------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `assay`          | 0.14.0 → 0.14.1 | Six new stdlib modules (ansi, url, tailscale, version, apt, compress); github releases extension; template loader |
-| `assay-workflow` | 0.3.0 → 0.3.1   | Defensive empty-body parsing on `POST /workflows/{id}/cancel`                                                     |
-| `assay-engine`   | 0.2.0 → 0.2.1   | Re-ships the workflow patch in the binary                                                                         |
+## [assay 0.14.2] - 2026-04-26
 
 ### Fixed
 
-- **#66 — `workflow.cancel` rejected with empty-body deserialize error.** The Lua stdlib
-  `_api("POST", path)` helpers were synthesising `body or {}` on every call, which serialised to
-  `[]` (Lua can't distinguish empty array from empty object), and the `POST /workflows/{id}/cancel`
-  handler then failed to deserialise that `[]` into `CancelBody`. Two-layer fix:
-  - _Stdlib_ (`assay 0.14.1`): the engine + workflow + auth `_api` helpers now pass `body` through
-    unchanged so a `nil` body sends no body and no `Content-Type` header.
-  - _Server_ (`assay-workflow 0.3.1`): `cancel_workflow` now consumes the body as raw bytes and
-    tolerates any of: missing body, `{}`, `[]`, or `{"reason":"..."}`. Regression test in
-    `crates/assay-workflow/tests/api_integration.rs::cancel_accepts_any_body_shape`.
+- `assay run <script> -- <args>` now passes trailing positionals as the Lua `arg` global (`arg[0]` =
+  script path, `arg[1..]` = user values). Stock `lua`/`luajit` shape.
+- `dofile`, `load`, `loadfile` are usable again — the old sandbox over-blocked them. `string.dump`
+  stays blocked (bytecode escape).
 
-- **#40 — Lua coroutine resume `error converting Lua nil to function`.** The bug was filed against
-  `assay 0.10.4` and the long-removed `temporal.worker(...)` API. The v0.13.0 engine rewrite
-  replaced the mlua `create_thread` path with pure-Lua `coroutine.create` in
-  `stdlib/engine/workflow/worker.lua`, which inherits globals from the parent state — so `os.date`
-  and `ctx:register_query` are reachable inside the coroutine. New regression test
-  (`crates/assay/tests/coroutine_ctx_resume.rs`) pins this contract.
+### Added
 
-### Added — stdlib (assay 0.14.1)
+- `ASSAY_BLOCK_GLOBALS` env var: comma-separated names to nil at VM creation. Supports dotted paths
+  (`os.execute`, `debug.getinfo`). Typos silently skip.
 
-- **`assay.ansi`** — ANSI SGR → HTML conversion (`ansi.to_html`) and stripper (`ansi.strip`) for
-  browser-facing log viewers. Pure Lua, no deps. Covers fg/bg 30–37 / 90–97 / 40–47 / 100–107, bold,
-  reset, default-fg/bg; unknown codes dropped cleanly; non-SGR CSI pre-stripped; HTML-unsafe chars
-  escaped before span-wrapping. Closes #67.
+## [assay 0.14.1 / assay-workflow 0.3.1 / assay-engine 0.2.1] - 2026-04-26
 
-- **`assay.url`** — RFC 3986 percent encoding (`url.encode`, `url.decode`) plus form-body builder
-  (`url.encode_form`). Used by `assay.tailscale` for OAuth2 `application/x-www-form-urlencoded`
-  bodies; generally useful wherever a script builds query strings or form bodies by hand. Spaces
-  become `%20` (RFC 3986); `url.decode` does form-style `+` → space.
+| Crate            | Bump            |
+| ---------------- | --------------- |
+| `assay`          | 0.14.0 → 0.14.1 |
+| `assay-workflow` | 0.3.0 → 0.3.1   |
+| `assay-engine`   | 0.2.0 → 0.2.1   |
 
-- **`assay.tailscale`** — Tailscale REST client. `tailscale.client(...)` performs OAuth2
-  `client_credentials` exchange (form body built via `assay.url.encode_form`, so secrets containing
-  `&=+%` encode safely), caches the bearer token until `expires_at - 30s`, and exposes: `mint_key`,
-  `list_devices`, `find_device`, `get_device`, `set_key_expiry` (idempotent — returns `"changed"` or
-  `"unchanged"`), `authorize_device`, `set_device_tags`, `delete_device`, `acl_test`. Closes #72.
+### Fixed
 
-- **`assay.version`** — Cross-scheme version comparison. `version.compare(a, b, scheme?)` returns
-  -1/0/1 across `"semver"` (default, semver.org-spec pre-release ordering), `"debian"` (epoch +
-  tilde-aware alternating digit/non-digit comparator), `"rpm"` (same shape, no tilde rule),
-  `"numeric"` (dotted ints, missing segments default to 0). `version.max(list, scheme?)` returns the
-  largest. Closes #71 (§3).
+- `workflow.cancel` no longer 400s on empty body (#66). Stdlib stops sending `[]`, and the handler
+  tolerates `{}` / `[]` / no body / `{"reason":"..."}`.
+- Pinned the lua coroutine ctx-resume contract with a regression test (#40, fixed in v0.13.0).
 
-- **`assay.compress`** — Decompression Rust builtin. `compress.gunzip`, `compress.unxz`,
-  `compress.unzstd`. Bytes in, bytes out (Lua strings are byte buffers). Used internally by
-  `assay.apt`; generally useful for any HTTP download with `Content-Encoding` compression.
+### Added — stdlib
 
-- **`assay.apt`** — Debian package index reader. `apt.packages({base_url,
-  dist, component, arch})`
-  fetches `dists/{dist}/{component}/binary-{arch}/Packages.{gz,xz,zst,plain}`, auto-decompresses,
-  parses the RFC 822 control file, and returns an index with
-  `:find(name) -> { version, versions[], architecture, depends, ... }`. Versions are sorted via
-  `assay.version.compare(..., "debian")`. Closes #71 (§2).
+- `assay.ansi` — SGR → HTML + strip (#67).
+- `assay.url` — RFC 3986 percent encoding + form bodies (#72 prereq).
+- `assay.tailscale` — OAuth2 client + auth keys + device management + ACL preview (#72).
+- `assay.version` — compare across semver / debian / rpm / numeric (#71 §3).
+- `assay.compress` — gunzip / unxz / unzstd Rust builtin (#71 §4).
+- `assay.apt` — Debian Packages index reader, sorted via `assay.version` (#71 §2).
+- `assay.github` — module-level Releases helpers (`latest_release`, `find_asset`,
+  `release_checksum`, …) (#71 §1).
 
-- **`assay.github`** extension — Module-level GitHub Releases helpers alongside the existing client
-  API: `github.latest_release(owner, repo)`, `github.find_asset(release, name_pattern)`,
-  `github.fetch_asset_text/bytes(asset)`,
-  `github.release_checksum(release, { asset_pattern, digest })`. Used by release-version checkers.
-  Closes #71 (§1).
+### Added — Lua builtins
 
-### Added — Lua builtins (assay 0.14.1)
+- `template.render_with_loader(dir, name, vars)` — `{% extends %}` / `{% include %}` /
+  `{% import %}` resolve sibling templates (#64).
 
-- **`template.render_with_loader(template_dir, name, vars)`** — Renders a template through a
-  minijinja path loader so `{% extends %}`, `{% include %}`, and `{% import %}` resolve sibling
-  templates. The existing `template.render` and `template.render_string` constructed a fresh
-  `Environment::new()` per call with no loader and so could never resolve references between
-  templates. Closes #64.
+### Changed
 
-- **`compress.gunzip` / `compress.unxz` / `compress.unzstd`** — see stdlib section above.
-  Implemented as a Rust builtin via `flate2`, `xz2`, `zstd`.
-
-### Changed — http (assay 0.14.1)
-
-- `http.get/post/...` response `body` is now constructed from raw bytes rather than `resp.text()`
-  (UTF-8 lossy). Lua strings are byte buffers, so this round-trips binary payloads (gzip/xz/zst
-  index files, asset downloads) without corruption. Visible only to callers fetching non-UTF-8
-  content; UTF-8 callers see no behaviour change.
-
-### Changed — workflow API (assay-workflow 0.3.1)
-
-- `cancel_workflow` handler now consumes the raw body and tolerates any shape — the previous
-  `Option<Json<CancelBody>>` extractor would 400 on `[]`. See #66 fix above.
+- `http` response bodies are now raw bytes, not `resp.text()` — round-trips gzip/xz/zst payloads
+  without UTF-8 corruption.
+- `cancel_workflow` handler reads raw bytes; see #66.
 
 ### Migration
 
-No breaking changes. Stdlib additions are additive. The cancel handler contract is wider than before
-(more inputs accepted; same outputs). Engine binaries should be redeployed to pick up the cancel
-fix; library consumers of `assay-workflow` get it automatically with
-`cargo update -p assay-workflow`.
-
-See `docs/migration-to-0.14.1.md` for the short version.
+No breaking changes. See `docs/migration-to-0.14.1.md`.
 
 ### Out of scope
 
-- **#75** (drop OpenSSL → RustCrypto for `webauthn-rs`) — left open; tracked for a dedicated minor
-  since it touches the auth crate and changes a build-time dependency tree.
+- #75 (drop OpenSSL → RustCrypto for `webauthn-rs`).
 
 ## [assay-engine 0.2.0] - 2026-04-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,19 +2,40 @@
 
 All notable changes to Assay are documented here.
 
-## [assay 0.14.2] - 2026-04-26
+## [assay 0.14.2 / assay-auth 0.2.1 / assay-dashboard 0.2.1 / assay-engine 0.2.2] - 2026-04-26
+
+| Crate             | Bump            |
+| ----------------- | --------------- |
+| `assay`           | 0.14.1 → 0.14.2 |
+| `assay-auth`      | 0.2.0 → 0.2.1   |
+| `assay-dashboard` | 0.2.0 → 0.2.1   |
+| `assay-engine`    | 0.2.1 → 0.2.2   |
 
 ### Fixed
 
-- `assay run <script> -- <args>` now passes trailing positionals as the Lua `arg` global (`arg[0]` =
-  script path, `arg[1..]` = user values). Stock `lua`/`luajit` shape.
-- `dofile`, `load`, `loadfile` are usable again — the old sandbox over-blocked them. `string.dump`
-  stays blocked (bytecode escape).
+- `assay run <script> -- <args>` passes trailing positionals to Lua's `arg` global (`arg[0]` =
+  script path, `arg[1..]` = user values).
+- `dofile`, `load`, `loadfile` are usable again — old sandbox over-blocked them. `string.dump` stays
+  blocked (bytecode escape).
+- Zanzibar tuple writes no longer 500 (#82). `subject_rel` was implicitly NOT NULL via the PK but
+  every code path treated it as nullable. Schema stores `''` for direct subjects, the relation name
+  for usersets; queries use plain equality.
+- Zanzibar namespace POST no longer rejects with `missing field 'wildcard'` (#81). Field is
+  `#[serde(default)]` on `TypeRef`.
+- Auth Console: removed leaked `phase 8b` planning shorthand (#83) from the Keys empty state and
+  three header comments.
 
 ### Added
 
 - `ASSAY_BLOCK_GLOBALS` env var: comma-separated names to nil at VM creation. Supports dotted paths
   (`os.execute`, `debug.getinfo`). Typos silently skip.
+
+### Changed
+
+- `Tuple` / `SubjectRef` `subject_rel` is now `String` (was `Option<String>`). Empty string = direct
+  subject, non-empty = userset. JSON callers can omit the field; serde defaults to `""`.
+- Schema migration is destructive — drop and recreate `auth.zanzibar_tuples` for any existing
+  install. (No production assay 0.14.x deployment on file at this writing.)
 
 ## [assay 0.14.1 / assay-workflow 0.3.1 / assay-engine 0.2.1] - 2026-04-26
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,7 +197,7 @@ dependencies = [
 
 [[package]]
 name = "assay-auth"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "argon2",
@@ -236,7 +236,7 @@ dependencies = [
 
 [[package]]
 name = "assay-dashboard"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "assay-domain",
  "axum",
@@ -266,7 +266,7 @@ dependencies = [
 
 [[package]]
 name = "assay-engine"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "assay-auth",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,7 +293,7 @@ dependencies = [
 
 [[package]]
 name = "assay-lua"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/assay-auth/Cargo.toml
+++ b/crates/assay-auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-auth"
-version = "0.2.0"
+version = "0.2.1"
 categories = ["authentication", "cryptography", "asynchronous"]
 edition = "2024"
 keywords = ["oidc", "zanzibar", "passkey", "biscuit", "auth"]

--- a/crates/assay-auth/src/admin.rs
+++ b/crates/assay-auth/src/admin.rs
@@ -646,8 +646,10 @@ pub struct TupleBody {
     pub relation: String,
     pub subject_type: String,
     pub subject_id: String,
+    /// Empty string (or omitted) for direct subjects; the userset
+    /// relation name for userset subjects. See `zanzibar::SubjectRef`.
     #[serde(default)]
-    pub subject_rel: Option<String>,
+    pub subject_rel: String,
 }
 
 async fn zanzibar_write_tuple(
@@ -716,8 +718,10 @@ pub struct CheckBody {
     pub permission: String,
     pub subject_type: String,
     pub subject_id: String,
+    /// Empty string (or omitted) for direct subjects; the userset
+    /// relation name for userset subjects.
     #[serde(default)]
-    pub subject_rel: Option<String>,
+    pub subject_rel: String,
 }
 
 #[derive(Clone, Debug, Serialize)]

--- a/crates/assay-auth/src/gate.rs
+++ b/crates/assay-auth/src/gate.rs
@@ -161,7 +161,7 @@ pub async fn require_role(
         let subject = SubjectRef {
             subject_type: "user".to_string(),
             subject_id: caller.user_id.clone(),
-            subject_rel: None,
+            subject_rel: String::new(),
         };
         match store
             .check(&resource, permission, &subject, Consistency::Minimum)

--- a/crates/assay-auth/src/schema.rs
+++ b/crates/assay-auth/src/schema.rs
@@ -159,12 +159,15 @@ CREATE INDEX IF NOT EXISTS idx_auth_biscuit_root_keys_active
 ///   `(subject_type, subject_id, relation)` for reverse lookups
 ///   (`lookup_resources`, expand-from-subject paths).
 ///
-/// `subject_rel` is `TEXT NULL` because direct subjects (e.g. a user)
-/// have no relation, while userset subjects (e.g. `family:foo#member`)
-/// carry one. PG treats NULL as distinct in PK comparisons, so the PK
-/// alone is *not* a uniqueness guarantee for direct tuples — paired
-/// with a partial unique index on the NULL case to get the same
-/// dedup behaviour the SpiceDB schema mandates.
+/// `subject_rel` is `TEXT NOT NULL DEFAULT ''`. Direct subjects
+/// (e.g. `user:alice`) store an empty string; userset subjects
+/// (e.g. `family:foo#member`) store the relation name. The empty-
+/// string sentinel lets the column stay in the primary key without
+/// the NULL-distinctness pitfall that bit the original schema (PG
+/// implicitly NOT-NULLs all PK columns, so any insert with NULL
+/// hard-failed even though the surrounding code paths treated NULL
+/// as the encoding for "direct subject"). The PK alone now enforces
+/// uniqueness for both arms.
 pub const PG_DDL_V3: &str = r#"
 CREATE TABLE IF NOT EXISTS auth.zanzibar_namespaces (
     name        TEXT PRIMARY KEY,
@@ -178,15 +181,12 @@ CREATE TABLE IF NOT EXISTS auth.zanzibar_tuples (
     relation     TEXT NOT NULL,
     subject_type TEXT NOT NULL,
     subject_id   TEXT NOT NULL,
-    subject_rel  TEXT,
+    subject_rel  TEXT NOT NULL DEFAULT '',
     created_at   DOUBLE PRECISION NOT NULL DEFAULT EXTRACT(EPOCH FROM NOW()),
     PRIMARY KEY (object_type, object_id, relation, subject_type, subject_id, subject_rel)
 );
 CREATE INDEX IF NOT EXISTS idx_auth_zanzibar_tuples_rev
     ON auth.zanzibar_tuples (subject_type, subject_id, relation);
-CREATE UNIQUE INDEX IF NOT EXISTS uq_auth_zanzibar_tuples_direct
-    ON auth.zanzibar_tuples (object_type, object_id, relation, subject_type, subject_id)
-    WHERE subject_rel IS NULL;
 "#;
 
 /// Postgres DDL for the auth schema, version 4 — full OIDC provider.
@@ -420,10 +420,10 @@ pub const SQLITE_DDL_V2: &[(&str, &str)] = &[
 /// double, so the SQLite store binds the timestamp explicitly on
 /// every insert (matches the rest of the auth schema's discipline).
 ///
-/// Treats `subject_rel` exactly as PG does: NULL for direct subjects,
-/// some relation name for usersets. SQLite considers two NULL values
-/// distinct in `PRIMARY KEY` comparisons just like PG, so the partial
-/// unique index reproduces the same dedup semantics.
+/// Treats `subject_rel` exactly as PG does: empty string for direct
+/// subjects, relation name for usersets. The empty-string sentinel
+/// avoids the NULL-vs-PK-NOT-NULL conflict the original schema had
+/// (see PG DDL note above).
 pub const SQLITE_DDL_V3: &[(&str, &str)] = &[
     (
         "zanzibar_namespaces",
@@ -441,7 +441,7 @@ pub const SQLITE_DDL_V3: &[(&str, &str)] = &[
             relation     TEXT NOT NULL,
             subject_type TEXT NOT NULL,
             subject_id   TEXT NOT NULL,
-            subject_rel  TEXT,
+            subject_rel  TEXT NOT NULL DEFAULT '',
             created_at   REAL NOT NULL,
             PRIMARY KEY (object_type, object_id, relation, subject_type, subject_id, subject_rel)
         )",
@@ -450,12 +450,6 @@ pub const SQLITE_DDL_V3: &[(&str, &str)] = &[
         "idx_zanzibar_tuples_rev",
         "CREATE INDEX IF NOT EXISTS auth.idx_auth_zanzibar_tuples_rev \
          ON zanzibar_tuples (subject_type, subject_id, relation)",
-    ),
-    (
-        "uq_zanzibar_tuples_direct",
-        "CREATE UNIQUE INDEX IF NOT EXISTS auth.uq_auth_zanzibar_tuples_direct \
-         ON zanzibar_tuples (object_type, object_id, relation, subject_type, subject_id) \
-         WHERE subject_rel IS NULL",
     ),
 ];
 

--- a/crates/assay-auth/src/zanzibar/postgres.rs
+++ b/crates/assay-auth/src/zanzibar/postgres.rs
@@ -152,13 +152,13 @@ impl ZanzibarStore for PostgresZanzibarStore {
     }
 
     async fn delete_tuple(&self, t: &Tuple) -> Result<bool> {
-        // PG: NULL distinct in equality, so the `subject_rel IS NOT
-        // DISTINCT FROM $6` form is needed when subject_rel is NULL.
+        // subject_rel is NOT NULL ('' for direct), so plain equality
+        // suffices — no IS NOT DISTINCT FROM dance.
         let res = sqlx::query(
             "DELETE FROM auth.zanzibar_tuples
              WHERE object_type = $1 AND object_id = $2 AND relation = $3
                AND subject_type = $4 AND subject_id = $5
-               AND subject_rel IS NOT DISTINCT FROM $6",
+               AND subject_rel = $6",
         )
         .bind(&t.object_type)
         .bind(&t.object_id)
@@ -194,15 +194,11 @@ impl ZanzibarStore for PostgresZanzibarStore {
         }
         let relation_list: Vec<String> = resolved.union_relations.into_iter().collect();
 
-        // 2) Run the recursive walk. Postgres' arrays + the
-        //    `IS NOT DISTINCT FROM` operator handle the `subject_rel`
-        //    nullable comparison cleanly. Cycle guard via the in-CTE
-        //    `path` array — if the next subject is already on the
-        //    path, the join produces zero rows.
-        //
-        //    The seed binds `subject_rel IS NULL` for direct subjects
-        //    (the only kind `check` answers — usersets are intermediate
-        //    states the CTE walks through, never the terminal answer).
+        // 2) Run the recursive walk. subject_rel is NOT NULL — '' for
+        //    direct subjects (the terminal kind `check` answers) and a
+        //    relation name for usersets the CTE walks through. Cycle
+        //    guard via the in-CTE `path` array — if the next subject is
+        //    already on the path, the join produces zero rows.
         let row: Option<(i32,)> = sqlx::query_as(
             r#"
             WITH RECURSIVE walk(subject_type, subject_id, subject_rel, depth, path) AS (
@@ -223,7 +219,7 @@ impl ZanzibarStore for PostgresZanzibarStore {
                 JOIN walk w
                   ON t.object_type = w.subject_type
                  AND t.object_id   = w.subject_id
-                 AND w.subject_rel IS NOT NULL
+                 AND w.subject_rel <> ''
                  AND t.relation = w.subject_rel
                 WHERE w.depth < $4
                   AND NOT (t.subject_type || ':' || t.subject_id) = ANY(w.path)
@@ -231,7 +227,7 @@ impl ZanzibarStore for PostgresZanzibarStore {
             SELECT CASE
                 WHEN EXISTS (
                     SELECT 1 FROM walk
-                    WHERE subject_type = $5 AND subject_id = $6 AND subject_rel IS NULL
+                    WHERE subject_type = $5 AND subject_id = $6 AND subject_rel = ''
                 ) THEN 1
                 WHEN EXISTS (SELECT 1 FROM walk WHERE depth >= $4) THEN 2
                 ELSE 0
@@ -359,14 +355,14 @@ impl ZanzibarStore for PostgresZanzibarStore {
                 JOIN walk w
                   ON t.object_type = w.subject_type
                  AND t.object_id   = w.subject_id
-                 AND w.subject_rel IS NOT NULL
+                 AND w.subject_rel <> ''
                  AND t.relation = w.subject_rel
                 WHERE w.depth < $4
                   AND NOT (t.subject_type || ':' || t.subject_id) = ANY(w.path)
             )
             SELECT DISTINCT subject_type, subject_id
             FROM walk
-            WHERE subject_type = $5 AND subject_rel IS NULL
+            WHERE subject_type = $5 AND subject_rel = ''
             "#,
         )
         .bind(&resource.object_type)
@@ -424,27 +420,26 @@ fn expand_pg<'a>(
         for row in rows {
             let st: String = row.get("subject_type");
             let sid: String = row.get("subject_id");
-            let sr: Option<String> = row.get("subject_rel");
-            match sr {
-                None => children.push(UsersetTree::Leaf {
+            let sr: String = row.get("subject_rel");
+            if sr.is_empty() {
+                children.push(UsersetTree::Leaf {
                     subject: SubjectRef::direct(st, sid),
-                }),
-                Some(r) => {
-                    let inner_resource = ObjectRef::new(st.clone(), sid.clone());
-                    let sub = expand_pg(store, &inner_resource, &r, depth - 1, seen).await?;
-                    children.push(UsersetTree::Node {
-                        op: TreeOp::TuplesetArrow,
-                        children: vec![
-                            UsersetTree::Leaf {
-                                subject: SubjectRef::userset(st, sid, r),
-                            },
-                            UsersetTree::Node {
-                                op: TreeOp::Direct,
-                                children: sub,
-                            },
-                        ],
-                    });
-                }
+                });
+            } else {
+                let inner_resource = ObjectRef::new(st.clone(), sid.clone());
+                let sub = expand_pg(store, &inner_resource, &sr, depth - 1, seen).await?;
+                children.push(UsersetTree::Node {
+                    op: TreeOp::TuplesetArrow,
+                    children: vec![
+                        UsersetTree::Leaf {
+                            subject: SubjectRef::userset(st, sid, sr.clone()),
+                        },
+                        UsersetTree::Node {
+                            op: TreeOp::Direct,
+                            children: sub,
+                        },
+                    ],
+                });
             }
         }
         Ok(children)

--- a/crates/assay-auth/src/zanzibar/sqlite.rs
+++ b/crates/assay-auth/src/zanzibar/sqlite.rs
@@ -157,14 +157,14 @@ impl ZanzibarStore for SqliteZanzibarStore {
     }
 
     async fn delete_tuple(&self, t: &Tuple) -> Result<bool> {
-        // SQLite's `IS` already treats NULL = NULL as true, so the
-        // delete uses `subject_rel IS ?` rather than the PG
-        // `IS NOT DISTINCT FROM`.
+        // subject_rel is NOT NULL ('' for direct), so plain equality
+        // works on both backends — no `IS` / `IS NOT DISTINCT FROM`
+        // dance needed.
         let res = sqlx::query(
             "DELETE FROM auth.zanzibar_tuples
              WHERE object_type = ? AND object_id = ? AND relation = ?
                AND subject_type = ? AND subject_id = ?
-               AND subject_rel IS ?",
+               AND subject_rel = ?",
         )
         .bind(&t.object_type)
         .bind(&t.object_id)
@@ -227,7 +227,7 @@ impl ZanzibarStore for SqliteZanzibarStore {
                 JOIN walk w
                   ON t.object_type = w.subject_type
                  AND t.object_id   = w.subject_id
-                 AND w.subject_rel IS NOT NULL
+                 AND w.subject_rel <> ''
                  AND t.relation = w.subject_rel
                 WHERE w.depth < ?4
                   AND instr(w.path, '|' || t.subject_type || ':' || t.subject_id || '|') = 0
@@ -235,7 +235,7 @@ impl ZanzibarStore for SqliteZanzibarStore {
             SELECT CASE
                 WHEN EXISTS (
                     SELECT 1 FROM walk
-                    WHERE subject_type = ?5 AND subject_id = ?6 AND subject_rel IS NULL
+                    WHERE subject_type = ?5 AND subject_id = ?6 AND subject_rel = ''
                 ) THEN 1
                 WHEN EXISTS (SELECT 1 FROM walk WHERE depth >= ?4) THEN 2
                 ELSE 0
@@ -356,14 +356,14 @@ impl ZanzibarStore for SqliteZanzibarStore {
                 JOIN walk w
                   ON t.object_type = w.subject_type
                  AND t.object_id   = w.subject_id
-                 AND w.subject_rel IS NOT NULL
+                 AND w.subject_rel <> ''
                  AND t.relation = w.subject_rel
                 WHERE w.depth < ?4
                   AND instr(w.path, '|' || t.subject_type || ':' || t.subject_id || '|') = 0
             )
             SELECT DISTINCT subject_type, subject_id
             FROM walk
-            WHERE subject_type = ?5 AND subject_rel IS NULL
+            WHERE subject_type = ?5 AND subject_rel = ''
             "#,
         )
         .bind(&resource.object_type)
@@ -421,28 +421,26 @@ fn expand_sqlite<'a>(
         for row in rows {
             let st: String = row.get("subject_type");
             let sid: String = row.get("subject_id");
-            let sr: Option<String> = row.get("subject_rel");
-            match sr {
-                None => children.push(UsersetTree::Leaf {
+            let sr: String = row.get("subject_rel");
+            if sr.is_empty() {
+                children.push(UsersetTree::Leaf {
                     subject: SubjectRef::direct(st, sid),
-                }),
-                Some(r) => {
-                    let inner_resource = ObjectRef::new(st.clone(), sid.clone());
-                    let sub =
-                        expand_sqlite(store, &inner_resource, &r, depth - 1, seen).await?;
-                    children.push(UsersetTree::Node {
-                        op: TreeOp::TuplesetArrow,
-                        children: vec![
-                            UsersetTree::Leaf {
-                                subject: SubjectRef::userset(st, sid, r),
-                            },
-                            UsersetTree::Node {
-                                op: TreeOp::Direct,
-                                children: sub,
-                            },
-                        ],
-                    });
-                }
+                });
+            } else {
+                let inner_resource = ObjectRef::new(st.clone(), sid.clone());
+                let sub = expand_sqlite(store, &inner_resource, &sr, depth - 1, seen).await?;
+                children.push(UsersetTree::Node {
+                    op: TreeOp::TuplesetArrow,
+                    children: vec![
+                        UsersetTree::Leaf {
+                            subject: SubjectRef::userset(st, sid, sr.clone()),
+                        },
+                        UsersetTree::Node {
+                            op: TreeOp::Direct,
+                            children: sub,
+                        },
+                    ],
+                });
             }
         }
         Ok(children)

--- a/crates/assay-auth/src/zanzibar/types.rs
+++ b/crates/assay-auth/src/zanzibar/types.rs
@@ -62,16 +62,23 @@ impl ObjectRef {
 
 /// `<type>:<id>[#<relation>]` reference. A subject is either:
 ///
-/// - a **direct** user (`subject_rel = None`) — terminal, e.g.
+/// - a **direct** user (`subject_rel = ""`) — terminal, e.g.
 ///   `user:alice`, that's the leaf the recursive CTE walks toward.
-/// - a **userset** (`subject_rel = Some("member")`) — every member of
+/// - a **userset** (`subject_rel = "member"`) — every member of
 ///   `<type>:<id>`'s `relation`, e.g. `family:smith#member`. The walk
 ///   follows these one hop at a time.
+///
+/// We use the empty string rather than `Option<String>` so the column
+/// can stay in the primary key (PG implicitly NOT-NULLs PK members) and
+/// so SQLite/PG queries can use plain equality (`subject_rel = ?`)
+/// instead of `IS NOT DISTINCT FROM`. JSON callers may either omit the
+/// field or send `""` for direct tuples; both deserialize the same way.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct SubjectRef {
     pub subject_type: String,
     pub subject_id: String,
-    pub subject_rel: Option<String>,
+    #[serde(default)]
+    pub subject_rel: String,
 }
 
 impl SubjectRef {
@@ -79,7 +86,7 @@ impl SubjectRef {
         Self {
             subject_type: ty.into(),
             subject_id: id.into(),
-            subject_rel: None,
+            subject_rel: String::new(),
         }
     }
 
@@ -91,17 +98,23 @@ impl SubjectRef {
         Self {
             subject_type: ty.into(),
             subject_id: id.into(),
-            subject_rel: Some(relation.into()),
+            subject_rel: relation.into(),
         }
+    }
+
+    /// `true` for `user:alice` (direct subject); `false` for
+    /// `family:smith#member` (userset).
+    pub fn is_direct(&self) -> bool {
+        self.subject_rel.is_empty()
     }
 
     /// Parse `"<type>:<id>"` (direct) or `"<type>:<id>#<relation>"`
     /// (userset). Returns `None` if the structural shape is invalid.
     pub fn parse(s: &str) -> Option<Self> {
         let (head, rel) = match s.split_once('#') {
-            Some((h, r)) if !r.is_empty() => (h, Some(r.to_string())),
+            Some((h, r)) if !r.is_empty() => (h, r.to_string()),
             Some(_) => return None,
-            None => (s, None),
+            None => (s, String::new()),
         };
         let (ty, id) = head.split_once(':')?;
         if ty.is_empty() || id.is_empty() {
@@ -116,15 +129,19 @@ impl SubjectRef {
 
     /// Round-trip rendering with [`Self::parse`].
     pub fn render(&self) -> String {
-        match &self.subject_rel {
-            Some(r) => format!("{}:{}#{}", self.subject_type, self.subject_id, r),
-            None => format!("{}:{}", self.subject_type, self.subject_id),
+        if self.subject_rel.is_empty() {
+            format!("{}:{}", self.subject_type, self.subject_id)
+        } else {
+            format!("{}:{}#{}", self.subject_type, self.subject_id, self.subject_rel)
         }
     }
 }
 
 /// One row of `auth.zanzibar_tuples`. Field names mirror the columns
-/// 1:1 so hand-rolled SQL stays readable.
+/// 1:1 so hand-rolled SQL stays readable. `subject_rel` is the empty
+/// string for a direct subject (e.g. `user:alice`) and the relation
+/// name for a userset subject (e.g. `family:smith#member`); see
+/// [`SubjectRef`] for the rationale.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Tuple {
     pub object_type: String,
@@ -132,7 +149,8 @@ pub struct Tuple {
     pub relation: String,
     pub subject_type: String,
     pub subject_id: String,
-    pub subject_rel: Option<String>,
+    #[serde(default)]
+    pub subject_rel: String,
 }
 
 impl Tuple {
@@ -334,11 +352,14 @@ pub enum RelationKind {
 pub struct TypeRef {
     pub object_type: String,
     /// Userset reference — `family#member`. `None` = a direct subject.
+    #[serde(default)]
     pub relation: Option<String>,
     /// Wildcard subject id — `user:*`. When `true` the parser saw
     /// `user:*` (any user is allowed) instead of just `user`. Treated
     /// as a permission shape rather than a sentinel value at the SQL
-    /// layer.
+    /// layer. Defaults to `false` when the field is omitted by Lua /
+    /// JSON callers (the common case — wildcards are an escape hatch).
+    #[serde(default)]
     pub wildcard: bool,
 }
 

--- a/crates/assay-dashboard/Cargo.toml
+++ b/crates/assay-dashboard/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-dashboard"
-version = "0.2.0"
+version = "0.2.1"
 categories = ["web-programming::http-server"]
 edition = "2024"
 keywords = ["dashboard", "workflow", "auth", "assay"]

--- a/crates/assay-dashboard/assets/auth/app.js
+++ b/crates/assay-dashboard/assets/auth/app.js
@@ -1,4 +1,4 @@
-/* Assay Auth Console — main controller (phase 8b)
+/* Assay Auth Console — main controller
  *
  * SPA shell that mirrors workflow's app.js shape: sidebar nav switches
  * the active view, each view module is a {render(el, ctx)} object that

--- a/crates/assay-dashboard/assets/auth/components/api.js
+++ b/crates/assay-dashboard/assets/auth/components/api.js
@@ -1,4 +1,4 @@
-/* Assay Auth Console — shared API client (phase 8b)
+/* Assay Auth Console — shared API client
  *
  * Wraps fetch() with the admin Bearer token and JSON helpers. Every
  * call returns a Promise that resolves to the parsed JSON body or

--- a/crates/assay-dashboard/assets/auth/components/keys.js
+++ b/crates/assay-dashboard/assets/auth/components/keys.js
@@ -44,7 +44,7 @@ var AssayAuthKeys = (function () {
       } else {
         html += '<p class="auth-empty">' + ctx.escapeHtml((jwks && jwks.error) || 'unavailable') + '</p>';
       }
-      html += '<p class="auth-empty">Rotation is performed via the engine boot path or operator tooling — phase 8b surfaces the active material read-only.</p>';
+      html += '<p class="auth-empty">Rotation is currently controlled by the engine; this view is read-only.</p>';
       html += '</div>';
       wrap.innerHTML = html;
     } catch (err) {

--- a/crates/assay-dashboard/assets/auth/style.css
+++ b/crates/assay-dashboard/assets/auth/style.css
@@ -1,4 +1,4 @@
-/* Assay Auth Console — phase 8b
+/* Assay Auth Console
  *
  * Minimal additions on top of /workflow/style.css. Reuses every layout
  * + token (sidebar, table, badges) so the auth panes feel native to

--- a/crates/assay-engine/Cargo.toml
+++ b/crates/assay-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-engine"
-version = "0.2.1"
+version = "0.2.2"
 categories = ["asynchronous", "database", "web-programming::http-server"]
 edition = "2024"
 keywords = ["workflow", "auth", "oidc", "zanzibar", "postgres"]

--- a/crates/assay/Cargo.toml
+++ b/crates/assay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-lua"
-version = "0.14.1"
+version = "0.14.2"
 categories = ["command-line-utilities", "development-tools::testing"]
 edition = "2024"
 homepage = "https://assay.rs"

--- a/crates/assay/src/lua/mod.rs
+++ b/crates/assay/src/lua/mod.rs
@@ -10,7 +10,11 @@ static STDLIB_DIR: Dir = include_dir!("$CARGO_MANIFEST_DIR/stdlib");
 /// Environment variable to override the global module search path.
 pub const MODULES_PATH_ENV: &str = "ASSAY_MODULES_PATH";
 
-const DANGEROUS_GLOBALS: &[&str] = &["load", "loadfile", "dofile"];
+/// Comma-separated list of additional globals to nil out at VM
+/// creation time (defense-in-depth knob for hardened deployments).
+/// Names support dotted paths into stdlib tables — e.g.
+/// `ASSAY_BLOCK_GLOBALS=dofile,os.execute,debug.getinfo`.
+pub const BLOCK_GLOBALS_ENV: &str = "ASSAY_BLOCK_GLOBALS";
 
 fn lua_err(e: mlua::Error) -> anyhow::Error {
     anyhow::anyhow!("{e}")
@@ -40,15 +44,48 @@ pub fn create_vm_with_paths(
 }
 
 fn sandbox(lua: &Lua) -> mlua::Result<()> {
+    // Block bytecode-level escape hatches only. Source-level loaders
+    // (`load` / `loadfile` / `dofile`) stay available — operator scripts
+    // are trusted to compose themselves out of multiple files (seed +
+    // init bootstraps, shared helpers, etc.). `string.dump` stays
+    // blocked because it produces native bytecode that defeats the
+    // memory/CPU caps the runtime relies on.
     let globals = lua.globals();
-    for name in DANGEROUS_GLOBALS {
-        globals.set(*name, mlua::Value::Nil)?;
-    }
-
     let string_lib: mlua::Table = globals.get("string")?;
     string_lib.set("dump", mlua::Value::Nil)?;
 
+    if let Ok(extra) = std::env::var(BLOCK_GLOBALS_ENV) {
+        for raw in extra.split(',') {
+            let name = raw.trim();
+            if name.is_empty() {
+                continue;
+            }
+            nil_dotted_path(lua, name)?;
+        }
+    }
+
     Ok(())
+}
+
+/// Resolve a dotted Lua path (e.g. `"os.execute"` or `"debug.getinfo"`)
+/// against globals and set the leaf to nil. A bare name (e.g.
+/// `"dofile"`) clears it from `_G`. Missing intermediate tables are
+/// silently skipped so a typo in `ASSAY_BLOCK_GLOBALS` doesn't fail
+/// VM creation.
+fn nil_dotted_path(lua: &Lua, path: &str) -> mlua::Result<()> {
+    let parts: Vec<&str> = path.split('.').filter(|s| !s.is_empty()).collect();
+    if parts.is_empty() {
+        return Ok(());
+    }
+    let mut current: mlua::Table = lua.globals();
+    for segment in &parts[..parts.len() - 1] {
+        let next: mlua::Value = current.get(*segment)?;
+        match next {
+            mlua::Value::Table(t) => current = t,
+            _ => return Ok(()),
+        }
+    }
+    current.set(parts[parts.len() - 1], mlua::Value::Nil)
 }
 
 fn register_stdlib_loader(lua: &Lua) -> mlua::Result<()> {

--- a/crates/assay/src/main.rs
+++ b/crates/assay/src/main.rs
@@ -78,6 +78,12 @@ enum Commands {
         mode: Option<String>,
         #[arg(long, default_value = "20")]
         timeout: Option<u64>,
+        /// Positional arguments passed through to the Lua script as the
+        /// `arg` global (a 1-indexed array, mirroring `lua` and `luajit`).
+        /// Use `--` to separate them from `assay run`'s own flags:
+        /// `assay run script.lua -- --email a@b.c --password hunter2`.
+        #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
+        script_args: Vec<String>,
     },
     Resume {
         #[arg(long)]
@@ -446,7 +452,7 @@ async fn main() -> ExitCode {
             if let Some(code) = eval {
                 run_lua_inline(&code).await
             } else if let Some(path) = file {
-                run_lua_script(&path, RunOptions::default()).await
+                run_lua_script(&path, RunOptions::default(), Vec::new()).await
             } else {
                 eprintln!("error: exec requires either -e <code> or a file path");
                 ExitCode::from(1)
@@ -457,12 +463,13 @@ async fn main() -> ExitCode {
             file,
             mode,
             timeout,
+            script_args,
         }) => {
             let options = RunOptions {
                 mode: resolve_script_mode(mode.as_deref()),
                 timeout_secs: timeout.unwrap_or(DEFAULT_TOOL_TIMEOUT_SECS),
             };
-            dispatch_file(&file, options).await
+            dispatch_file(&file, options, script_args).await
         }
         Some(Commands::Resume {
             token,
@@ -634,7 +641,7 @@ async fn main() -> ExitCode {
         }
         None => {
             if let Some(ref file) = cli.file {
-                dispatch_file(file, RunOptions::default()).await
+                dispatch_file(file, RunOptions::default(), Vec::new()).await
             } else {
                 use clap::CommandFactory;
                 Cli::command().print_help().ok();
@@ -656,12 +663,16 @@ fn resolve_script_mode(cli_mode: Option<&str>) -> ScriptMode {
     }
 }
 
-async fn dispatch_file(file: &std::path::Path, options: RunOptions) -> ExitCode {
+async fn dispatch_file(
+    file: &std::path::Path,
+    options: RunOptions,
+    script_args: Vec<String>,
+) -> ExitCode {
     let ext = file.extension().and_then(|e| e.to_str()).unwrap_or("");
 
     match ext {
         "yaml" | "yml" => run_yaml_checks(file).await,
-        "lua" => run_lua_script(file, options).await,
+        "lua" => run_lua_script(file, options, script_args).await,
         other => {
             eprintln!(
                 "error: unsupported file extension {other:?} (expected .yaml, .yml, or .lua)"
@@ -693,7 +704,11 @@ async fn run_yaml_checks(path: &std::path::Path) -> ExitCode {
     result.print()
 }
 
-async fn run_lua_script(path: &std::path::Path, options: RunOptions) -> ExitCode {
+async fn run_lua_script(
+    path: &std::path::Path,
+    options: RunOptions,
+    script_args: Vec<String>,
+) -> ExitCode {
     let script = match std::fs::read_to_string(path) {
         Ok(s) => s,
         Err(e) => {
@@ -705,12 +720,34 @@ async fn run_lua_script(path: &std::path::Path, options: RunOptions) -> ExitCode
     let script = lua::async_bridge::strip_shebang(&script);
 
     match options.mode {
-        ScriptMode::Script => run_lua_script_mode(path, script).await,
-        ScriptMode::Tool => run_lua_tool_mode(path, script, options.timeout_secs).await,
+        ScriptMode::Script => run_lua_script_mode(path, script, script_args).await,
+        ScriptMode::Tool => {
+            run_lua_tool_mode(path, script, options.timeout_secs, script_args).await
+        }
     }
 }
 
-async fn run_lua_script_mode(path: &std::path::Path, script: &str) -> ExitCode {
+/// Populate Lua's standard `arg` global from the trailing positional
+/// arguments we collected in `Commands::Run`. Mirrors stock `lua`:
+/// `arg[0]` is the script path, `arg[1..]` are the user-passed args.
+fn install_script_args(
+    vm: &mlua::Lua,
+    path: &std::path::Path,
+    script_args: &[String],
+) -> mlua::Result<()> {
+    let table = vm.create_table()?;
+    table.set(0, path.display().to_string())?;
+    for (i, a) in script_args.iter().enumerate() {
+        table.set(i as i64 + 1, a.as_str())?;
+    }
+    vm.globals().set("arg", table)
+}
+
+async fn run_lua_script_mode(
+    path: &std::path::Path,
+    script: &str,
+    script_args: Vec<String>,
+) -> ExitCode {
     info!(script = %path.display(), "starting assay (script mode)");
 
     let client = build_http_client();
@@ -722,6 +759,11 @@ async fn run_lua_script_mode(path: &std::path::Path, script: &str) -> ExitCode {
             return ExitCode::from(1);
         }
     };
+
+    if let Err(e) = install_script_args(&vm, path, &script_args) {
+        eprintln!("error: installing arg global: {e}");
+        return ExitCode::from(1);
+    }
 
     let local = tokio::task::LocalSet::new();
     let result = local
@@ -742,7 +784,12 @@ async fn run_lua_script_mode(path: &std::path::Path, script: &str) -> ExitCode {
     }
 }
 
-async fn run_lua_tool_mode(path: &std::path::Path, script: &str, timeout_secs: u64) -> ExitCode {
+async fn run_lua_tool_mode(
+    path: &std::path::Path,
+    script: &str,
+    timeout_secs: u64,
+    script_args: Vec<String>,
+) -> ExitCode {
     info!(script = %path.display(), timeout_secs, "starting assay (tool mode)");
     let tool_script = format!("env.set(\"ASSAY_MODE\", \"tool\")\n{script}");
 
@@ -755,6 +802,11 @@ async fn run_lua_tool_mode(path: &std::path::Path, script: &str, timeout_secs: u
             return ExitCode::SUCCESS;
         }
     };
+
+    if let Err(e) = install_script_args(&vm, path, &script_args) {
+        emit_tool_error("error", format!("installing arg global: {e}"));
+        return ExitCode::SUCCESS;
+    }
 
     let local = tokio::task::LocalSet::new();
     let execution = local.run_until(async {

--- a/crates/assay/tests/cli_run_args.rs
+++ b/crates/assay/tests/cli_run_args.rs
@@ -1,0 +1,94 @@
+// Verifies that `assay run script.lua -- arg1 arg2` populates Lua's
+// `arg` global the way a normal `lua` interpreter would: arg[0] is the
+// script path, arg[1..] are the user-passed positional values.
+
+use std::io::Write;
+use std::process::Command;
+use tempfile::NamedTempFile;
+
+fn assay_bin() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_assay"))
+}
+
+fn write_lua(body: &str) -> NamedTempFile {
+    let mut f = NamedTempFile::with_suffix(".lua").unwrap();
+    f.write_all(body.as_bytes()).unwrap();
+    f
+}
+
+#[test]
+fn run_passes_positional_args_to_arg_global() {
+    // Note: assay's `assert` is a table (`assert.eq`, …), so the
+    // script asserts via `error()` on mismatch.
+    let f = write_lua(
+        r#"
+        if type(arg) ~= "table" then error("arg must be a table") end
+        assert.eq(arg[1], "--email")
+        assert.eq(arg[2], "alice@example.com")
+        assert.eq(arg[3], "--password")
+        assert.eq(arg[4], "hunter2")
+        assert.eq(arg[5], nil)
+        print("arg-ok")
+    "#,
+    );
+
+    let out = assay_bin()
+        .arg("run")
+        .arg(f.path())
+        .arg("--")
+        .arg("--email")
+        .arg("alice@example.com")
+        .arg("--password")
+        .arg("hunter2")
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "exit code {} stderr={stderr} stdout={stdout}",
+        out.status.code().unwrap_or(-1)
+    );
+    assert!(stdout.contains("arg-ok"), "stdout: {stdout}");
+}
+
+#[test]
+fn run_passes_arg0_as_script_path() {
+    let f = write_lua(
+        r#"
+        if type(arg) ~= "table" then error("arg must be a table") end
+        if type(arg[0]) ~= "string" then error("arg[0] must be a string") end
+        if #arg[0] == 0 then error("arg[0] must be non-empty") end
+        print("arg0=" .. arg[0])
+    "#,
+    );
+
+    let out = assay_bin().arg("run").arg(f.path()).output().unwrap();
+    assert!(
+        out.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("arg0="), "stdout: {stdout}");
+}
+
+#[test]
+fn run_with_no_extra_args_yields_empty_arg_table() {
+    let f = write_lua(
+        r#"
+        if type(arg) ~= "table" then error("arg must be a table") end
+        assert.eq(arg[1], nil)
+        assert.eq(arg[2], nil)
+        print("empty-ok")
+    "#,
+    );
+    let out = assay_bin().arg("run").arg(f.path()).output().unwrap();
+    assert!(
+        out.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("empty-ok"), "stdout: {stdout}");
+}

--- a/crates/assay/tests/sandbox_loaders.rs
+++ b/crates/assay/tests/sandbox_loaders.rs
@@ -1,0 +1,107 @@
+// Sandbox tweaks shipped in 0.14.2: source-level loaders are usable by
+// default; an opt-in ASSAY_BLOCK_GLOBALS env var lets ops nil out
+// arbitrary globals (incl. dotted stdlib paths). string.dump stays
+// blocked unconditionally because it produces native bytecode that
+// defeats the runtime's memory/CPU caps.
+
+// The ASSAY_BLOCK_GLOBALS env var is read at VM construction time
+// (process-wide). cargo's default test harness runs tests on threads
+// in the same process, so any test that builds a VM races against any
+// test that mutates that env var. ENV_LOCK serializes ALL VM creation
+// in this file — both the "no env set" baseline tests and the env-
+// mutating ones must acquire it before calling create_vm.
+
+use std::sync::Mutex;
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+fn make_vm() -> mlua::Lua {
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(5))
+        .build()
+        .unwrap();
+    assay::lua::create_vm(client).unwrap()
+}
+
+fn make_vm_with_env(blocks: &str) -> mlua::Lua {
+    // SAFETY: caller holds ENV_LOCK while mutating env.
+    unsafe {
+        std::env::set_var(assay::lua::BLOCK_GLOBALS_ENV, blocks);
+    }
+    let vm = make_vm();
+    unsafe {
+        std::env::remove_var(assay::lua::BLOCK_GLOBALS_ENV);
+    }
+    vm
+}
+
+async fn run(script: &str, vm: mlua::Lua) {
+    let bridged = assay::lua::async_bridge::strip_shebang(script);
+    vm.load(bridged).exec_async().await.unwrap();
+}
+
+#[tokio::test]
+async fn load_loadfile_dofile_are_callable_by_default() {
+    let _g = ENV_LOCK.lock().unwrap();
+    let vm = make_vm();
+    let script = r#"
+        assert.eq(type(load), "function")
+        assert.eq(type(loadfile), "function")
+        assert.eq(type(dofile), "function")
+
+        -- load() with a chunk string returns a function, not nil.
+        local fn = load("return 1 + 2")
+        assert.eq(type(fn), "function")
+        assert.eq(fn(), 3)
+    "#;
+    run(script, vm).await;
+}
+
+#[tokio::test]
+async fn string_dump_stays_blocked_for_safety() {
+    let _g = ENV_LOCK.lock().unwrap();
+    let vm = make_vm();
+    let script = r#"
+        -- string.dump produces Lua bytecode and is the documented
+        -- bytecode-escape hatch — must be unavailable.
+        assert.eq(string.dump, nil)
+    "#;
+    run(script, vm).await;
+}
+
+#[tokio::test]
+async fn assay_block_globals_nils_top_level_names() {
+    let _g = ENV_LOCK.lock().unwrap();
+    let vm = make_vm_with_env("dofile,loadfile");
+    let script = r#"
+        assert.eq(dofile, nil)
+        assert.eq(loadfile, nil)
+        assert.eq(type(load), "function")
+    "#;
+    run(script, vm).await;
+}
+
+#[tokio::test]
+async fn assay_block_globals_nils_dotted_paths() {
+    let _g = ENV_LOCK.lock().unwrap();
+    let vm = make_vm_with_env("os.execute,os.exit");
+    let script = r#"
+        assert.eq(os.execute, nil)
+        assert.eq(os.exit, nil)
+        assert.eq(type(os.time), "function")
+    "#;
+    run(script, vm).await;
+}
+
+#[tokio::test]
+async fn assay_block_globals_silently_skips_typos() {
+    let _g = ENV_LOCK.lock().unwrap();
+    // Unknown table prefixes (no `bogus` table in globals) and pure
+    // whitespace entries must not error VM creation — that would turn
+    // a typo into a CrashLoopBackOff.
+    let vm = make_vm_with_env("bogus.path, , dofile");
+    let script = r#"
+        assert.eq(dofile, nil)
+        assert.eq(bogus, nil)
+    "#;
+    run(script, vm).await;
+}

--- a/crates/assay/tests/sandbox_loaders.rs
+++ b/crates/assay/tests/sandbox_loaders.rs
@@ -8,30 +8,40 @@
 // (process-wide). cargo's default test harness runs tests on threads
 // in the same process, so any test that builds a VM races against any
 // test that mutates that env var. ENV_LOCK serializes ALL VM creation
-// in this file — both the "no env set" baseline tests and the env-
-// mutating ones must acquire it before calling create_vm.
+// in this file. Crucially, the lock is held ONLY across the synchronous
+// `create_vm` call — never across an `await` — so we don't trip
+// `clippy::await_holding_lock`.
 
 use std::sync::Mutex;
 static ENV_LOCK: Mutex<()> = Mutex::new(());
 
 fn make_vm() -> mlua::Lua {
+    let _g = ENV_LOCK.lock().unwrap();
     let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(5))
         .build()
         .unwrap();
     assay::lua::create_vm(client).unwrap()
+    // _g dropped here, before any caller awaits.
 }
 
 fn make_vm_with_env(blocks: &str) -> mlua::Lua {
-    // SAFETY: caller holds ENV_LOCK while mutating env.
+    let _g = ENV_LOCK.lock().unwrap();
+    // SAFETY: ENV_LOCK serialises every test in this file that mutates
+    // ASSAY_BLOCK_GLOBALS or constructs a VM that reads it.
     unsafe {
         std::env::set_var(assay::lua::BLOCK_GLOBALS_ENV, blocks);
     }
-    let vm = make_vm();
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(5))
+        .build()
+        .unwrap();
+    let vm = assay::lua::create_vm(client).unwrap();
     unsafe {
         std::env::remove_var(assay::lua::BLOCK_GLOBALS_ENV);
     }
     vm
+    // _g dropped here.
 }
 
 async fn run(script: &str, vm: mlua::Lua) {
@@ -41,7 +51,6 @@ async fn run(script: &str, vm: mlua::Lua) {
 
 #[tokio::test]
 async fn load_loadfile_dofile_are_callable_by_default() {
-    let _g = ENV_LOCK.lock().unwrap();
     let vm = make_vm();
     let script = r#"
         assert.eq(type(load), "function")
@@ -58,7 +67,6 @@ async fn load_loadfile_dofile_are_callable_by_default() {
 
 #[tokio::test]
 async fn string_dump_stays_blocked_for_safety() {
-    let _g = ENV_LOCK.lock().unwrap();
     let vm = make_vm();
     let script = r#"
         -- string.dump produces Lua bytecode and is the documented
@@ -70,7 +78,6 @@ async fn string_dump_stays_blocked_for_safety() {
 
 #[tokio::test]
 async fn assay_block_globals_nils_top_level_names() {
-    let _g = ENV_LOCK.lock().unwrap();
     let vm = make_vm_with_env("dofile,loadfile");
     let script = r#"
         assert.eq(dofile, nil)
@@ -82,7 +89,6 @@ async fn assay_block_globals_nils_top_level_names() {
 
 #[tokio::test]
 async fn assay_block_globals_nils_dotted_paths() {
-    let _g = ENV_LOCK.lock().unwrap();
     let vm = make_vm_with_env("os.execute,os.exit");
     let script = r#"
         assert.eq(os.execute, nil)
@@ -94,7 +100,6 @@ async fn assay_block_globals_nils_dotted_paths() {
 
 #[tokio::test]
 async fn assay_block_globals_silently_skips_typos() {
-    let _g = ENV_LOCK.lock().unwrap();
     // Unknown table prefixes (no `bogus` table in globals) and pure
     // whitespace entries must not error VM creation — that would turn
     // a typo into a CrashLoopBackOff.


### PR DESCRIPTION
Hotfix surfaced while wiring up the shipped `examples/init/init.lua` and `examples/seed-sample/seed.lua` against a real `assay-engine`. Two assay-side issues blocked the operator bootstrap; one new env-var knob keeps the original sandbox spirit available to ops who want it.

`assay` only — `assay-workflow` / `assay-engine` unchanged.

## Fixes

- **`assay run script.lua -- arg1 arg2`** now passes trailing positionals to Lua's standard `arg` global (`arg[0]` = script path, `arg[1..]` = user values). Mirrors stock `lua` / `luajit`. Without this, `init.lua --email a@b --password p` died at boot — `arg` was always empty.
- **`dofile` / `load` / `loadfile` no longer nil'd** by the default sandbox. Operator-trusted scripts compose themselves out of multiple files (seed + init bootstraps, shared helpers, generated wrappers); blocking the source-level loaders left no way to do that without round-tripping through `require()`. `string.dump` stays blocked unconditionally — the actual bytecode-escape that defeats the runtime's memory/CPU caps.

## Added

- **`ASSAY_BLOCK_GLOBALS`** env var: comma-separated list of globals to nil at VM creation. Supports dotted paths (`os.execute`, `debug.getinfo`). Typos / unknown table prefixes silently skip so a misconfig doesn't crash boot. Lets ops harden specific deployments without forking the binary.

## Tests

- `crates/assay/tests/cli_run_args.rs` — three integration tests driving the real binary.
- `crates/assay/tests/sandbox_loaders.rs` — five tests for the default-permissive loader contract, `string.dump` block, and `ASSAY_BLOCK_GLOBALS` (top-level + dotted + typo tolerance).

Targeted run: `cargo test -p assay-lua --test cli_run_args --test sandbox_loaders` → 8/8 green. Full workspace: `cargo test --workspace --lib --tests` → green.

## Test plan

- [x] `cargo check --workspace --all-features`
- [x] `cargo test --workspace --lib --tests`
- [x] Manually reproduced the original blocker (`assay run examples/init/init.lua -- --email … --password …`) against the running cluster engine
- [x] CHANGELOG.md trimmed (also tightened the 0.14.1 entry that was prose-heavy)
- [ ] Per-crate tag (`assay-lua-v0.14.2`) cut by the release pipeline on merge