### PR TITLE
fix(release): bump assay-auth 0.2.1 → 0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,7 +239,7 @@ dependencies = [
 
 [[package]]
 name = "assay-auth"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "argon2",

--- a/crates/assay-auth/Cargo.toml
+++ b/crates/assay-auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-auth"
-version = "0.2.1"
+version = "0.2.2"
 categories = ["authentication", "cryptography", "asynchronous"]
 edition = "2024"
 keywords = ["oidc", "zanzibar", "passkey", "biscuit", "auth"]


### PR DESCRIPTION
## Summary

Follow-up to #87. The release run on `bda4903` still fails at the `libraries / Publish assay-vault` step:

```
error[E0599]: no method named `issuer` found for &JwtConfig
error[E0599]: no method named `audience` found for &JwtConfig
error: failed to verify package tarball
```

`assay-vault::bitwarden_compat::identity` calls `JwtConfig::{issuer,audience}` (added to assay-auth in #85, see `crates/assay-auth/src/jwt.rs:134,139`). Those methods exist locally but **not** in the published `assay-auth 0.2.1` — `cargo publish --verify` builds the packaged tarball outside the workspace and resolves `assay-auth = "0.2"` from crates.io, which only has the older 0.2.1.

`check-bumped.sh` triggers solely on `Cargo.toml` version changes; #85 added new public API to assay-auth without bumping its crate version, so `detect` skipped publishing it. Bumping → 0.2.2 flips `assay_auth_bumped=true`, the `libraries` job publishes 0.2.2 to crates.io before assay-vault, and the 30s index-propagation sleep in `publish-crate.sh` lets assay-vault's verify step resolve `"0.2"` to 0.2.2 and build cleanly.

After merge, `release.yml` re-fires on the merge commit and should green through to the GHCR docker push.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, `release` workflow run on main is fully green
- [ ] `cargo search assay-auth` shows `0.2.2`
- [ ] `cargo search assay-vault` shows `0.1.0`
- [ ] `docker buildx imagetools inspect ghcr.io/developerinlondon/assay-engine:0.3.0` succeeds
- [ ] (separate PR) k3s auto-deploy + `assay.agenteda.com` rollout verification