### PR TITLE
fix(release): publish assay-vault before assay-engine

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
       assay_workflow_bumped: ${{ steps.assay-workflow.outputs.bumped }}
       assay_dashboard_bumped: ${{ steps.assay-dashboard.outputs.bumped }}
       assay_auth_bumped: ${{ steps.assay-auth.outputs.bumped }}
+      assay_vault_bumped: ${{ steps.assay-vault.outputs.bumped }}
       assay_engine_bumped: ${{ steps.assay-engine.outputs.bumped }}
       assay_lua_bumped: ${{ steps.assay-lua.outputs.bumped }}
       assay_engine_version: ${{ steps.assay-engine.outputs.version }}
@@ -72,6 +73,9 @@ jobs:
 
       - id: assay-auth
         run: .github/release/check-bumped.sh assay-auth
+
+      - id: assay-vault
+        run: .github/release/check-bumped.sh assay-vault
 
       - id: assay-engine
         run: .github/release/check-bumped.sh assay-engine
@@ -150,7 +154,8 @@ jobs:
       needs.detect.outputs.assay_domain_bumped    == 'true' ||
       needs.detect.outputs.assay_workflow_bumped  == 'true' ||
       needs.detect.outputs.assay_dashboard_bumped == 'true' ||
-      needs.detect.outputs.assay_auth_bumped      == 'true'
+      needs.detect.outputs.assay_auth_bumped      == 'true' ||
+      needs.detect.outputs.assay_vault_bumped     == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -205,6 +210,15 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: /tmp/publish-crate.sh assay-auth
+
+      # assay-vault depends on assay-domain + assay-auth — the
+      # publish-crate.sh helper sleeps 30s after each publish so the
+      # crates.io index has caught up by the time we hit it.
+      - name: Publish assay-vault
+        if: needs.detect.outputs.assay_vault_bumped == 'true'
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: /tmp/publish-crate.sh assay-vault
 
   # Cross-compile both products for both targets. Shared between the
   # release-* jobs.


### PR DESCRIPTION
## Summary

Hotfix — the v0.3.0 release run failed at \`release-assay-engine\` with \`no matching package named assay-vault found\`. PR #85 added the \`assay-vault\` crate but didn't wire it into the release pipeline:

- \`detect\` job didn't compute \`assay_vault_bumped\`
- \`libraries\` job's \`if:\` and publish-list never included it
- \`assay-engine\` depends on \`assay-vault\`, so \`cargo publish -p assay-engine\` fails until \`assay-vault\` lands on crates.io

This patch wires \`assay-vault\` through both jobs. Order is correct: \`assay-vault\` publishes after \`assay-auth\` (its only assay-* dep besides \`assay-domain\`), and \`publish-crate.sh\`'s 30s sleep gives the crates.io index time to catch up before \`release-assay-engine\` pulls deps.

After merge, \`release.yml\` re-fires automatically on the merge commit and should green through to the GHCR docker push (which is the step the failed run never reached).

## Test plan

- [ ] CI green on this PR
- [ ] After merge, \`release\` workflow run completes with \`release-assay-engine\` green
- [ ] \`docker buildx imagetools inspect ghcr.io/developerinlondon/assay-engine:0.3.0\` returns
- [ ] Manual k3s rollout: \`kubectl set image deployment/assay-engine assay-engine=ghcr.io/developerinlondon/assay-engine:0.3.0 -n assay\`
- [ ] \`assay.agenteda.com\` serves the new version