### PR TITLE
engine: expose ctx-builders for downstream composition

### DIFF
--- a/crates/assay-engine/src/lib.rs
+++ b/crates/assay-engine/src/lib.rs
@@ -114,7 +114,7 @@ pub async fn run(cfg: EngineConfig) -> anyhow::Result<()> {
 /// a fresh one on first boot) and composes the per-feature stores
 /// against the same pool the rest of the engine uses.
 #[cfg(all(feature = "vault", feature = "backend-postgres"))]
-async fn build_vault_ctx_pg(
+pub async fn build_vault_ctx_pg(
     modules: &[String],
     pool: &sqlx::PgPool,
 ) -> anyhow::Result<Option<assay_vault::VaultCtx>> {
@@ -188,7 +188,7 @@ async fn build_vault_ctx_pg(
 
 /// SQLite mirror of [`build_vault_ctx_pg`].
 #[cfg(all(feature = "vault", feature = "backend-sqlite"))]
-async fn build_vault_ctx_sqlite(
+pub async fn build_vault_ctx_sqlite(
     modules: &[String],
     pool: &sqlx::SqlitePool,
 ) -> anyhow::Result<Option<assay_vault::VaultCtx>> {
@@ -249,7 +249,7 @@ async fn build_vault_ctx_sqlite(
 }
 
 #[cfg(feature = "backend-postgres")]
-async fn build_auth_ctx_pg(
+pub async fn build_auth_ctx_pg(
     cfg: &EngineConfig,
     pool: &sqlx::PgPool,
 ) -> anyhow::Result<assay_auth::AuthCtx> {
@@ -329,7 +329,7 @@ async fn build_auth_ctx_pg(
 }
 
 #[cfg(feature = "backend-sqlite")]
-async fn build_auth_ctx_sqlite(
+pub async fn build_auth_ctx_sqlite(
     cfg: &EngineConfig,
     pool: &sqlx::SqlitePool,
 ) -> anyhow::Result<assay_auth::AuthCtx> {


### PR DESCRIPTION
## Summary

Expose four context-builder functions in `assay-engine` so downstream binaries can compose `EngineState<S>` and merge the engine's `axum::Router` into a parent router instead of being limited to the all-or-nothing `assay_engine::run` entrypoint.

The four functions promoted from private to `pub` (in `crates/assay-engine/src/lib.rs`):

- `build_vault_ctx_pg`     (gated on `feature = "vault"` + `feature = "backend-postgres"`)
- `build_vault_ctx_sqlite` (gated on `feature = "vault"` + `feature = "backend-sqlite"`)
- `build_auth_ctx_pg`      (gated on `feature = "backend-postgres"`)
- `build_auth_ctx_sqlite`  (gated on `feature = "backend-sqlite"`)

All `#[cfg(...)]` attributes are preserved; only the visibility changes.

## Use case

`knowhere v0.2.0` (a downstream host-ops binary) needs to:

1. Build `EngineState<S>` by composing auth + vault contexts from the same pool the engine uses.
2. Merge the engine's `axum::Router` into a parent router that adds host-ops routes (e.g. `/health`, `/version`, additional ops endpoints).

Today this is impossible without forking, because the ctx-builders are private and `assay_engine::run` owns the whole listener lifecycle.

## Compatibility

Strictly additive:

- No API removed.
- No signature changed.
- No behaviour change for existing callers of `assay_engine::run` (which still calls these helpers internally).

Targets the next `assay-engine` patch release (0.4.1).

## Verification

- `cargo build --workspace` -> finished in 55s, only the pre-existing dead-code warnings in `crates/assay/src/lua/file_source.rs` (unrelated).
- `cargo test --workspace --lib --no-fail-fast` -> 275 passed, 0 failed, 8 ignored across 7 lib test suites.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace --lib --no-fail-fast` clean
- [ ] Downstream `knowhere` consumes `assay-engine = "0.4.1"` and composes `EngineState<S>` without forking