### PR TITLE
ci: route maintainer PRs to self-hosted runner for 3-5x speedup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,11 @@ jobs:
             target: x86_64-unknown-linux-gnu
           - os: macos-14
             target: aarch64-apple-darwin
-    runs-on: ${{ matrix.os }}
+    # On the linux row, route to the self-hosted runner when the actor
+    # is the maintainer; any other actor (Dependabot, future outside
+    # contributors) falls back to ubuntu-latest. The macOS row always
+    # uses GitHub-hosted — there is no local mac.
+    runs-on: ${{ matrix.os == 'ubuntu-latest' && github.actor == 'developerinlondon' && fromJSON('["self-hosted","linux","assay"]') || matrix.os }}
     timeout-minutes: 25
 
     steps:
@@ -72,8 +76,12 @@ jobs:
       # eliminates the per-test testcontainer churn that intermittently
       # hung the docker daemon. macOS is SQLite-only (PG cases cfg-gated
       # `target_os = "linux"`).
+      #
+      # Skipped on self-hosted: the assay-runner nspawn container has
+      # postgres-18 installed as a systemd service, listening on
+      # localhost:5432 with the same trust-auth credentials.
       - name: Start Postgres 18 (Linux)
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && runner.environment == 'github-hosted'
         run: |
           docker run -d --name assay-pg-test \
             -e POSTGRES_PASSWORD=postgres \
@@ -134,7 +142,7 @@ jobs:
   # Dedicated extension gate so an extension-only break fails this job
   # specifically rather than hiding behind a generic "moon ci failed".
   extension-tests:
-    runs-on: ubuntu-latest
+    runs-on: ${{ github.actor == 'developerinlondon' && fromJSON('["self-hosted","linux","assay"]') || 'ubuntu-latest' }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- Linux row of the matrix runs on the on-prem nspawn runner (`assay-runner` container, i9-13900, 32 threads, 64GB memory cap, target/ persisted on `/var/build`) when the PR actor is `developerinlondon`. Any other actor or the macOS row falls back to GitHub-hosted runners.
- Postgres-18 is provisioned in the runner as a systemd service (trust auth on localhost, same `postgres://postgres:postgres@localhost:5432/postgres` connection string the workflow already uses), so the docker-based postgres-startup step is skipped on self-hosted.
- Wall-time target: ~12min → 2-4min for maintainer PRs.

## Runner setup (host-side)

The `assay-runner` systemd-nspawn container is registered to this repo only, with labels `[self-hosted, linux, x64, assay]`. It mirrors the existing `github-runner` container pattern on the same box (Ubuntu 24.04 base) but with raised limits (`MemoryMax=64G`, `CPUQuota=2400%`) and a `/var/build/assay-target` bind mount. The runner survives container reboots via the in-container `actions.runner.developerinlondon-assay.assay-runner-eda.service` unit.

## Security posture

- Repo is public, so any drive-by PR could in principle ask for self-hosted execution. The actor-gate prevents the workflow from binding to the self-hosted label for anyone other than `developerinlondon` — a stranger's PR resolves `runs-on:` to `ubuntu-latest` instead.
- Runner runs inside a separate nspawn container (rootful, but isolated from host \$HOME, \~/.ssh, \~/.gnupg, \~/.cargo/credentials.toml). Compromise blast radius = the container, not the box.
- Repo setting **Settings → Actions → "Require approval for first-time contributors"** is the belt to the actor-gate's braces. Recommend flipping that on after this lands.

## Test plan

- [ ] CI run on this PR routes the linux job to `assay-runner-eda` (visible in the job header on GitHub).
- [ ] Postgres step is skipped on self-hosted; `moon ci` connects to the in-container postgres successfully.
- [ ] Wall-clock for the linux row drops from ~12min baseline to <5min on first run, <2min on warm rerun.
- [ ] macOS row stays on `macos-14` GitHub-hosted, unaffected.
- [ ] `extension-tests` job also routes to self-hosted on maintainer PRs.

## Follow-ups (separate commits or PRs)

- CD job: deploy assay-engine to the local k3s cluster on merge-to-main, behind the existing `assay.agenteda.com` Cloudflare tunnel.
- Ephemeral-runner hardening: switch from persistent registration to `--ephemeral` with a fine-grained PAT for token renewal, shrinking the credentials-at-rest window from "always" to "during a single job".