### PR TITLE
v0.3.0 — assay-secrets module (plan + implementation)

### DIFF
--- a/.claude/plans/17-v0.3.0-secrets-module.md
+++ b/.claude/plans/17-v0.3.0-secrets-module.md
@@ -1,0 +1,366 @@
+# Plan 17 — assay-engine v0.3.0: secrets module
+
+**Status:** drafted, not started **Successor of:** plan 12 (v0.2.0 auth + IdP) **Target tag:**
+`assay-engine-v0.3.0` **Sibling crate:** `assay-secrets` (new) at `crates/assay-secrets/`
+
+## Why this exists
+
+assay-engine v0.2.x already covers identity, authz, workflows. The fourth thing every self-hosted
+ops stack needs is **secrets** — the gap is currently filled by Vault (service secrets) plus
+1Password / Bitwarden (human secrets). They overlap in capability, don't share identity, don't share
+audit, run as separate stacks.
+
+The unified-platform thesis says: one binary, one auth model, one audit log, one dashboard. Add
+secrets as the fourth module and the ~300 MB compressed footprint of (Vault + 1pw self-host)
+collapses into the existing engine binary at +3-5 MB.
+
+This plan scopes a **first cut** that ships ~80% of real usage. The long tail (PKI v2, ACME,
+GCP/Azure dynamic creds, plugin runtime, enterprise replication) is explicitly out.
+
+## Cost estimate
+
+| Dimension      | engine 0.2.x today | + secrets enabled |
+| -------------- | ------------------ | ----------------- |
+| Binary on-disk | 19 MB              | 22-25 MB          |
+| Compressed     | ~14 MB             | ~16-18 MB         |
+| Idle RAM       | ~80-150 MB         | ~100-180 MB       |
+| Cold compile   | ~3 min             | ~3.5-4 min        |
+
+Low delta because assay-auth already pulls in `argon2`, `ed25519-dalek`, `aes-gcm-siv` (via
+`webauthn-rs`), `biscuit-auth`. The new code is schema + handlers + sharing math, not new crypto.
+
+## Scope (what's IN)
+
+### S1. KV v2 — versioned key/value store
+
+Vault's KV v2 semantics: namespaced paths, soft-delete, version history, opt-in metadata. Write
+paths `auth.secrets_kv` (path, version, ciphertext, created_at, deleted_at).
+
+- `PUT /api/v1/secrets/kv/{path}` — store new version
+- `GET /api/v1/secrets/kv/{path}?version=N` — read version (default latest)
+- `LIST /api/v1/secrets/kv/{prefix}` — list paths
+- `DELETE /api/v1/secrets/kv/{path}?version=N` — soft delete
+- `POST /api/v1/secrets/kv/{path}/destroy?version=N` — hard delete
+- `POST /api/v1/secrets/kv/{path}/undelete?version=N`
+
+Encrypted at rest with the engine's master key (envelope: per-secret DEK wrapped by KEK; KEK rotates
+via existing `auth.jwks_keys`-shaped key registry).
+
+### S2. transit — encrypt/decrypt without exposing the key
+
+Vault's transit semantics. Operators register a key; clients call encrypt/decrypt without ever
+seeing the raw key. Useful for application-layer encryption (PII fields, etc.).
+
+- `POST /api/v1/secrets/transit/keys/{name}` — create key
+- `POST /api/v1/secrets/transit/encrypt/{name}` — `{plaintext}` → `{ciphertext}` (versioned)
+- `POST /api/v1/secrets/transit/decrypt/{name}` — `{ciphertext}` → `{plaintext}` (any version)
+- `POST /api/v1/secrets/transit/keys/{name}/rotate` — bump version; old versions stay decryptable
+
+Crypto: AES-256-GCM-SIV (deterministic and misuse-resistant). One key per name, multiple versions,
+latest for encrypt, any for decrypt.
+
+### S3. dynamic creds — short-lived service credentials
+
+Three providers in v0.3.0; rest deferred:
+
+- **Postgres**: assume-role pattern. Operator pre-creates a master role;
+  `POST /api/v1/secrets/dynamic/postgres/{role}/lease` issues a short-lived role with the configured
+  grants, returns `{username, password, lease_id, expires_at}`. Lease renewal + revoke endpoints.
+- **AWS IAM**: `sts:AssumeRole` with a configured ARN, returns
+  `{access_key_id, secret_access_key, session_token, expires_at}`.
+- **Kubernetes**: ServiceAccount-token binding for the engine's own cluster. Returns a fresh
+  projected token for a configured SA + audience.
+
+Lease tracking in `auth.secrets_leases`. Background task revokes on expiry.
+
+### S4. vaults + sharing — 1pw-style team/personal storage
+
+A _vault_ is a permission scope owned by a user or a Zanzibar object. Items inside a vault are E2E
+encrypted with a per-vault wrapping key, which is in turn encrypted to each member's public key (RSA
+or X25519 — TBD in Phase 1 design review).
+
+- `POST /api/v1/secrets/vaults` — create vault, returns vault id + per-member envelope
+- `POST /api/v1/secrets/vaults/{id}/items` — add item (login, password, secure note, SSH key,
+  software license, identity doc)
+- `GET /api/v1/secrets/vaults/{id}/items/{item}` — fetch (decrypted by client using their wrapped
+  vault key)
+- `POST /api/v1/secrets/vaults/{id}/members` — add member (writes a new envelope wrap)
+
+Membership is a Zanzibar tuple: `vault:engineering#viewer@user:alice`. Reuses the auth-zanzibar
+primitive — vaults compose with the existing authz model. Three relations: `viewer`, `editor`,
+`owner`.
+
+### S5. biscuit-share — assay-only differentiator
+
+biscuit lets us mint a capability token that grants narrow access to a specific item (or a specific
+path/prefix), with on-token attenuation (time-bound, IP-bound, single-use). Verify offline. Vault +
+1pw both require server round-trips to revoke a "share link"; biscuit can do expiry + IP scope
+without ever touching the server.
+
+- `POST /api/v1/secrets/share` — `{item_id, ttl, max_ip, …}` → biscuit token
+- `GET /secrets/share/{token}` — public endpoint, validates the biscuit, returns the item if all
+  caveats pass
+- Server-side revocation list (by biscuit `key_id`) for the cases where attenuation isn't enough
+
+This is the assay-distinct capability — Vault doesn't have it, 1pw doesn't have it. It's a real
+reason to choose us.
+
+### S6. Bitwarden-protocol compatibility shim
+
+Existing Bitwarden mobile / browser / CLI clients are mature and multi-platform. Implement the
+subset of their HTTP API (the `/api/sync`, `/api/ciphers`, `/api/folders`,
+`/api/identity/connect/token` surface) so users can point a stock Bitwarden client at `assay-engine`
+and get the human-friendly UX for free.
+
+Reference: `vaultwarden` does this exact thing in Rust; we can study their handlers as a template
+(MIT-licensed, source readable).
+
+Out of compat scope for v0.3.0:
+
+- Send (separate ephemeral share feature — biscuit-share covers it better anyway)
+- Emergency Access (deferred)
+- Device approval flows (deferred)
+- Premium-tier features (TOTP, attachments — TBD)
+
+### S7. Dashboard panes
+
+New section in `assay-dashboard` mounted at `/secrets/console`:
+
+- **Vaults** — list, create, member management
+- **Items** — browse a vault, view/edit (decryption client-side)
+- **KV browser** — Vault-style tree of `secrets/kv/...`
+- **Transit keys** — list, rotate, view key versions (no plaintext)
+- **Dynamic creds** — current leases, revoke
+- **Audit** — secrets-scoped audit log
+
+Same pattern as auth-console: SPA, reads `/api/v1/modules` to render panes only when `secrets`
+module is enabled.
+
+### S8. Lua stdlib — `assay.secrets.*`
+
+Mirror of `assay.auth.*`. Programmatic API for scripts:
+
+```lua
+local secrets = require("assay.secrets")
+local c = secrets.client({ engine_url = "..." })
+
+-- KV
+c.kv:get("api/stripe")            --> { value, version, created_at }
+c.kv:put("api/stripe", { ... })
+
+-- Transit
+c.transit:encrypt("logs", "...")  --> ciphertext
+c.transit:decrypt("logs", ct)     --> plaintext
+
+-- Vaults
+local vault = c.vaults:create({ name = "deploy", members = {"alice"} })
+c.vaults:add_item(vault.id, { type = "password", … })
+
+-- Share
+c.share:mint({ item_id = "...", ttl_secs = 3600 })
+```
+
+## Architecture
+
+### Crate layout
+
+```
+crates/
+  assay-secrets/                  NEW — same shape as assay-auth
+    src/
+      lib.rs
+      kv.rs                       module S1
+      transit.rs                  module S2
+      dynamic/                    module S3
+        postgres.rs
+        aws.rs
+        kubernetes.rs
+      vault.rs                    module S4
+      share.rs                    module S5
+      bitwarden_compat/           module S6 (subset of /api/* shim)
+      schema.rs                   PG + SQLite DDL
+      admin.rs                    HTTP handlers
+      ctx.rs                      SecretsCtx (mirrors AuthCtx)
+    tests/
+      kv.rs
+      transit.rs
+      dynamic_postgres.rs
+      vault.rs
+      share.rs
+      bitwarden_compat.rs
+```
+
+### Engine wiring
+
+- New module entry in `engine.modules` (matching `auth`, `workflow`).
+- Cargo features: `auth-secrets-kv`, `auth-secrets-transit`, `auth-secrets-dynamic`,
+  `auth-secrets-vault`, `auth-secrets-share`, `auth-secrets-bitwarden-compat`. Default-on group
+  `auth-secrets` enables KV + transit + vault + share. Dynamic-creds + Bitwarden compat opt-in.
+- Schema namespace: `secrets` (PG schema; SQLite attached file). Tables: `secrets_kv`,
+  `secrets_kv_meta`, `secrets_transit_keys`, `secrets_transit_versions`, `secrets_leases`,
+  `secrets_vaults`, `secrets_vault_members`, `secrets_items`, `secrets_share_revoked`.
+- `SecretsCtx` composed into `AuthCtx`-style central state struct, reuses the same backend pool (PG
+  or SQLite) the rest of the engine uses.
+
+### Crypto choices (locked)
+
+| Concern               | Primitive                                                       | Why                                                |
+| --------------------- | --------------------------------------------------------------- | -------------------------------------------------- |
+| KV at-rest encryption | AES-256-GCM-SIV (per-record DEK)                                | Misuse-resistant, AEAD. RustCrypto.                |
+| Transit               | AES-256-GCM-SIV with 96-bit nonce, version in AAD               | Same primitive; nonce derived from version+counter |
+| Vault wrap key        | Argon2id-derived from per-user keypair, X25519 ECDH for sharing | Standard 1pw/Bitwarden shape.                      |
+| User keypair          | X25519 (encryption) + Ed25519 (signing)                         | Already in tree via webauthn-rs.                   |
+| Capability tokens     | biscuit (Datalog caveats)                                       | Already in tree.                                   |
+| Master key            | KEK in `auth.jwks_keys`-style table, rotatable                  | Reuses key-registry from auth.                     |
+
+**No custom protocols. No homebrew crypto.** Every primitive above has a peer-reviewed
+implementation in the Rust ecosystem.
+
+## Phases
+
+### Phase 0 — Crate scaffold + schema (1 session)
+
+- New `assay-secrets` crate, Cargo.toml, lib.rs stubs.
+- DDL for all eight tables, PG + SQLite, behind `secrets` schema.
+- Engine module wiring (`engine.modules` row, `SecretsCtx` composition).
+- Empty handler stubs returning 501 Not Implemented.
+- One smoke test that creates the schema and inserts/reads a row.
+
+### Phase 1 — KV v2 + transit (2-3 sessions)
+
+- KV: PUT/GET/LIST/DELETE/destroy/undelete with versioning.
+- Transit: keys CRUD + encrypt/decrypt + rotate.
+- Master KEK rotation reuses `auth.jwks_keys` mechanism.
+- Tests: full lifecycle for KV (write, read latest, read v1, soft delete, undelete, hard destroy,
+  list under prefix); transit encrypt → decrypt round-trip across rotations.
+- Lua stdlib: `assay.secrets.kv` + `assay.secrets.transit`.
+- Dashboard pane: KV browser.
+
+### Phase 2 — vaults + sharing math (3-4 sessions)
+
+- Vault create / member add / item add / item get.
+- Per-vault wrapping key, per-member envelope encryption.
+- Membership via Zanzibar tuples (reuse auth-zanzibar).
+- Three relations (viewer/editor/owner) baked into the SpiceDB schema shipped with the module.
+- Tests: create vault → add 3 members → each member can decrypt → 4th member cannot → revoke member
+  → previously-encrypted items stay readable but no new shares.
+- Lua stdlib: `assay.secrets.vaults`.
+- Dashboard pane: Vaults + Items.
+
+### Phase 3 — biscuit-share (1-2 sessions)
+
+- Mint short-lived capability tokens for an item or a path.
+- Public-facing share endpoint validates biscuit caveats.
+- Server-side revoke list (by biscuit key id).
+- Tests: mint → fetch (allowed) → mint with TTL=1s, sleep 2s, fetch (denied); mint → revoke key id →
+  fetch (denied); attenuate to a specific IP and verify offline.
+- Lua stdlib: `assay.secrets.share`.
+- Dashboard pane: Share manager.
+
+### Phase 4 — dynamic creds (3-4 sessions)
+
+- PG: master-role config, lease issuance, revoke, expiry sweeper.
+- AWS STS: AssumeRole with configured ARN.
+- K8s: ServiceAccount-token projection.
+- Tests: lease lifecycle for each provider; revoke fires server cleanup; expired leases swept.
+- Lua stdlib: `assay.secrets.dynamic`.
+- Dashboard pane: Leases.
+
+### Phase 5 — Bitwarden-compat shim (4-5 sessions)
+
+- Implement the minimum of Bitwarden's HTTP API for sync (cipher, folder, identity/connect/token
+  endpoints).
+- Translate Bitwarden's user-key shape onto our vault-member model.
+- Test against actual Bitwarden CLI (`bw login` + `bw sync` + `bw get`).
+- Test against actual Bitwarden Browser extension.
+- Defer: Send, Emergency Access, attachments, organizations.
+- Behind feature flag `auth-secrets-bitwarden-compat` (off by default in slim builds).
+
+### Phase 6 — docs + release
+
+- `docs/migration-to-0.3.0.md`.
+- `docs/modules/secrets.md` (Lua stdlib reference, fed via the unified-docs frontmatter pipeline).
+- CHANGELOG entry (concise — per the lessons from PR #79).
+- Per-crate version bumps:
+  - `assay-secrets` 0.0.0 → 0.1.0 (new crate, first release)
+  - `assay-engine` 0.2.x → 0.3.0
+  - `assay` 0.14.x → 0.15.0 (new stdlib)
+  - `assay-dashboard` 0.2.x → 0.3.0 (secrets panes)
+  - `assay-auth` unchanged
+  - `assay-workflow` unchanged
+
+## What's explicitly OUT of scope
+
+- **PKI / cert authority.** Vault has it. We don't. Use cert-manager.
+- **ACME** as a backend.
+- **GCP / Azure dynamic creds.** Two-platform launch is enough for v0.3.0; add later based on
+  demand.
+- **SSH cert signing.**
+- **Plugin runtime** (Vault has out-of-process secret backends). The Lua stdlib already gives
+  operators an extension story; we don't need a parallel mechanism.
+- **Cloud HSM / KMS integration** for the master KEK. Plaintext KEK in DB at rest for v0.3.0; add
+  HSM in v0.4.0 once the column shape is stable.
+- **Replication / multi-region.** Same posture as the rest of the engine — single-leader, follower
+  replicas come later.
+- **Bitwarden Send / Emergency Access / Organizations.** Send is largely covered by biscuit-share;
+  Org is a different IAM model than ours; Emergency Access is a separate phase.
+- **Mobile / browser frontend.** Bitwarden compat shim lets the existing clients work — we don't
+  ship our own.
+- **Rotation alerts / scheduled rotation.** Manual rotation only in v0.3.0; cron-based rotation
+  rides on top of `assay-workflow` later.
+- **Audit log forwarding** (S3, syslog). Surfaces in dashboard + Postgres only.
+- **Compliance certifications** (SOC2 / FIPS / FedRAMP). Build the primitives, defer the audit.
+
+## Risk register
+
+| Risk                         | Likelihood | Severity | Mitigation                                                                                                   |
+| ---------------------------- | ---------- | -------- | ------------------------------------------------------------------------------------------------------------ |
+| Custom crypto subtle bug     | Med        | Critical | No custom protocols. Stick to ed25519-dalek + RustCrypto AEAD. Crypto review pass before Phase 2 lands.      |
+| Bitwarden-compat scope creep | High       | Med      | Hard-freeze the supported endpoint list at start of Phase 5. Defer everything else.                          |
+| Schema lock-in               | Med        | High     | Ship Phase 0 schema separately, run for one week before Phase 1+ commits to it.                              |
+| Sharing UX confusion         | Med        | Med      | Ship the dashboard pane in same session as the API; eat dogfood.                                             |
+| Vault parity expectation     | High       | Low      | Document the OUT list prominently in README. Position as "secrets for assay users", not "Vault replacement". |
+
+## Test plan (cross-phase)
+
+- Hermetic: PG (testcontainer or shared dev PG18) + SQLite + crypto. No external clouds in
+  unit/integration tests.
+- AWS / K8s dynamic creds tested against `localstack` and `kind` (already used elsewhere in the
+  repo).
+- Bitwarden-compat shim driven by the official `bw` CLI in CI (npm install).
+- Crypto round-trips: every encrypt path has a decrypt round-trip test with version rotation.
+- Permission isolation: a vault member with `viewer` cannot decrypt an item they aren't enveloped to
+  (via Zanzibar tuple absence).
+
+## References (read-only research forks at /opt/forks)
+
+| Repo                                                 | Purpose                                                                      | License                          |
+| ---------------------------------------------------- | ---------------------------------------------------------------------------- | -------------------------------- |
+| `dani-garcia/vaultwarden` (`/opt/forks/vaultwarden`) | Bitwarden-compat HTTP API in Rust; closest existing implementation to our S6 | MIT — adaptable code             |
+| `openbao/openbao` (`/opt/forks/openbao`)             | Vault fork, Go; reference for KV v2 / transit / dynamic-creds _semantics_    | MPL-2.0 — pattern, not lift      |
+| `keybase/client` (`/opt/forks/keybase-client`)       | Password-derived keypair + paper-key recovery patterns                       | BSD-3-Clause — pattern reference |
+
+Plus 1Password security whitepaper (PDF, public) for the team-vault sharing model and recovery-group
+/ Shamir-secret-sharing approach.
+
+## Open questions to resolve before Phase 1 commits
+
+1. **User keypair shape.** X25519 (encryption) + Ed25519 (signing) works; one shared key via
+   `crypto_box`-style might be simpler. Decide based on what `webauthn-rs` already gives us.
+2. **Master KEK rotation cadence.** Reuse `auth.jwks_keys` rotation triggers, or independent?
+   Probably independent — JWKS rotation is fast (issue new tokens), KEK rotation is slow (re-encrypt
+   every DEK).
+3. **Backend feature flags.** Per-feature (`auth-secrets-kv` etc.) or one umbrella (`auth-secrets`)?
+   Per-feature gives slim builds; umbrella is simpler. Default to umbrella, add per-feature only if
+   asked.
+4. **biscuit issuer key handling.** Reuse the auth biscuit root key, or have a separate
+   secrets-biscuit-root? Separate keeps blast radius small if a key is compromised.
+
+## Delivery posture
+
+Per maintainer note: ship the entire scope on a single feature branch (`feature/0.3.0-secrets`) in
+one PR after PR #80 lands. No incremental staging across PRs. Phases above are session scoping
+inside that branch, not separate PRs.
+
+Resume marker: when starting Phase 0, read this plan in full plus the latest CHANGELOG to confirm no
+scope assumptions have shifted.


### PR DESCRIPTION
Docs-only — drops the planning doc for the secrets-module work onto \`main\` so it's tracked. No code, no version bump.

This was originally pushed onto PR #80 minutes after the squash merge fired, so it didn't make the cut. Same content, just on its own tiny PR.

## What's in the plan

\`.claude/plans/17-v0.3.0-secrets-module.md\` — scopes the v0.3.0 \`assay-secrets\` module: KV v2 + transit + dynamic creds (PG/AWS/K8s) + 1pw-style vaults & sharing + biscuit-share + Bitwarden-protocol compat shim. Per-crate bumps. 6 phases inside one feature branch (no incremental PRs). Explicit out-of-scope list (PKI, ACME, GCP/Azure, plugin runtime, mobile UX, replication).

Cost estimate (vs engine 0.2.x): +3-5 MB binary, +15-30 MB idle RAM, +30-60s cold compile. Low because \`assay-auth\` already pulled in every primitive.

Research forks already cloned read-only at \`/opt/forks/{vaultwarden,openbao,keybase-client}\` for reference during implementation.

## Test plan

- [x] No code changes; plan doc only.
- [ ] No CI assertion needed beyond the docs-sync gate, which won't trip because we're not touching \`docs/modules/\` frontmatter or the build pipeline.