### PR TITLE
feat(crypto): add jwt_verify Lua builtin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Assay are documented here.
 
+## [assay 0.15.2] - 2026-04-27
+
+- **`crypto.jwt_verify(token, key, opts?)`** — verify-side mirror of `jwt_sign`. PEM
+  (RS256/384/512) or JWKS table (dispatched by `kid`). Validates `aud`/`iss`/`exp`/`nbf`
+  with optional `leeway`. Lets pure-Lua services accept JWTs without an `assay-engine`.
+
 ## [assay-engine 0.4.0 / assay-auth 0.3.0 / assay-vault 0.2.0] - 2026-04-27
 
 | Crate          | Bump          |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "assay-lua"
-version = "0.15.1"
+version = "0.15.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/assay/Cargo.toml
+++ b/crates/assay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-lua"
-version = "0.15.1"
+version = "0.15.2"
 categories = ["command-line-utilities", "development-tools::testing"]
 edition = "2024"
 homepage = "https://assay.rs"

--- a/crates/assay/src/lua/builtins/crypto.rs
+++ b/crates/assay/src/lua/builtins/crypto.rs
@@ -1,7 +1,8 @@
 use super::json::{json_value_to_lua, lua_value_to_json};
 use data_encoding::BASE64URL_NOPAD;
 use digest::Digest;
-use jsonwebtoken::{Algorithm, EncodingKey, Header};
+use jsonwebtoken::jwk::{JwkSet, KeyAlgorithm};
+use jsonwebtoken::{Algorithm, DecodingKey, EncodingKey, Header, Validation, decode, decode_header};
 use mlua::{Lua, Value};
 use rand::RngExt;
 use zeroize::Zeroizing;
@@ -114,6 +115,171 @@ pub fn register_crypto(lua: &Lua) -> mlua::Result<()> {
         Ok(result)
     })?;
     crypto_table.set("jwt_decode", jwt_decode_fn)?;
+
+    // crypto.jwt_verify(token, key, opts?) -> { header, claims }
+    //
+    // Verify a JWT's signature and validate its claims. Mirrors
+    // `crypto.jwt_sign` for the receive side. Use this for tokens
+    // arriving from untrusted sources; for tokens travelling through a
+    // trusted channel (e.g. your own session cookie over TLS) where
+    // you only need to read claims, prefer `crypto.jwt_decode`.
+    //
+    // `key` accepts either:
+    //   - a PEM-encoded RSA public key string (algorithm taken from
+    //     `opts.algorithm`, default RS256)
+    //   - a JWKS table `{ keys = { ... } }` — the verifier dispatches on
+    //     the JWT header's `kid`, picks the matching JWK, and uses the
+    //     JWK's `alg` (or the JWT header's `alg` if the key omits it)
+    //
+    // `opts` (table, optional):
+    //   - `algorithm`: "RS256" | "RS384" | "RS512" — only used for the PEM path
+    //   - `audience`: string or array of strings — validates `aud`
+    //   - `issuer`:   string or array of strings — validates `iss`
+    //   - `leeway`: integer seconds of clock skew tolerance (default 0)
+    //   - `validate_exp`: boolean (default true)
+    //   - `validate_nbf`: boolean (default false)
+    //   - `required_claims`: array of strings (default ["exp"]; pass {} to skip)
+    //
+    // Returns `{ header = {...}, claims = {...} }`. Raises on signature
+    // mismatch, expired token, audience/issuer mismatch, malformed token,
+    // missing JWK, or bad arguments.
+    let jwt_verify_fn = lua.create_function(|lua, args: mlua::MultiValue| {
+        let mut args_iter = args.into_iter();
+
+        let token: String = match args_iter.next() {
+            Some(Value::String(s)) => s.to_str()?.to_string(),
+            _ => {
+                return Err(mlua::Error::runtime(
+                    "crypto.jwt_verify: first argument must be a JWT string",
+                ));
+            }
+        };
+
+        let key_arg = match args_iter.next() {
+            Some(v) => v,
+            None => {
+                return Err(mlua::Error::runtime(
+                    "crypto.jwt_verify: second argument must be a PEM string or JWKS table",
+                ));
+            }
+        };
+
+        let opts: Option<mlua::Table> = match args_iter.next() {
+            Some(Value::Table(t)) => Some(t),
+            Some(Value::Nil) | None => None,
+            _ => {
+                return Err(mlua::Error::runtime(
+                    "crypto.jwt_verify: third argument must be an options table or nil",
+                ));
+            }
+        };
+
+        // Dispatch on key type (PEM string vs JWKS table).
+        let (decoding_key, algorithm) = match key_arg {
+            Value::String(pem) => {
+                let pem_str = pem.to_str()?.to_string();
+                let alg_str = opts
+                    .as_ref()
+                    .and_then(|t| t.get::<Option<String>>("algorithm").ok().flatten());
+                let alg = match alg_str.as_deref() {
+                    Some(s) => match s.to_uppercase().as_str() {
+                        "RS256" => Algorithm::RS256,
+                        "RS384" => Algorithm::RS384,
+                        "RS512" => Algorithm::RS512,
+                        other => {
+                            return Err(mlua::Error::runtime(format!(
+                                "crypto.jwt_verify: unsupported algorithm: {other}"
+                            )));
+                        }
+                    },
+                    None => Algorithm::RS256,
+                };
+                let pem_bytes = Zeroizing::new(pem_str.into_bytes());
+                let key = DecodingKey::from_rsa_pem(&pem_bytes).map_err(|e| {
+                    mlua::Error::runtime(format!("crypto.jwt_verify: invalid PEM key: {e}"))
+                })?;
+                (key, alg)
+            }
+            Value::Table(jwks_table) => {
+                let jwks_json = lua_value_to_json(&Value::Table(jwks_table))?;
+                let jwks: JwkSet = serde_json::from_value(jwks_json).map_err(|e| {
+                    mlua::Error::runtime(format!("crypto.jwt_verify: invalid JWKS table: {e}"))
+                })?;
+
+                let header = decode_header(&token).map_err(|e| {
+                    mlua::Error::runtime(format!(
+                        "crypto.jwt_verify: malformed token header: {e}"
+                    ))
+                })?;
+                let kid = header.kid.as_deref().ok_or_else(|| {
+                    mlua::Error::runtime(
+                        "crypto.jwt_verify: token header missing 'kid' (required for JWKS dispatch)",
+                    )
+                })?;
+                let jwk = jwks.find(kid).ok_or_else(|| {
+                    mlua::Error::runtime(format!(
+                        "crypto.jwt_verify: no key in JWKS matches kid '{kid}'"
+                    ))
+                })?;
+
+                let alg = jwk
+                    .common
+                    .key_algorithm
+                    .and_then(key_algorithm_to_algorithm)
+                    .unwrap_or(header.alg);
+                let key = DecodingKey::from_jwk(jwk).map_err(|e| {
+                    mlua::Error::runtime(format!("crypto.jwt_verify: cannot decode JWK: {e}"))
+                })?;
+                (key, alg)
+            }
+            _ => {
+                return Err(mlua::Error::runtime(
+                    "crypto.jwt_verify: second argument must be a PEM string or JWKS table",
+                ));
+            }
+        };
+
+        let mut validation = Validation::new(algorithm);
+
+        if let Some(opts_table) = opts.as_ref() {
+            if let Some(audience) = lua_string_or_array(opts_table, "audience", "crypto.jwt_verify")? {
+                validation.set_audience(&audience);
+            }
+            if let Some(issuer) = lua_string_or_array(opts_table, "issuer", "crypto.jwt_verify")? {
+                validation.set_issuer(&issuer);
+            }
+            if let Ok(Some(leeway)) = opts_table.get::<Option<u64>>("leeway") {
+                validation.leeway = leeway;
+            }
+            if let Ok(Some(validate_exp)) = opts_table.get::<Option<bool>>("validate_exp") {
+                validation.validate_exp = validate_exp;
+            }
+            if let Ok(Some(validate_nbf)) = opts_table.get::<Option<bool>>("validate_nbf") {
+                validation.validate_nbf = validate_nbf;
+            }
+            if let Ok(Some(required_table)) = opts_table.get::<Option<mlua::Table>>("required_claims") {
+                let mut required: Vec<String> = Vec::new();
+                for item in required_table.sequence_values::<mlua::String>() {
+                    required.push(item?.to_str()?.to_string());
+                }
+                let required_refs: Vec<&str> = required.iter().map(String::as_str).collect();
+                validation.set_required_spec_claims(&required_refs);
+            }
+        }
+
+        let token_data: jsonwebtoken::TokenData<serde_json::Value> =
+            decode(&token, &decoding_key, &validation)
+                .map_err(|e| mlua::Error::runtime(format!("crypto.jwt_verify: {e}")))?;
+
+        let header_json = serde_json::to_value(&token_data.header).map_err(|e| {
+            mlua::Error::runtime(format!("crypto.jwt_verify: serialize header: {e}"))
+        })?;
+        let result = lua.create_table()?;
+        result.set("header", json_value_to_lua(lua, &header_json)?)?;
+        result.set("claims", json_value_to_lua(lua, &token_data.claims)?)?;
+        Ok(result)
+    })?;
+    crypto_table.set("jwt_verify", jwt_verify_fn)?;
 
     let hash_fn = lua.create_function(|_, args: mlua::MultiValue| {
         let mut args_iter = args.into_iter();
@@ -246,6 +412,53 @@ pub fn register_crypto(lua: &Lua) -> mlua::Result<()> {
 
     lua.globals().set("crypto", crypto_table)?;
     Ok(())
+}
+
+// Read a Lua opts-table field that accepts either a string or an array of
+// strings. Returns Ok(None) if the field is absent or nil. Used by jwt_verify
+// for `audience` and `issuer`.
+fn lua_string_or_array(
+    opts: &mlua::Table,
+    field: &str,
+    fn_name: &str,
+) -> mlua::Result<Option<Vec<String>>> {
+    let raw: Value = opts.get(field)?;
+    match raw {
+        Value::Nil => Ok(None),
+        Value::String(s) => Ok(Some(vec![s.to_str()?.to_string()])),
+        Value::Table(t) => {
+            let mut out = Vec::new();
+            for item in t.sequence_values::<mlua::String>() {
+                out.push(item?.to_str()?.to_string());
+            }
+            Ok(Some(out))
+        }
+        _ => Err(mlua::Error::runtime(format!(
+            "{fn_name}: '{field}' must be a string or array of strings"
+        ))),
+    }
+}
+
+// Map a JWK's declared key algorithm to the matching JWT algorithm enum.
+// Returns None for algorithms not representable in jsonwebtoken's `Algorithm`
+// (none in the current crate version, but kept Option-shaped for forward
+// compatibility) so the caller can fall back to the JWT header's `alg`.
+fn key_algorithm_to_algorithm(key_alg: KeyAlgorithm) -> Option<Algorithm> {
+    Some(match key_alg {
+        KeyAlgorithm::HS256 => Algorithm::HS256,
+        KeyAlgorithm::HS384 => Algorithm::HS384,
+        KeyAlgorithm::HS512 => Algorithm::HS512,
+        KeyAlgorithm::RS256 => Algorithm::RS256,
+        KeyAlgorithm::RS384 => Algorithm::RS384,
+        KeyAlgorithm::RS512 => Algorithm::RS512,
+        KeyAlgorithm::PS256 => Algorithm::PS256,
+        KeyAlgorithm::PS384 => Algorithm::PS384,
+        KeyAlgorithm::PS512 => Algorithm::PS512,
+        KeyAlgorithm::ES256 => Algorithm::ES256,
+        KeyAlgorithm::ES384 => Algorithm::ES384,
+        KeyAlgorithm::EdDSA => Algorithm::EdDSA,
+        _ => return None,
+    })
 }
 
 fn compute_hmac_bytes(key: &[u8], data: &[u8], algorithm: &str) -> Result<Vec<u8>, String> {

--- a/crates/assay/tests/crypto.rs
+++ b/crates/assay/tests/crypto.rs
@@ -172,6 +172,430 @@ async fn test_jwt_decode_roundtrip_with_jwt_sign() {
 }
 
 #[tokio::test]
+async fn test_jwt_verify_rs256_roundtrip() {
+    // Sign with the private key, verify with the matching public key.
+    let priv_pem = std::fs::read_to_string("tests/fixtures/test_rsa.pem").unwrap();
+    let pub_pem = std::fs::read_to_string("tests/fixtures/test_rsa_pub.pem").unwrap();
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    let exp = now + 3600;
+
+    let vm = create_vm();
+    vm.globals().set("priv_pem", vm.create_string(&priv_pem).unwrap()).unwrap();
+    vm.globals().set("pub_pem", vm.create_string(&pub_pem).unwrap()).unwrap();
+    vm.globals().set("test_iat", now as i64).unwrap();
+    vm.globals().set("test_exp", exp as i64).unwrap();
+
+    vm.load(
+        r#"
+        local token = crypto.jwt_sign({
+            iss = "test-issuer",
+            sub = "test-subject",
+            aud = "test-audience",
+            iat = test_iat,
+            exp = test_exp,
+        }, priv_pem)
+        local out = crypto.jwt_verify(token, pub_pem, {
+            audience = "test-audience",
+            issuer = "test-issuer",
+        })
+        assert.eq(out.header.alg, "RS256")
+        assert.eq(out.claims.iss, "test-issuer")
+        assert.eq(out.claims.sub, "test-subject")
+        assert.eq(out.claims.aud, "test-audience")
+        "#,
+    )
+    .exec_async()
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn test_jwt_verify_rejects_wrong_audience() {
+    let priv_pem = std::fs::read_to_string("tests/fixtures/test_rsa.pem").unwrap();
+    let pub_pem = std::fs::read_to_string("tests/fixtures/test_rsa_pub.pem").unwrap();
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64;
+
+    let vm = create_vm();
+    vm.globals().set("priv_pem", vm.create_string(&priv_pem).unwrap()).unwrap();
+    vm.globals().set("pub_pem", vm.create_string(&pub_pem).unwrap()).unwrap();
+    vm.globals().set("test_iat", now).unwrap();
+    vm.globals().set("test_exp", now + 3600).unwrap();
+
+    let result = vm
+        .load(
+            r#"
+            local token = crypto.jwt_sign({
+                iss = "test-issuer",
+                aud = "intended-audience",
+                iat = test_iat,
+                exp = test_exp,
+            }, priv_pem)
+            return crypto.jwt_verify(token, pub_pem, { audience = "different-audience" })
+            "#,
+        )
+        .exec_async()
+        .await;
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("audience") || err.contains("Audience") || err.contains("aud"),
+        "got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn test_jwt_verify_rejects_wrong_issuer() {
+    let priv_pem = std::fs::read_to_string("tests/fixtures/test_rsa.pem").unwrap();
+    let pub_pem = std::fs::read_to_string("tests/fixtures/test_rsa_pub.pem").unwrap();
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64;
+
+    let vm = create_vm();
+    vm.globals().set("priv_pem", vm.create_string(&priv_pem).unwrap()).unwrap();
+    vm.globals().set("pub_pem", vm.create_string(&pub_pem).unwrap()).unwrap();
+    vm.globals().set("test_iat", now).unwrap();
+    vm.globals().set("test_exp", now + 3600).unwrap();
+
+    let result = vm
+        .load(
+            r#"
+            local token = crypto.jwt_sign({
+                iss = "real-issuer",
+                aud = "test-audience",
+                iat = test_iat,
+                exp = test_exp,
+            }, priv_pem)
+            return crypto.jwt_verify(token, pub_pem, {
+                audience = "test-audience",
+                issuer = "expected-issuer",
+            })
+            "#,
+        )
+        .exec_async()
+        .await;
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("issuer") || err.contains("Issuer") || err.contains("iss"),
+        "got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn test_jwt_verify_rejects_expired_token() {
+    let priv_pem = std::fs::read_to_string("tests/fixtures/test_rsa.pem").unwrap();
+    let pub_pem = std::fs::read_to_string("tests/fixtures/test_rsa_pub.pem").unwrap();
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64;
+
+    let vm = create_vm();
+    vm.globals().set("priv_pem", vm.create_string(&priv_pem).unwrap()).unwrap();
+    vm.globals().set("pub_pem", vm.create_string(&pub_pem).unwrap()).unwrap();
+    vm.globals().set("test_iat", now - 7200).unwrap();
+    vm.globals().set("test_exp", now - 3600).unwrap();
+
+    let result = vm
+        .load(
+            r#"
+            local token = crypto.jwt_sign({
+                iss = "test-issuer",
+                aud = "test-audience",
+                iat = test_iat,
+                exp = test_exp,
+            }, priv_pem)
+            return crypto.jwt_verify(token, pub_pem, { audience = "test-audience" })
+            "#,
+        )
+        .exec_async()
+        .await;
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("expired") || err.contains("ExpiredSignature") || err.contains("exp"),
+        "got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn test_jwt_verify_rejects_tampered_signature() {
+    let priv_pem = std::fs::read_to_string("tests/fixtures/test_rsa.pem").unwrap();
+    let pub_pem = std::fs::read_to_string("tests/fixtures/test_rsa_pub.pem").unwrap();
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64;
+
+    let vm = create_vm();
+    vm.globals().set("priv_pem", vm.create_string(&priv_pem).unwrap()).unwrap();
+    vm.globals().set("pub_pem", vm.create_string(&pub_pem).unwrap()).unwrap();
+    vm.globals().set("test_iat", now).unwrap();
+    vm.globals().set("test_exp", now + 3600).unwrap();
+
+    let result = vm
+        .load(
+            r#"
+            -- Two different payloads → different signatures over the same key.
+            -- Splice token_a's header.payload onto token_b's signature; result
+            -- is well-formed base64url everywhere but signature ≠ message.
+            local token_a = crypto.jwt_sign({
+                iss = "test-issuer",
+                aud = "test-audience",
+                iat = test_iat,
+                exp = test_exp,
+                marker = "alpha",
+            }, priv_pem)
+            local token_b = crypto.jwt_sign({
+                iss = "test-issuer",
+                aud = "test-audience",
+                iat = test_iat,
+                exp = test_exp,
+                marker = "beta",
+            }, priv_pem)
+            local sig_b = token_b:match("[^.]+$")
+            local prefix_a = token_a:match("^(.+)%.[^.]+$")
+            local tampered = prefix_a .. "." .. sig_b
+            return crypto.jwt_verify(tampered, pub_pem, { audience = "test-audience" })
+            "#,
+        )
+        .exec_async()
+        .await;
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("InvalidSignature") || err.contains("signature") || err.contains("Signature"),
+        "got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn test_jwt_verify_jwks_dispatch_by_kid() {
+    let priv_pem = std::fs::read_to_string("tests/fixtures/test_rsa.pem").unwrap();
+    let jwks_json = std::fs::read_to_string("tests/fixtures/test_rsa_pub.jwks.json").unwrap();
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64;
+
+    let vm = create_vm();
+    vm.globals().set("priv_pem", vm.create_string(&priv_pem).unwrap()).unwrap();
+    vm.globals().set("jwks_json", vm.create_string(&jwks_json).unwrap()).unwrap();
+    vm.globals().set("test_iat", now).unwrap();
+    vm.globals().set("test_exp", now + 3600).unwrap();
+
+    vm.load(
+        r#"
+        local jwks = json.parse(jwks_json)
+        local token = crypto.jwt_sign({
+            iss = "test-issuer",
+            aud = "test-audience",
+            iat = test_iat,
+            exp = test_exp,
+        }, priv_pem, "RS256", { kid = "test-key-1" })
+        local out = crypto.jwt_verify(token, jwks, { audience = "test-audience" })
+        assert.eq(out.header.kid, "test-key-1")
+        assert.eq(out.claims.iss, "test-issuer")
+        "#,
+    )
+    .exec_async()
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn test_jwt_verify_jwks_rejects_unknown_kid() {
+    let priv_pem = std::fs::read_to_string("tests/fixtures/test_rsa.pem").unwrap();
+    let jwks_json = std::fs::read_to_string("tests/fixtures/test_rsa_pub.jwks.json").unwrap();
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64;
+
+    let vm = create_vm();
+    vm.globals().set("priv_pem", vm.create_string(&priv_pem).unwrap()).unwrap();
+    vm.globals().set("jwks_json", vm.create_string(&jwks_json).unwrap()).unwrap();
+    vm.globals().set("test_iat", now).unwrap();
+    vm.globals().set("test_exp", now + 3600).unwrap();
+
+    let result = vm
+        .load(
+            r#"
+            local jwks = json.parse(jwks_json)
+            local token = crypto.jwt_sign({
+                iss = "test-issuer",
+                aud = "test-audience",
+                iat = test_iat,
+                exp = test_exp,
+            }, priv_pem, "RS256", { kid = "missing-key" })
+            return crypto.jwt_verify(token, jwks, { audience = "test-audience" })
+            "#,
+        )
+        .exec_async()
+        .await;
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(
+        err.contains("no key in JWKS matches kid") || err.contains("missing-key"),
+        "got: {err}"
+    );
+}
+
+#[tokio::test]
+async fn test_jwt_verify_jwks_requires_kid_in_token() {
+    let priv_pem = std::fs::read_to_string("tests/fixtures/test_rsa.pem").unwrap();
+    let jwks_json = std::fs::read_to_string("tests/fixtures/test_rsa_pub.jwks.json").unwrap();
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64;
+
+    let vm = create_vm();
+    vm.globals().set("priv_pem", vm.create_string(&priv_pem).unwrap()).unwrap();
+    vm.globals().set("jwks_json", vm.create_string(&jwks_json).unwrap()).unwrap();
+    vm.globals().set("test_iat", now).unwrap();
+    vm.globals().set("test_exp", now + 3600).unwrap();
+
+    let result = vm
+        .load(
+            r#"
+            local jwks = json.parse(jwks_json)
+            -- Sign without a kid header.
+            local token = crypto.jwt_sign({
+                iss = "test-issuer",
+                aud = "test-audience",
+                iat = test_iat,
+                exp = test_exp,
+            }, priv_pem)
+            return crypto.jwt_verify(token, jwks, { audience = "test-audience" })
+            "#,
+        )
+        .exec_async()
+        .await;
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("missing 'kid'"), "got: {err}");
+}
+
+#[tokio::test]
+async fn test_jwt_verify_audience_array() {
+    // `audience` accepts both a string and an array of strings; either acts
+    // as an allowlist (token's aud must match at least one entry).
+    let priv_pem = std::fs::read_to_string("tests/fixtures/test_rsa.pem").unwrap();
+    let pub_pem = std::fs::read_to_string("tests/fixtures/test_rsa_pub.pem").unwrap();
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64;
+
+    let vm = create_vm();
+    vm.globals().set("priv_pem", vm.create_string(&priv_pem).unwrap()).unwrap();
+    vm.globals().set("pub_pem", vm.create_string(&pub_pem).unwrap()).unwrap();
+    vm.globals().set("test_iat", now).unwrap();
+    vm.globals().set("test_exp", now + 3600).unwrap();
+
+    vm.load(
+        r#"
+        local token = crypto.jwt_sign({
+            iss = "test-issuer",
+            aud = "second-audience",
+            iat = test_iat,
+            exp = test_exp,
+        }, priv_pem)
+        local out = crypto.jwt_verify(token, pub_pem, {
+            audience = { "first-audience", "second-audience", "third-audience" },
+        })
+        assert.eq(out.claims.aud, "second-audience")
+        "#,
+    )
+    .exec_async()
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn test_jwt_verify_skip_exp_validation() {
+    let priv_pem = std::fs::read_to_string("tests/fixtures/test_rsa.pem").unwrap();
+    let pub_pem = std::fs::read_to_string("tests/fixtures/test_rsa_pub.pem").unwrap();
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64;
+
+    let vm = create_vm();
+    vm.globals().set("priv_pem", vm.create_string(&priv_pem).unwrap()).unwrap();
+    vm.globals().set("pub_pem", vm.create_string(&pub_pem).unwrap()).unwrap();
+    vm.globals().set("test_iat", now - 7200).unwrap();
+    vm.globals().set("test_exp", now - 3600).unwrap();
+
+    vm.load(
+        r#"
+        local token = crypto.jwt_sign({
+            iss = "test-issuer",
+            aud = "test-audience",
+            iat = test_iat,
+            exp = test_exp,
+        }, priv_pem)
+        -- An expired token verifies fine when validate_exp is off and the
+        -- exp claim is no longer required.
+        local out = crypto.jwt_verify(token, pub_pem, {
+            audience = "test-audience",
+            validate_exp = false,
+            required_claims = {},
+        })
+        assert.eq(out.claims.iss, "test-issuer")
+        "#,
+    )
+    .exec_async()
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn test_jwt_verify_rejects_malformed_token() {
+    let pub_pem = std::fs::read_to_string("tests/fixtures/test_rsa_pub.pem").unwrap();
+    let vm = create_vm();
+    vm.globals().set("pub_pem", vm.create_string(&pub_pem).unwrap()).unwrap();
+
+    let result = vm
+        .load(r#"return crypto.jwt_verify("only.two", pub_pem)"#)
+        .exec_async()
+        .await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn test_jwt_verify_rejects_invalid_pem() {
+    let result = run_lua(
+        r#"
+        crypto.jwt_verify("a.b.c", "not-a-real-pem-key")
+        "#,
+    )
+    .await;
+    assert!(result.is_err());
+    let err = result.unwrap_err().to_string();
+    assert!(err.contains("invalid PEM key"), "got: {err}");
+}
+
+#[tokio::test]
 async fn test_jwt_decode_rejects_malformed_token() {
     // Not three segments
     let result = run_lua(r#"crypto.jwt_decode("only.two")"#).await;

--- a/crates/assay/tests/fixtures/test_rsa_pub.jwks.json
+++ b/crates/assay/tests/fixtures/test_rsa_pub.jwks.json
@@ -1,0 +1,12 @@
+{
+  "keys": [
+    {
+      "kty": "RSA",
+      "use": "sig",
+      "alg": "RS256",
+      "kid": "test-key-1",
+      "n": "xWnNz2jbegL4NHAQ_Ol6iMXhWHUrwYh9j54Lcnc9iISm2xKIjo2f_WrYMUSTaau92V-GauTqfmRforCfPEU6iZnl64qK7ZzKx8BY6u5v9RgJHw8k7dxsoo6ZfYewSa-MxM0TSo1eG4R35AGwmFJ-InA5r7TR35BjFKXmqFgv-R-JiKQEFe5WWWggjGDzPohYEUkydx8O-4livbR6XNP6lYEC2gZmgSR2tEuYnEkKVfXp7fetLdao9pH7SNcYIwXpk7P6P1ihiiHXJhHCc4NrRdJEfMMnewdvB9lICaKjIA2Io8HOQOVFhP1od9b-r0EortsfEPMovb1EEa1YhYT8Cw",
+      "e": "AQAB"
+    }
+  ]
+}

--- a/docs/modules/crypto.md
+++ b/docs/modules/crypto.md
@@ -15,7 +15,15 @@ Cryptography utilities. No `require()` needed.
   - Returns `header` and `claims` parsed from the base64url segments
   - Use when the JWT travels through a trusted channel (your own session cookie over TLS) and you
     just need to read the claims
-  - For untrusted JWTs, verify the signature with a JWKS-aware verifier instead
+  - For untrusted JWTs, use `crypto.jwt_verify` instead
+- `crypto.jwt_verify(token, key, opts?)` → `{header, claims}` — Verify signature and validate claims
+  - `key`: PEM-encoded RSA public key string, OR a JWKS table `{ keys = { ... } }`
+    - PEM path uses `opts.algorithm` (default `"RS256"`)
+    - JWKS path dispatches on the JWT header's `kid` and uses the matching JWK's `alg`
+  - `opts`: `{algorithm = "RS256"|"RS384"|"RS512", audience = "x" | {"x","y"}, issuer = "x" | {"x","y"}, leeway = 0, validate_exp = true, validate_nbf = false, required_claims = {"exp"}}`
+  - Returns the same shape as `jwt_decode`; raises on signature mismatch, expired token, claim
+    mismatch, malformed token, or missing JWK
+  - Pair with `assay.ory.hydra` `c.discovery:jwks()` to fetch the issuer's JWKS table at boot
 - `crypto.hash(str, alg)` → string — Hash string (hex output)
   - `alg`: `"sha256"` | `"sha384"` | `"sha512"` | `"md5"`
 - `crypto.hmac(key, data, alg?, raw?)` → string — HMAC signature

--- a/llms.txt
+++ b/llms.txt
@@ -19,7 +19,7 @@
 - [http](https://assay.rs/modules/http.html): HTTP client, server, SSE streaming — http.get/post/put/patch/delete/serve
 - [json, yaml, toml](https://assay.rs/modules/serialization.html): JSON/YAML/TOML parse and encode
 - [fs](https://assay.rs/modules/fs.html): Filesystem — fs.read/write, fs.lines (streaming line iterator), fs.sub_in_file (sed -i equivalent using Lua patterns)
-- [crypto, base64](https://assay.rs/modules/crypto.html): JWT signing/decoding, HMAC, hashing, random, base64
+- [crypto, base64](https://assay.rs/modules/crypto.html): JWT signing/verification/decoding (PEM or JWKS), HMAC, hashing, random, base64
 - [regex](https://assay.rs/modules/regex.html): Regex match, find, replace
 - [db](https://assay.rs/modules/db.html): SQL database — Postgres, MySQL, SQLite — db.connect/query/execute
 - [ws](https://assay.rs/modules/ws.html): WebSocket client — ws.connect/send/recv/close


### PR DESCRIPTION
### Summary

Restores native JWT verification in the Lua runtime — the only piece of v0.12's auth surface still missing post-split. Pure-Lua services can now accept JWTs without standing up an `assay-engine` alongside them just for `[[auth.external_issuers]]`.

`crypto.jwt_verify(token, key, opts?)` mirrors `crypto.jwt_sign`:

- **key**: PEM string (RS256/384/512) or JWKS table — JWKS path dispatches by JWT header `kid` and uses the matching JWK's `alg`
- **opts**: `audience` (string or array), `issuer` (string or array), `leeway` seconds, `validate_exp` (default true), `validate_nbf` (default false), `required_claims` (default `["exp"]`; pass `{}` to disable)
- **returns** `{header, claims}` — same shape as `crypto.jwt_decode`
- **raises** on signature mismatch / expired / claim mismatch / malformed / missing JWK

Pair with `assay.ory.hydra` `c.discovery:jwks()` to fetch an issuer's JWKS table at boot.

### Footprint (release build, aarch64-darwin)

Same machine, same release profile (`lto = true`, `codegen-units = 1`, `opt-level = "z"`, `panic = "abort"`, `strip = true`). Workload: `assay run /tmp/noop.lua` where `noop.lua = print("ok")`.

| Metric                          | origin/main             | this branch             | Δ                          |
| ------------------------------- | ----------------------- | ----------------------- | -------------------------- |
| Stripped binary (\`assay\`)     | 7.55 MiB (7,918,520)    | 7.60 MiB (7,968,544)    | **+48.85 KiB / +0.63%**    |
| Max RSS at startup (mean of 5)  | 10,220 KiB              | 10,188 KiB              | within noise               |
| Cold-start wall (mean of 50)    | 29.52 ms                | 30.08 ms                | **+0.56 ms / +1.9%** (noise) |

No new crate dependencies — `jsonwebtoken` is already linked for `jwt_sign`, and `rust_crypto` features pulled in the verifiers. The +48 KiB is `jsonwebtoken::decode` + `Validation` + `jwk::JwkSet` deserialize paths plus the new closure.

### Test plan

- [x] cargo test -p assay-lua --test crypto (37/37 pass — 12 new + 25 existing)
- [x] cargo clippy -p assay-lua --tests -- -D warnings (clean)
- [ ] CI green