### PR TITLE
chore(vault)!: bump 0.2.0 + sweep #[non_exhaustive] — unblock engine 0.4.0 publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,23 +2,28 @@
 
 All notable changes to Assay are documented here.
 
-## [assay-engine 0.4.0 / assay-auth 0.3.0] - 2026-04-27
+## [assay-engine 0.4.0 / assay-auth 0.3.0 / assay-vault 0.2.0] - 2026-04-27
 
 | Crate          | Bump          |
 | -------------- | ------------- |
 | `assay-engine` | 0.3.1 → 0.4.0 |
 | `assay-auth`   | 0.2.2 → 0.3.0 |
+| `assay-vault`  | 0.1.0 → 0.2.0 |
 | (others)       | unchanged     |
 
 **Breaking change (pre-1.0 minor bump).** Adding the `external_issuers` field to `AuthCtx` and
 `AuthConfig` changes their shapes; per pre-1.0 semver convention the minor version is the
-breaking-change bump. While doing it, every public config struct in both crates is now marked
-`#[non_exhaustive]` so future field additions are non-breaking — `AuthCtx`, `AuthConfig`,
-`EngineConfig`, `BackendConfig`, `ServerConfig`, `WorkflowConfig`, `AuthSessionConfig`,
-`AuthPasskeyConfig`, `AuthOidcProviderConfig`, `DashboardConfig`, `LoggingConfig`, and
-`ExternalIssuerConfig` all now require `Default::default()` + field assignment (or the existing
-builder methods on `AuthCtx`) for external construction. Pattern matches on `BackendConfig` from
-outside the crate must include a wildcard arm.
+breaking-change bump. `assay-vault 0.2.0` rides along — its dep declaration on `assay-auth` had
+to update from `"0.2"` to `"0.3"` (the published `assay-vault 0.1.0` couldn't be reused because
+its baked-in manifest pinned the old assay-auth, and there's no way to mutate a published crate).
+While doing it, every public config struct in all three crates is now marked `#[non_exhaustive]`
+so future field additions are non-breaking — `AuthCtx`, `AuthConfig`, `EngineConfig`,
+`BackendConfig`, `ServerConfig`, `WorkflowConfig`, `AuthSessionConfig`, `AuthPasskeyConfig`,
+`AuthOidcProviderConfig`, `DashboardConfig`, `LoggingConfig`, `ExternalIssuerConfig`, plus all 51
+public structs/enums in `assay-vault` are now `#[non_exhaustive]` and all require
+`Default::default()` + field assignment for external construction. Pattern matches on
+`BackendConfig` and on assay-vault's enums (`SealingMethod`, `VaultError`, `ShareTarget`,
+`ActiveKek`, `Parent`) from outside the crate must include a wildcard arm.
 
 **Headline:** **JWT pass-through validation.** The engine now accepts JWTs minted by an upstream
 OIDC provider (Hydra, Keycloak, Auth0, …) on incoming `Authorization: Bearer ...` requests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,7 +388,7 @@ dependencies = [
 
 [[package]]
 name = "assay-vault"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",

--- a/crates/assay-engine/Cargo.toml
+++ b/crates/assay-engine/Cargo.toml
@@ -90,7 +90,7 @@ backend-sqlite = [
 assay-auth = { path = "../assay-auth", version = "0.3" }
 assay-dashboard = { path = "../assay-dashboard", version = "0.3" }
 assay-domain = { path = "../assay-domain", version = "0.2" }
-assay-vault = { path = "../assay-vault", version = "0.1", optional = true, default-features = false }
+assay-vault = { path = "../assay-vault", version = "0.2", optional = true, default-features = false }
 assay-workflow = { path = "../assay-workflow", version = "0.3" }
 
 axum = "0.8"

--- a/crates/assay-vault/Cargo.toml
+++ b/crates/assay-vault/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-vault"
-version = "0.1.0"
+version = "0.2.0"
 categories = ["cryptography", "asynchronous", "database"]
 edition = "2024"
 keywords = ["vault", "secrets", "kv", "transit", "biscuit"]

--- a/crates/assay-vault/src/audit.rs
+++ b/crates/assay-vault/src/audit.rs
@@ -27,6 +27,7 @@ use crate::error::Result;
 /// patterns operators set on each sink (e.g. `vault.kv.put`,
 /// `vault.transit.encrypt`, `auth.login.success`).
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct AuditEvent {
     pub event: String,
     pub actor: Option<String>,
@@ -389,6 +390,7 @@ pub use s3_sink::S3Sink;
 /// Owns every configured sink. Cheap to clone — sinks live behind
 /// `Arc`s. Cloning the registry shares the same set across handlers.
 #[derive(Default, Clone)]
+#[non_exhaustive]
 pub struct SinkRegistry {
     sinks: std::sync::Arc<Vec<std::sync::Arc<dyn Sink>>>,
 }

--- a/crates/assay-vault/src/bitwarden_compat/types.rs
+++ b/crates/assay-vault/src/bitwarden_compat/types.rs
@@ -21,6 +21,7 @@ pub mod cipher_type {
 /// `GET /api/accounts/profile` returns.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
+#[non_exhaustive]
 pub struct Profile {
     pub id: String,
     pub email: String,
@@ -50,6 +51,7 @@ pub struct Profile {
 /// `item_type` stays 1 (Login); the Fido2Credentials array distinguishes.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
+#[non_exhaustive]
 pub struct Cipher {
     pub id: String,
     pub user_id: Option<String>,
@@ -75,6 +77,7 @@ pub struct Cipher {
 /// What the client POSTs / PUTs to /api/ciphers — BW's wire shape.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "PascalCase")]
+#[non_exhaustive]
 pub struct CipherInput {
     pub folder_id: Option<String>,
     #[serde(rename = "Type")]
@@ -98,6 +101,7 @@ pub struct CipherInput {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "PascalCase")]
+#[non_exhaustive]
 pub struct Folder {
     pub id: String,
     pub name: String,
@@ -108,6 +112,7 @@ pub struct Folder {
 
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "PascalCase")]
+#[non_exhaustive]
 pub struct FolderInput {
     pub name: String,
 }
@@ -115,6 +120,7 @@ pub struct FolderInput {
 /// What `GET /api/sync` returns — the full vault dump for a user.
 #[derive(Clone, Debug, Serialize)]
 #[serde(rename_all = "PascalCase")]
+#[non_exhaustive]
 pub struct SyncResponse {
     pub profile: Profile,
     pub folders: Vec<Folder>,
@@ -129,6 +135,7 @@ pub struct SyncResponse {
 
 #[derive(Clone, Debug, Deserialize)]
 #[allow(dead_code)]
+#[non_exhaustive]
 pub struct ConnectTokenForm {
     pub grant_type: String,
     pub username: Option<String>,
@@ -146,6 +153,7 @@ pub struct ConnectTokenForm {
 }
 
 #[derive(Clone, Debug, Serialize)]
+#[non_exhaustive]
 pub struct TokenResponse {
     pub access_token: String,
     pub expires_in: u64,

--- a/crates/assay-vault/src/cloud/gcp_jwt.rs
+++ b/crates/assay-vault/src/cloud/gcp_jwt.rs
@@ -21,6 +21,7 @@ use crate::error::{Result, VaultError};
 
 /// A Google Cloud service account loaded from the JSON key file.
 #[derive(Clone, Debug, Deserialize)]
+#[non_exhaustive]
 pub struct ServiceAccount {
     pub client_email: String,
     pub private_key: String,
@@ -50,6 +51,7 @@ struct TokenResponse {
 
 /// One acquired access token with the absolute expiry epoch.
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct AccessToken {
     pub access_token: String,
     pub expires_at: u64,

--- a/crates/assay-vault/src/cloud/sigv4.rs
+++ b/crates/assay-vault/src/cloud/sigv4.rs
@@ -19,6 +19,7 @@ type HmacSha256 = Hmac<Sha256>;
 /// One signed request — all the fields the caller needs to construct an
 /// `http::Request` against the target service.
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct SignedRequest {
     pub url: String,
     pub method: String,
@@ -28,6 +29,7 @@ pub struct SignedRequest {
 
 /// Inputs to [`sign`].
 #[derive(Clone, Copy, Debug)]
+#[non_exhaustive]
 pub struct SigV4Input<'a> {
     /// IAM access key ID.
     pub access_key_id: &'a str,

--- a/crates/assay-vault/src/collections.rs
+++ b/crates/assay-vault/src/collections.rs
@@ -19,6 +19,7 @@ use crate::error::Result;
 
 /// One row in `vault.collections`.
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct Collection {
     pub id: String,
     pub org_id: Option<String>,
@@ -31,6 +32,7 @@ pub struct Collection {
 /// the server — it's the collection's symmetric key encrypted to the
 /// member's X25519 pubkey, produced client-side.
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct CollectionMember {
     pub collection_id: String,
     pub user_id: String,

--- a/crates/assay-vault/src/crypto/kek.rs
+++ b/crates/assay-vault/src/crypto/kek.rs
@@ -25,6 +25,7 @@ use crate::error::{Result, VaultError};
 /// In-memory KEK material. Cheap to clone — the inner Arc shares the
 /// raw bytes across consumers without re-allocating.
 #[derive(Clone)]
+#[non_exhaustive]
 pub struct KekHandle {
     inner: Arc<KekInner>,
 }
@@ -38,6 +39,7 @@ struct KekInner {
 /// disk. Layout: `nonce (12) || wrapped DEK ciphertext (32+16 = 48)`.
 /// Total 60 bytes. Stored as a single BYTEA / BLOB column.
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct WrappedDek(pub Vec<u8>);
 
 impl WrappedDek {

--- a/crates/assay-vault/src/crypto/kek_rotate.rs
+++ b/crates/assay-vault/src/crypto/kek_rotate.rs
@@ -37,6 +37,7 @@ use crate::error::{Result, VaultError};
 
 /// Outcome of a single rotate pass.
 #[derive(Debug)]
+#[non_exhaustive]
 pub struct RotationReport {
     pub old_kid: String,
     pub new_kid: String,

--- a/crates/assay-vault/src/crypto/kek_store.rs
+++ b/crates/assay-vault/src/crypto/kek_store.rs
@@ -26,6 +26,7 @@ pub const METHOD_SHAMIR: &str = "shamir";
 
 /// Outcome of [`load_active_*`] — fully describes the at-rest state so
 /// engine boot can construct the right [`crate::crypto::seal_state::SealState`].
+#[non_exhaustive]
 pub enum ActiveKek {
     /// Plaintext sealing (Phase 1 placeholder). The KEK is in memory.
     Plaintext { kid: String, handle: KekHandle },

--- a/crates/assay-vault/src/crypto/seal_state.rs
+++ b/crates/assay-vault/src/crypto/seal_state.rs
@@ -21,6 +21,7 @@ use crate::error::{Result, VaultError};
 
 /// Snapshot of the live sealing state. Cheap to clone.
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct SealStatus {
     pub method: SealingMethod,
     pub sealed: bool,
@@ -35,6 +36,7 @@ pub struct SealStatus {
 
 /// Mutable runtime state. Held by [`crate::ctx::VaultCtx`] behind an
 /// `Arc<RwLock<…>>`.
+#[non_exhaustive]
 pub struct SealStateInner {
     pub method: SealingMethod,
     pub kid: Option<String>,
@@ -49,6 +51,7 @@ pub struct SealStateInner {
 
 /// Cheap clonable wrapper.
 #[derive(Clone)]
+#[non_exhaustive]
 pub struct SealState {
     inner: Arc<RwLock<SealStateInner>>,
 }
@@ -214,6 +217,7 @@ impl SealState {
 }
 
 /// Collected shares during a Shamir unseal ceremony.
+#[non_exhaustive]
 pub struct UnsealAccumulator {
     threshold: u8,
     #[cfg(feature = "vault-sealing-shamir")]

--- a/crates/assay-vault/src/crypto/sealing.rs
+++ b/crates/assay-vault/src/crypto/sealing.rs
@@ -25,6 +25,7 @@ use crate::error::{Result, VaultError};
 /// Sealing method recorded in `vault.kek_metadata.sealing_method`.
 /// `Display` emits the wire-format string the column expects.
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum SealingMethod {
     /// Phase-1 placeholder. Blob IS the raw 32 bytes. WARN-logged.
     Plaintext,

--- a/crates/assay-vault/src/ctx.rs
+++ b/crates/assay-vault/src/ctx.rs
@@ -26,6 +26,7 @@ use crate::transit::{TransitService, TransitStore};
 /// `axum::extract::FromRef`. Cheap to clone — every service is
 /// `Arc`-shared underneath the type-erased trait object.
 #[derive(Clone)]
+#[non_exhaustive]
 pub struct VaultCtx {
     /// Master KEK handle. Always present so KV / transit services can
     /// hold a clone — but the live sealing state in `seal_state`

--- a/crates/assay-vault/src/dynamic.rs
+++ b/crates/assay-vault/src/dynamic.rs
@@ -21,6 +21,7 @@ use crate::error::Result;
 
 /// Lease metadata returned from `issue`.
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct Lease {
     pub id: String,
     pub provider: String,
@@ -38,6 +39,7 @@ pub struct Lease {
 /// existence + expiry + revocation, the credential bytes themselves
 /// are short-lived ephemera.
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct LeaseRecord {
     pub id: String,
     pub provider: String,
@@ -106,6 +108,7 @@ pub trait DynamicCredsProvider: Send + Sync + 'static {
 /// (e.g. the AWS access-key-id, the PG role name) without keeping the
 /// plaintext credential server-side.
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct IssuedCredentials {
     pub credentials: serde_json::Value,
     pub metadata: serde_json::Value,
@@ -114,6 +117,7 @@ pub struct IssuedCredentials {
 /// Top-level dispatcher held by [`crate::ctx::VaultCtx`]. Registers
 /// providers at boot; the HTTP layer + sweeper consult it.
 #[derive(Clone, Default)]
+#[non_exhaustive]
 pub struct DynamicCredsRegistry {
     providers: std::sync::Arc<
         parking_lot::RwLock<
@@ -199,6 +203,7 @@ mod tests {
 /// credentials via the right provider, persists the lease row, runs
 /// background revocation on expiry.
 #[derive(Clone)]
+#[non_exhaustive]
 pub struct DynamicCredsService {
     registry: DynamicCredsRegistry,
     leases: std::sync::Arc<dyn LeaseStore>,

--- a/crates/assay-vault/src/error.rs
+++ b/crates/assay-vault/src/error.rs
@@ -4,6 +4,7 @@ use thiserror::Error;
 /// responses in the admin layer (added in Phase 1) and onto Lua runtime
 /// errors for the stdlib client.
 #[derive(Debug, Error)]
+#[non_exhaustive]
 pub enum VaultError {
     #[error("not found")]
     NotFound,

--- a/crates/assay-vault/src/items.rs
+++ b/crates/assay-vault/src/items.rs
@@ -17,6 +17,7 @@ use crate::error::Result;
 
 /// Which container the item / folder belongs to.
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum Parent<'a> {
     /// Personal vault, identified by its `vault.vaults.id`.
     Vault(&'a str),
@@ -41,6 +42,7 @@ impl<'a> Parent<'a> {
 
 /// One row in `vault.items`.
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct Item {
     pub id: String,
     pub vault_id: Option<String>,
@@ -56,6 +58,7 @@ pub struct Item {
 
 /// One row in `vault.folders`.
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct Folder {
     pub id: String,
     pub vault_id: Option<String>,

--- a/crates/assay-vault/src/kv.rs
+++ b/crates/assay-vault/src/kv.rs
@@ -28,6 +28,7 @@ use crate::error::{Result, VaultError};
 
 /// One stored version of a KV path. Returned by store-layer reads.
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct KvRow {
     pub path: String,
     pub version: i64,
@@ -42,6 +43,7 @@ pub struct KvRow {
 
 /// Path-level metadata. One row in `vault.kv_meta` per path.
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct KvMeta {
     pub path: String,
     pub latest_version: i64,
@@ -103,6 +105,7 @@ pub trait KvStore: Send + Sync + 'static {
 
 /// Decrypted read result.
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct KvRead {
     pub path: String,
     pub version: i64,
@@ -118,6 +121,7 @@ pub struct KvRead {
 /// which fails closed with [`VaultError::Sealed`] when the vault is
 /// sealed.
 #[derive(Clone)]
+#[non_exhaustive]
 pub struct KvService<S: KvStore> {
     store: S,
     seal_state: crate::crypto::seal_state::SealState,

--- a/crates/assay-vault/src/personal_vault.rs
+++ b/crates/assay-vault/src/personal_vault.rs
@@ -21,6 +21,7 @@ use crate::error::Result;
 
 /// One personal-vault row. The `public_key` is X25519 raw (32 bytes).
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct PersonalVault {
     pub id: String,
     pub owner_user: String,

--- a/crates/assay-vault/src/sealing/kms_aws.rs
+++ b/crates/assay-vault/src/sealing/kms_aws.rs
@@ -27,6 +27,7 @@ use crate::error::{Result, VaultError};
 /// surface accepts explicit credentials so a localstack test path
 /// works out of the box.
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct AwsCredentials {
     pub access_key_id: String,
     pub secret_access_key: String,
@@ -34,6 +35,7 @@ pub struct AwsCredentials {
 }
 
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct AwsKmsSeal {
     pub region: String,
     pub key_id: String,

--- a/crates/assay-vault/src/sealing/kms_gcp.rs
+++ b/crates/assay-vault/src/sealing/kms_gcp.rs
@@ -24,6 +24,7 @@ use crate::error::{Result, VaultError};
 const KMS_SCOPE: &str = "https://www.googleapis.com/auth/cloudkms";
 
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct GcpKmsSeal {
     pub project: String,
     pub location: String,

--- a/crates/assay-vault/src/share.rs
+++ b/crates/assay-vault/src/share.rs
@@ -29,6 +29,7 @@ use crate::error::Result;
 /// future targets (e.g. transit key) just add a variant.
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(tag = "kind", content = "id")]
+#[non_exhaustive]
 pub enum ShareTarget {
     Item(String),
     Vault(String),
@@ -53,6 +54,7 @@ impl ShareTarget {
 
 /// Caveats wired into the biscuit at mint time.
 #[derive(Clone, Debug, Default)]
+#[non_exhaustive]
 pub struct ShareCaveats {
     /// Token expires this many seconds after mint.
     pub ttl_secs: u64,
@@ -70,6 +72,7 @@ pub struct ShareCaveats {
 /// the caller hands out. The `revocation_ids` are the IDs an operator
 /// uses with [`ShareService::revoke`] to disable the token.
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct MintedShare {
     pub token: String,
     pub revocation_ids: Vec<String>,
@@ -78,6 +81,7 @@ pub struct MintedShare {
 
 /// Verified-token grant — what `verify` returns when caveats pass.
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct ShareGrant {
     pub target: ShareTarget,
 }
@@ -100,6 +104,7 @@ pub trait RevocationStore: Send + Sync + 'static {
 
 /// One row in `vault.share_revoked`.
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct RevocationEntry {
     pub key_id: String,
     pub revoked_at: f64,

--- a/crates/assay-vault/src/transit.rs
+++ b/crates/assay-vault/src/transit.rs
@@ -29,6 +29,7 @@ use crate::error::{Result, VaultError};
 
 /// Per-key metadata.
 #[derive(Clone, Debug, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct TransitKey {
     pub name: String,
     pub algo: String,
@@ -38,6 +39,7 @@ pub struct TransitKey {
 
 /// One version of a transit key — DEK wrapped by the master KEK.
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct TransitVersion {
     pub name: String,
     pub version: i64,
@@ -82,6 +84,7 @@ pub trait TransitStore: Send + Sync + 'static {
 /// crypto op fails closed with [`VaultError::Sealed`] when the vault
 /// is sealed.
 #[derive(Clone)]
+#[non_exhaustive]
 pub struct TransitService<S: TransitStore> {
     store: S,
     seal_state: crate::crypto::seal_state::SealState,


### PR DESCRIPTION
## Summary

- Bumps `assay-vault 0.1.0 → 0.2.0` (minor — pre-1.0 breaking-change bump)
- Updates `assay-engine`'s dep declaration on `assay-vault` from `"0.1"` to `"0.2"`
- Marks all 51 of `assay-vault`'s public structs/enums `#[non_exhaustive]` (46 structs + 5 enums) so future field/variant additions no longer require a minor bump
- CHANGELOG header rolled to include `assay-vault 0.2.0` under the existing `0.4.0 / 0.3.0` release banner

## Why

`assay-engine 0.4.0`'s publish to crates.io (#98 release run) failed because:

```
multiple different versions of crate `assay_auth` in the dependency graph
  expected: assay-auth 0.2.2  (pinned by published assay-vault 0.1.0)
  found:    assay-auth 0.3.0  (direct dep of assay-engine 0.4.0)
```

`cargo publish`'s verify-build pulls deps from crates.io. The published `assay-vault 0.1.0` has `assay-auth = "0.2"` baked into its manifest — and there's no way to mutate a published version. So the only fix is a new `assay-vault` version pinning the new `assay-auth = "0.3"`.

Riding the breaking-change cost of that bump, the comprehensive `#[non_exhaustive]` sweep matches what was just done in the previous PR for `assay-auth` and `assay-engine`'s public config types — same future-proofing intent, same one-time minor-bump cost.

## Test plan

- [x] `cargo build -p assay-vault -p assay-engine` clean
- [x] `cargo test -p assay-vault -p assay-engine --lib` — 60 tests pass
- [x] `cargo clippy -p assay-vault -p assay-engine --tests -- -D warnings` clean
- [ ] `cargo semver-checks check-release` — running locally + CI will verify
- [ ] CI green
- [ ] Release run after merge: `assay-vault 0.2.0` published to crates.io, then `assay-engine 0.4.0` publish retries and succeeds (orphaned `assay-auth 0.3.0` from the previous run gets its companion)

## Breaking-change notes

External code that pattern-matches assay-vault enums (`SealingMethod`, `VaultError`, `ShareTarget`, `ActiveKek`, `Parent`) now needs a wildcard arm. External struct construction needs `Default::default()` + field assignment. Within the workspace nothing changes — `#[non_exhaustive]` only restricts external consumers.

## Bumps

| Crate | From | To | Reason |
|---|---|---|---|
| `assay-vault` | 0.1.0 | 0.2.0 | dep update (assay-auth 0.2 → 0.3) + comprehensive `#[non_exhaustive]` sweep |
| `assay-engine` deps | `assay-vault = "0.1"` | `assay-vault = "0.2"` | track new vault major |