### PR TITLE
ci: add cargo-semver-checks gate to catch public-API drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,3 +219,14 @@ jobs:
         run: moon run openclaw-extension:test --color
         env:
           MOON_LOG: "info"
+
+  # Catches public-API drift in workspace crates so the release-time
+  # `cargo publish --verify` step doesn't fail on a method that was
+  # added to a workspace dep without bumping that dep's Cargo.toml.
+  semver-checks:
+    name: cargo-semver-checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: obi1kenobi/cargo-semver-checks-action@v2


### PR DESCRIPTION
## Summary

Adds a `semver-checks` job to `ci.yml` that runs `cargo-semver-checks` against the workspace on every PR. Catches the failure mode that broke #87 / #89: new public API added to a workspace dep without bumping its `Cargo.toml`, which ships a `cargo publish` tarball whose `--verify` step can't resolve the new symbol against the older crates.io baseline.

The [`obi1kenobi/cargo-semver-checks-action@v2`](https://github.com/obi1kenobi/cargo-semver-checks-action) action handles toolchain + tool install internally — the job body is six lines.

I ran the audit locally on `main` after #89 merged. Result:

- `assay-auth 0.2.1 → 0.2.2` — confirmed minor change, no further bump required
- `assay-domain 0.2.0` — internal-only drift, no public API change
- `assay-workflow 0.3.1` — clean
- `assay-dashboard 0.3.0` — clean

No other crates need bumping, so this PR is purely the gate addition.

## Test plan

- [ ] CI green on this PR (the new `semver-checks` job passes)
- [ ] Spot-check by adding a deliberate `pub fn foo()` to a non-bumped library on a throwaway branch and confirming the job fails with the expected diff