### PR TITLE
ci(release): deploy assay-engine to k3s after GHCR push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -423,6 +423,51 @@ jobs:
             ghcr.io/developerinlondon/assay-engine:${{ needs.detect.outputs.assay_engine_version }}
             ghcr.io/developerinlondon/assay-engine:latest
 
+  # Roll the in-cluster deployment to the version we just pushed, then
+  # smoke-check the engine_version field via port-forward. We hit the
+  # in-cluster service rather than https://assay.agenteda.com because
+  # Cloudflare Access guards the public URL and we don't want a service
+  # token in CI just for a healthcheck.
+  deploy-assay-engine:
+    needs: [detect, release-assay-engine]
+    if: always() && needs.release-assay-engine.result == 'success'
+    runs-on: [self-hosted, assay]
+    timeout-minutes: 10
+    env:
+      NAMESPACE: assay
+      DEPLOYMENT: assay-engine
+      SERVICE: assay-engine
+      SERVICE_PORT: "8420"
+      VERSION: ${{ needs.detect.outputs.assay_engine_version }}
+    steps:
+      - name: Roll deployment to assay-engine:${{ needs.detect.outputs.assay_engine_version }}
+        run: |
+          set -euo pipefail
+          IMAGE="ghcr.io/developerinlondon/assay-engine:${VERSION}"
+          kubectl set image -n "$NAMESPACE" \
+            "deployment/$DEPLOYMENT" \
+            "$DEPLOYMENT=$IMAGE"
+          kubectl rollout status -n "$NAMESPACE" \
+            "deployment/$DEPLOYMENT" --timeout=5m
+
+      - name: Smoke-check engine_version via in-cluster service
+        run: |
+          set -euo pipefail
+          kubectl port-forward -n "$NAMESPACE" \
+            "svc/$SERVICE" "18420:$SERVICE_PORT" >/dev/null 2>&1 &
+          PF=$!
+          trap "kill $PF 2>/dev/null || true" EXIT
+          for i in 1 2 3 4 5 6 7 8 9 10; do
+            curl -sSf -o /dev/null http://127.0.0.1:18420/api/v1/engine/core/health && break
+            sleep 1
+          done
+          actual=$(curl -sSf http://127.0.0.1:18420/api/v1/engine/core/health | jq -r .engine_version)
+          if [ "$actual" != "$VERSION" ]; then
+            echo "::error::engine_version mismatch — expected ${VERSION}, got ${actual}"
+            exit 1
+          fi
+          echo "OK — assay-engine ${actual} live in cluster"
+
   release-assay-lua:
     needs: [detect, libraries, binaries]
     if: |


### PR DESCRIPTION
## Summary

Adds the missing CD step so a successful release of `assay-engine` rolls out to the k3s cluster behind `assay.agenteda.com` automatically. Until now the release pipeline ended at the GHCR docker push and the cluster had to be rolled by hand — the deployment is sitting on `:0.2.1` even though `:0.2.2` and `:0.3.0` have shipped.

## Design

- New `deploy-assay-engine` job in `release.yml`, fires after `release-assay-engine` succeeds.
- Runs on the self-hosted runner with the `assay` label — already has direct k3s API access via its kubeconfig, so no new GitHub secrets are introduced.
- Three steps:
  1. `kubectl set image deployment/assay-engine assay-engine=ghcr.io/.../assay-engine:<VERSION> -n assay`
  2. `kubectl rollout status … --timeout=5m` (gates on the readiness probe)
  3. `kubectl port-forward svc/assay-engine` + curl `127.0.0.1:18420/api/v1/engine/core/health` and assert `engine_version == VERSION`
- Smoke-check goes through port-forward, not the public URL, because Cloudflare Access wraps `assay.agenteda.com` and a service token in CI just for a healthcheck would be overkill.
- Idempotent — `kubectl set image` is a no-op when the image string already matches, so re-runs of `release.yml` don't trigger spurious rollouts.

## Why pin by tag, not digest

The release pipeline already guarantees tags are immutable (`docker buildx imagetools inspect` skips the push if the tag exists). Tag is more readable in `kubectl describe` output and rollback is just setting the manifest to the previous version.

## Future work (separate PR)

- Tighter RBAC: replace whatever broad kubeconfig the runner has with a service account scoped to `patch deployments/assay-engine` in the `assay` namespace only.

## Test plan

- [ ] CI green on this PR (no functional change — only `release.yml` is touched, which only fires on `push: main`)
- [ ] After merge, `release.yml` re-fires on the merge commit; `release-assay-engine` is idempotent (already pushed 0.3.0) so it skips publish/tag/release/docker-push, then `deploy-assay-engine` runs for the first time and rolls k3s from `:0.2.1` → `:0.3.0`
- [ ] `kubectl get deployment assay-engine -n assay -o jsonpath='{.spec.template.spec.containers[0].image}'` shows `:0.3.0`
- [ ] Smoke step prints `OK — assay-engine 0.3.0 live in cluster`
- [ ] `https://assay.agenteda.com` (after Cloudflare Access auth) shows the new dashboard / engine behaviour from #80 and #85