### PR TITLE
chore(ci): disable deploy-assay-engine job until runner is set up

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -430,7 +430,13 @@ jobs:
   # token in CI just for a healthcheck.
   deploy-assay-engine:
     needs: [detect, release-assay-engine]
-    if: always() && needs.release-assay-engine.result == 'success'
+    # Disabled — see https://github.com/developerinlondon/assay/issues/94.
+    # The [self-hosted, assay] runner has no kubectl + no kubeconfig + no
+    # confirmed network reach to the EDA k3s API. Releases still publish to
+    # GHCR; this job only handled auto-rollout to the personal cluster.
+    # Flip back to `always() && needs.release-assay-engine.result == 'success'`
+    # once #94's checklist is done.
+    if: false
     runs-on: [self-hosted, assay]
     timeout-minutes: 10
     env:


### PR DESCRIPTION
## Summary

- Flips `deploy-assay-engine` job in `release.yml` to `if: false`
- Adds a comment block pointing at tracking issue #94 with the re-enable checklist

## Why

Every release since #91 (which added the deploy job) has failed on the `Roll deployment` step with `kubectl: command not found` on the [self-hosted, assay] runner. The latest run on `assay-engine 0.3.1` (#93) tripped the same failure.

Releases still publish to GHCR cleanly — only the auto-rollout to the personal EDA k3s cluster is affected. Disabling stops every release from showing dirty-red until the runner has kubectl + kubeconfig + confirmed cluster connectivity.

## Re-enable path

See #94 — runner curl check + `K3S_KUBECONFIG` repo secret + workflow patch (`azure/setup-kubectl@v4` + kubeconfig write + cluster-info smoke check) + remove `if: false`.

## Test plan

- [ ] CI green
- [ ] Visual confirm: `if: false` in place, comment present, pointing at #94