### PR TITLE
lua + engine: support embedding into a parent binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "assay-lua"
-version = "0.15.2"
+version = "0.15.3"
 dependencies = [
  "anyhow",
  "axum",
@@ -375,6 +375,7 @@ dependencies = [
  "tokio-test",
  "tokio-tungstenite",
  "toml",
+ "tower",
  "tower-http",
  "tracing",
  "tracing-subscriber",

--- a/crates/assay-engine/src/embedded.rs
+++ b/crates/assay-engine/src/embedded.rs
@@ -1,8 +1,8 @@
 //! Embedded-mode entrypoints for `assay-engine`.
 //!
-//! Use case: a parent binary (knowhere v2, …) wants to compose engine
-//! into its own [`axum::Router`] rather than running engine standalone
-//! via [`crate::run`].
+//! Use case: a parent binary wants to compose engine into its own
+//! [`axum::Router`] rather than running engine standalone via
+//! [`crate::run`].
 //!
 //! ```no_run
 //! # async fn example() -> anyhow::Result<()> {

--- a/crates/assay-engine/src/embedded.rs
+++ b/crates/assay-engine/src/embedded.rs
@@ -182,6 +182,12 @@ async fn build_sqlite(
 /// task, and constructs the [`axum::Router`]. The caller (this
 /// module's `build`, or the standalone `run` wrapper) decides what
 /// to do with the resulting router.
+//
+// 8 args (1 over clippy's default limit) — splitting them into a
+// struct just to placate the lint adds boilerplate without making
+// the call sites clearer (each call site is a single-use match
+// arm). Allow the lint here.
+#[allow(clippy::too_many_arguments)]
 async fn compose<S: WorkflowStore + Clone + 'static>(
     cfg: EngineConfig,
     store: S,

--- a/crates/assay-engine/src/embedded.rs
+++ b/crates/assay-engine/src/embedded.rs
@@ -1,0 +1,280 @@
+//! Embedded-mode entrypoints for `assay-engine`.
+//!
+//! Use case: a parent binary (knowhere v2, …) wants to compose engine
+//! into its own [`axum::Router`] rather than running engine standalone
+//! via [`crate::run`].
+//!
+//! ```no_run
+//! # async fn example() -> anyhow::Result<()> {
+//! use assay_engine::embedded;
+//! use assay_engine::config::EngineConfig;
+//! use std::path::Path;
+//!
+//! let cfg = EngineConfig::from_file(Path::new("engine.toml"))?;
+//! let engine = embedded::build(cfg).await?;
+//! // Mount engine.router on parent's listener
+//! // Use engine.pool for parent's queries (engine confines its
+//! //   writes to its own schemas)
+//! # let _ = engine;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! The standalone [`crate::run`] is implemented as a thin wrapper
+//! around [`build`] + a serve loop; standalone behaviour is unchanged.
+//!
+//! # Compared to the previous (now-closed) PR exposing four
+//! # `pub fn build_*_ctx_*` helpers
+//!
+//! Embedded mode is a first-class concept here: one type, one
+//! function, one symmetric `migrate` helper. Internal ctx-builders
+//! (`build_auth_ctx_{pg,sqlite}`, `build_vault_ctx_{pg,sqlite}`)
+//! stay `pub(crate)` — they are implementation details. Preconditions
+//! that prevent operator lockout (no operator users + no admin
+//! api-keys + no external issuers) are enforced inside [`build`] and
+//! cannot be skipped.
+
+use std::sync::Arc;
+
+use assay_dashboard::{DashboardCtx, WhitelabelConfig};
+use assay_domain::events::EngineEventBus;
+use assay_workflow::{WorkflowStore, WorkflowCtx};
+
+use crate::config::EngineConfig;
+use crate::init::EngineBoot;
+use crate::state::EngineState;
+
+/// Engine composed for embedding into a parent binary. See module
+/// docs.
+///
+/// Marked `#[non_exhaustive]` so future fields (graceful-shutdown
+/// handle, metrics handle, …) can be added without breaking
+/// downstream pattern-matching.
+#[non_exhaustive]
+pub struct EmbeddedEngine {
+    /// Engine's [`axum::Router`]. Mount on parent's listener at root,
+    /// or under a sub-path. URL surface includes:
+    ///   - `/api/v1/engine/*` — engine + per-module APIs
+    ///   - `/auth/*` — OIDC spec endpoints (when auth module enabled)
+    ///   - `/api/v1/vault/*` — vault APIs (when vault module enabled)
+    ///   - `/workflow/`, `/auth/console`, `/engine/console`,
+    ///     `/vault/console` — assay-dashboard SPAs
+    pub router: axum::Router,
+
+    /// Backend-typed pool engine's modules use. Parent may share for
+    /// its own queries; engine confines writes to its own schemas
+    /// (`engine.*`, `workflow.*`, `auth.*`, `vault.*` on PG; per-
+    /// module `.db` files on sqlite via ATTACH).
+    pub pool: EmbeddedPool,
+
+    /// This engine instance's `engine.instances` row id. Surface in
+    /// parent's introspection endpoints if useful.
+    pub instance_id: uuid::Uuid,
+
+    /// Names of modules attached/enabled at boot. Mirrors
+    /// `EngineState::modules` but cloned out so the parent doesn't
+    /// need to keep an `Arc<EngineState>` around.
+    pub modules: Vec<String>,
+
+    /// `assay-engine` crate version.
+    pub engine_version: &'static str,
+}
+
+/// Backend-typed pool. Engine's internal code paths are backend-
+/// specific (PG advisory locks, SQLite ATTACH for multi-module DB
+/// files); we expose typed pools so downstream can dispatch on the
+/// variant explicitly rather than guess.
+///
+/// Marked `#[non_exhaustive]` so future backends (e.g., MySQL) can
+/// be added without breaking exhaustive matches.
+#[non_exhaustive]
+pub enum EmbeddedPool {
+    #[cfg(feature = "backend-postgres")]
+    Postgres(sqlx::PgPool),
+    #[cfg(feature = "backend-sqlite")]
+    Sqlite(sqlx::SqlitePool),
+}
+
+/// Build engine for embedding. Internally:
+///
+///   1. Open pool against `cfg.backend` via [`EngineBoot::run`]
+///      (which also runs engine + per-module schema migrations).
+///   2. Bootstrap module contexts (auth, vault, workflow).
+///   3. **Enforce preconditions** — refuse to start when auth is on
+///      and the deployment has no operator users, no admin api-keys,
+///      and no external OIDC issuers (would lock the operator out).
+///   4. Compose [`axum::Router`] via [`crate::server::build_app`].
+///   5. Spawn engine's background tasks (events outbox cleanup;
+///      module-specific schedulers spawn during ctx construction).
+///
+/// Returns `Err` on any of: pool-open failure, migration failure,
+/// ctx-build failure, precondition failure. The `Err` carries a
+/// helpful operator-facing message when the cause is configuration.
+pub async fn build(cfg: EngineConfig) -> anyhow::Result<EmbeddedEngine> {
+    let boot = EngineBoot::run(&cfg).await?;
+    match boot {
+        #[cfg(feature = "backend-postgres")]
+        EngineBoot::Postgres(b) => build_pg(cfg, b).await,
+        #[cfg(feature = "backend-sqlite")]
+        EngineBoot::Sqlite(b) => build_sqlite(cfg, b).await,
+    }
+}
+
+#[cfg(feature = "backend-postgres")]
+async fn build_pg(
+    cfg: EngineConfig,
+    b: crate::init::PgBoot,
+) -> anyhow::Result<EmbeddedEngine> {
+    let store = assay_workflow::PostgresStore::from_pool(b.pool.clone())
+        .await
+        .map_err(|e| anyhow::anyhow!("workflow store (pg): {e}"))?;
+    let auth_ctx = crate::build_auth_ctx_pg(&cfg, &b.pool).await?;
+    #[cfg(feature = "vault")]
+    let vault_ctx = crate::build_vault_ctx_pg(&b.modules, &b.pool).await?;
+    #[cfg(not(feature = "vault"))]
+    let vault_ctx: Option<()> = None;
+
+    compose(
+        cfg,
+        store,
+        b.bus,
+        b.modules,
+        b.instance_id,
+        Some(auth_ctx),
+        vault_ctx,
+        EmbeddedPool::Postgres(b.pool),
+    )
+    .await
+}
+
+#[cfg(feature = "backend-sqlite")]
+async fn build_sqlite(
+    cfg: EngineConfig,
+    b: crate::init::SqliteBoot,
+) -> anyhow::Result<EmbeddedEngine> {
+    let store = assay_workflow::SqliteStore::from_attached_pool(b.pool.clone())
+        .await
+        .map_err(|e| anyhow::anyhow!("workflow store (sqlite): {e}"))?;
+    let auth_ctx = crate::build_auth_ctx_sqlite(&cfg, &b.pool).await?;
+    #[cfg(feature = "vault")]
+    let vault_ctx = crate::build_vault_ctx_sqlite(&b.modules, &b.pool).await?;
+    #[cfg(not(feature = "vault"))]
+    let vault_ctx: Option<()> = None;
+
+    compose(
+        cfg,
+        store,
+        b.bus,
+        b.modules,
+        b.instance_id,
+        Some(auth_ctx),
+        vault_ctx,
+        EmbeddedPool::Sqlite(b.pool),
+    )
+    .await
+}
+
+/// Common composition step shared between PG + SQLite paths.
+///
+/// Mirrors the body of the previous private `run_with_store` (now
+/// removed) minus the final `server::serve` call: builds the Lua-
+/// VM-equivalent state container, spawns the engine_events cleanup
+/// task, and constructs the [`axum::Router`]. The caller (this
+/// module's `build`, or the standalone `run` wrapper) decides what
+/// to do with the resulting router.
+async fn compose<S: WorkflowStore + Clone + 'static>(
+    cfg: EngineConfig,
+    store: S,
+    bus: Arc<dyn EngineEventBus>,
+    modules: Vec<String>,
+    instance_id: uuid::Uuid,
+    auth_ctx: Option<assay_auth::AuthCtx>,
+    #[cfg(feature = "vault")] vault_ctx: Option<assay_vault::VaultCtx>,
+    #[cfg(not(feature = "vault"))] _vault_ctx: Option<()>,
+    pool: EmbeddedPool,
+) -> anyhow::Result<EmbeddedEngine> {
+    // Precondition: refuse to start when auth is on and no operator
+    // user / api-key / external issuer is configured. Same logic as
+    // the previous run_with_store, lifted unchanged.
+    if let Some(auth) = auth_ctx.as_ref() {
+        let user_count = auth
+            .users
+            .count_users(None)
+            .await
+            .map_err(|e| anyhow::anyhow!("count auth.users: {e}"))?;
+        if user_count == 0
+            && cfg.auth.admin_api_keys.is_empty()
+            && cfg.auth.external_issuers().is_empty()
+        {
+            anyhow::bail!(
+                "engine refuses to start: no operator users exist, \
+                 `auth.admin_api_keys` is empty, and no external issuers \
+                 are configured. Either run `assay-engine bootstrap-admin \
+                 --email <e> --password <p>` to seed the first user, add \
+                 at least one entry to `auth.admin_api_keys` in \
+                 engine.toml as a break-glass, or configure \
+                 `[[auth.external_issuers]]` with an upstream OIDC \
+                 provider (e.g. Hydra) that mints the JWTs your callers \
+                 forward."
+            );
+        }
+    }
+
+    let workflow_ctx: Arc<WorkflowCtx<S>> =
+        crate::server::build_workflow_ctx_with_bus(store, Arc::clone(&bus));
+
+    // Hourly sweep of the engine_events outbox. Detached — the handle
+    // lives for the process lifetime; nothing to await for clean
+    // shutdown (prune is idempotent, missed tick is fine).
+    tokio::spawn(assay_workflow::events_cleanup::run_events_cleanup(
+        Arc::clone(&bus),
+        std::time::Duration::from_secs(3600),
+        cfg.engine_events_ttl_secs,
+    ));
+
+    let whitelabel = Arc::new(WhitelabelConfig::from_env());
+    let asset_version = env!("CARGO_PKG_VERSION").to_string();
+    let dashboard_ctx = Arc::new(DashboardCtx::new(whitelabel, asset_version));
+    let admin_api_keys = Arc::new(cfg.auth.admin_api_keys.clone());
+    let started_at = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs_f64();
+    let engine_config = Arc::new(cfg);
+
+    let state = EngineState {
+        workflow: workflow_ctx,
+        dashboard: dashboard_ctx,
+        auth: auth_ctx,
+        #[cfg(feature = "vault")]
+        vault: vault_ctx,
+        admin_api_keys,
+        modules: Arc::new(modules.clone()),
+        instance_id,
+        engine_version: env!("CARGO_PKG_VERSION"),
+        started_at,
+        engine_config,
+    };
+
+    let router = crate::server::build_app(state);
+
+    Ok(EmbeddedEngine {
+        router,
+        pool,
+        instance_id,
+        modules,
+        engine_version: env!("CARGO_PKG_VERSION"),
+    })
+}
+
+/// Run engine + per-module schema migrations against the configured
+/// backend. No runtime state is built, no background tasks are
+/// spawned. Idempotent — calling on an up-to-date schema is a no-op.
+///
+/// Used by parent binaries that want a `migrate` subcommand without
+/// booting workflow scheduler / vault unseal / etc. Equivalent to
+/// `EngineBoot::run(cfg).await?;` with a more discoverable name.
+pub async fn migrate(cfg: &EngineConfig) -> anyhow::Result<()> {
+    let _boot = EngineBoot::run(cfg).await?;
+    Ok(())
+}

--- a/crates/assay-engine/src/lib.rs
+++ b/crates/assay-engine/src/lib.rs
@@ -39,11 +39,8 @@
 
 use std::sync::Arc;
 
-use assay_dashboard::{DashboardCtx, WhitelabelConfig};
-use assay_domain::events::EngineEventBus;
-use assay_workflow::WorkflowStore;
-
 pub mod config;
+pub mod embedded;
 pub mod engine_api;
 pub mod init;
 pub mod server;
@@ -60,53 +57,16 @@ pub use config::{
 };
 pub use state::{AdminApiKeys, EngineState};
 
-/// Top-level entrypoint: pick the backend from config, build state, serve.
+/// Top-level entrypoint for the standalone `assay-engine` binary.
+/// Picks the backend from config, composes engine via
+/// [`embedded::build`], and serves forever on `cfg.server.bind_addr`.
+///
+/// For embedded use (composing engine into a parent binary's
+/// router), call [`embedded::build`] directly.
 pub async fn run(cfg: EngineConfig) -> anyhow::Result<()> {
-    let boot = init::EngineBoot::run(&cfg).await?;
-    match boot {
-        #[cfg(feature = "backend-postgres")]
-        init::EngineBoot::Postgres(b) => {
-            let store = assay_workflow::PostgresStore::from_pool(b.pool.clone())
-                .await
-                .map_err(|e| anyhow::anyhow!("workflow store (pg): {e}"))?;
-            let auth_ctx = build_auth_ctx_pg(&cfg, &b.pool).await?;
-            #[cfg(feature = "vault")]
-            let vault_ctx = build_vault_ctx_pg(&b.modules, &b.pool).await?;
-            #[cfg(not(feature = "vault"))]
-            let vault_ctx: Option<()> = None;
-            run_with_store(
-                cfg,
-                store,
-                b.bus,
-                b.modules,
-                b.instance_id,
-                Some(auth_ctx),
-                vault_ctx,
-            )
-            .await
-        }
-        #[cfg(feature = "backend-sqlite")]
-        init::EngineBoot::Sqlite(b) => {
-            let store = assay_workflow::SqliteStore::from_attached_pool(b.pool.clone())
-                .await
-                .map_err(|e| anyhow::anyhow!("workflow store (sqlite): {e}"))?;
-            let auth_ctx = build_auth_ctx_sqlite(&cfg, &b.pool).await?;
-            #[cfg(feature = "vault")]
-            let vault_ctx = build_vault_ctx_sqlite(&b.modules, &b.pool).await?;
-            #[cfg(not(feature = "vault"))]
-            let vault_ctx: Option<()> = None;
-            run_with_store(
-                cfg,
-                store,
-                b.bus,
-                b.modules,
-                b.instance_id,
-                Some(auth_ctx),
-                vault_ctx,
-            )
-            .await
-        }
-    }
+    let bind_addr = cfg.server.bind_addr.clone();
+    let engine = embedded::build(cfg).await?;
+    server::bind_and_serve(&bind_addr, engine.router).await
 }
 
 /// Build the vault context iff the runtime `engine.modules.vault.enabled`
@@ -510,82 +470,8 @@ fn build_passkey_manager(
     }
 }
 
-async fn run_with_store<S: WorkflowStore + Clone + 'static>(
-    cfg: EngineConfig,
-    store: S,
-    bus: Arc<dyn EngineEventBus>,
-    modules: Vec<String>,
-    instance_id: uuid::Uuid,
-    auth_ctx: Option<assay_auth::AuthCtx>,
-    #[cfg(feature = "vault")] vault_ctx: Option<assay_vault::VaultCtx>,
-    #[cfg(not(feature = "vault"))] _vault_ctx: Option<()>,
-) -> anyhow::Result<()> {
-    // The engine refuses to start unless there's at least one operator
-    // user (created via `bootstrap-admin`) or at least one entry in
-    // `admin_api_keys` as a break-glass. Without either, every admin
-    // request would 401 and the operator would be locked out — fail
-    // fast with a helpful message instead.
-    if let Some(auth) = auth_ctx.as_ref() {
-        let user_count = auth
-            .users
-            .count_users(None)
-            .await
-            .map_err(|e| anyhow::anyhow!("count auth.users: {e}"))?;
-        if user_count == 0
-            && cfg.auth.admin_api_keys.is_empty()
-            && cfg.auth.external_issuers().is_empty()
-        {
-            anyhow::bail!(
-                "engine refuses to start: no operator users exist, \
-                 `auth.admin_api_keys` is empty, and no external issuers \
-                 are configured. Either run `assay-engine bootstrap-admin \
-                 --email <e> --password <p>` to seed the first user, add \
-                 at least one entry to `auth.admin_api_keys` in \
-                 engine.toml as a break-glass, or configure \
-                 `[[auth.external_issuers]]` with an upstream OIDC \
-                 provider (e.g. Hydra) that mints the JWTs your callers \
-                 forward."
-            );
-        }
-    }
-
-    let workflow_ctx = server::build_workflow_ctx_with_bus(store, Arc::clone(&bus));
-
-    // Hourly sweep of the engine_events outbox. Detached — the handle
-    // lives for the process lifetime; there's nothing to await for
-    // clean shutdown (prune is idempotent so a missed tick is fine).
-    tokio::spawn(assay_workflow::events_cleanup::run_events_cleanup(
-        Arc::clone(&bus),
-        std::time::Duration::from_secs(3600),
-        cfg.engine_events_ttl_secs,
-    ));
-
-    let whitelabel = Arc::new(WhitelabelConfig::from_env());
-    let asset_version = env!("CARGO_PKG_VERSION").to_string();
-    let dashboard_ctx = Arc::new(DashboardCtx::new(whitelabel, asset_version));
-    let admin_api_keys = Arc::new(cfg.auth.admin_api_keys.clone());
-    // Wall-clock seconds since epoch — uptime baseline for the
-    // /api/v1/engine/core/info response. Captured here (just before serve)
-    // so the value reflects the moment HTTP becomes ready, not the
-    // earlier boot-sequence start.
-    let started_at = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs_f64();
-    let bind_addr = cfg.server.bind_addr.clone();
-    let engine_config = Arc::new(cfg);
-    let state = EngineState {
-        workflow: workflow_ctx,
-        dashboard: dashboard_ctx,
-        auth: auth_ctx,
-        #[cfg(feature = "vault")]
-        vault: vault_ctx,
-        admin_api_keys,
-        modules: Arc::new(modules),
-        instance_id,
-        engine_version: env!("CARGO_PKG_VERSION"),
-        started_at,
-        engine_config,
-    };
-    server::serve(&bind_addr, state).await
-}
+// `run_with_store` (the previous private composition helper) is gone.
+// Its body lives in `embedded::compose` (this module's `embedded` sibling),
+// minus the final `server::serve` call. `pub async fn run` above
+// composes the engine via `embedded::build` and then binds + serves
+// the resulting `axum::Router` via `server::bind_and_serve`.

--- a/crates/assay-engine/src/server.rs
+++ b/crates/assay-engine/src/server.rs
@@ -219,11 +219,29 @@ async fn workflow_gate_middleware<S: WorkflowStore + Clone + 'static>(
 use axum::response::IntoResponse;
 
 /// Bind a TCP listener on `bind_addr` and serve the composed app.
+///
+/// Convenience wrapper that composes [`EngineState`] into an
+/// [`axum::Router`] via [`build_app`] and hands off to
+/// [`bind_and_serve`]. Used by the standalone `assay-engine` binary.
 pub async fn serve<S: WorkflowStore + Clone + 'static>(
     bind_addr: &str,
     state: EngineState<S>,
 ) -> anyhow::Result<()> {
     let app = build_app(state);
+    bind_and_serve(bind_addr, app).await
+}
+
+/// Bind a TCP listener on `bind_addr` and serve a pre-built
+/// [`axum::Router`].
+///
+/// Used by [`crate::run`] (after `embedded::build` returns the
+/// composed router) and by downstream embedders who want to add
+/// their own middleware / merge with their own router before
+/// serving.
+pub async fn bind_and_serve(
+    bind_addr: &str,
+    app: axum::Router,
+) -> anyhow::Result<()> {
     let listener = tokio::net::TcpListener::bind(bind_addr)
         .await
         .map_err(|e| anyhow::anyhow!("bind {bind_addr}: {e}"))?;

--- a/crates/assay/Cargo.toml
+++ b/crates/assay/Cargo.toml
@@ -112,6 +112,7 @@ http-body-util = { version = "0.1", optional = true }
 hyper = { version = "1", features = ["http1", "server"], optional = true }
 hyper-util = { version = "0.1", features = ["tokio"], optional = true }
 tower-http = { version = "0.6.8", features = ["cors", "trace"] }
+tower = { version = "0.5", features = ["util"] }
 
 [dev-dependencies]
 tempfile = "3.27.0"

--- a/crates/assay/src/lua/builtins/http.rs
+++ b/crates/assay/src/lua/builtins/http.rs
@@ -2,7 +2,7 @@ use super::json::lua_table_to_json;
 #[cfg(feature = "server")]
 use super::json::lua_value_to_json;
 #[cfg(feature = "server")]
-use http_body_util::{Either, Full};
+use http_body_util::Full;
 #[cfg(feature = "server")]
 use hyper::body::{Bytes, Frame, Incoming};
 #[cfg(feature = "server")]
@@ -26,6 +26,24 @@ use std::task::{Context, Poll};
 use tokio::net::TcpListener;
 #[cfg(feature = "server")]
 use tracing::error;
+
+/// Public newtype wrapping an [`axum::Router`] so it can round-trip through
+/// the Lua VM as a [`mlua::AnyUserData`].
+///
+/// Downstream binaries (e.g. knowhere) build a Rust-side `axum::Router`
+/// (typically holding `assay-engine` HTTP routes), wrap it in this type,
+/// stash it in a Lua global (or pass it positionally), and the Lua-defined
+/// `http.serve_with_extra(port, routes, extra)` builtin pulls the router
+/// back out and folds its routes into the dispatcher.
+///
+/// The type is intentionally a tuple-struct with a `pub` inner so callers
+/// can construct one trivially: `LuaAxumRouter(my_router)`.
+#[cfg(feature = "server")]
+#[derive(Clone)]
+pub struct LuaAxumRouter(pub axum::Router);
+
+#[cfg(feature = "server")]
+impl mlua::UserData for LuaAxumRouter {}
 
 struct HttpClient(reqwest::Client);
 impl UserData for HttpClient {}
@@ -212,7 +230,7 @@ pub fn register_http(lua: &Lua, client: reqwest::Client) -> mlua::Result<()> {
                     let routes = routes.clone();
                     let lua = lua.clone();
                     let peer_addr = peer_addr.clone();
-                    async move { handle_request(&lua, &routes, peer_addr, req).await }
+                    async move { handle_request(&lua, &routes, None, peer_addr, req).await }
                 });
 
                 if let Err(e) = http1::Builder::new()
@@ -228,6 +246,119 @@ pub fn register_http(lua: &Lua, client: reqwest::Client) -> mlua::Result<()> {
     })?;
     #[cfg(feature = "server")]
     http_table.set("serve", serve_fn)?;
+
+    // ── http.serve_with_extra(port, routes_table, extra_router) ───────────────
+    //
+    // Same shape as `http.serve` plus a third argument: a [`LuaAxumRouter`]
+    // userdata wrapping a Rust-built `axum::Router`. Lua-defined routes are
+    // matched first; on miss, the request is forwarded to the extra
+    // `axum::Router` (which can produce 404 itself if it doesn't match either).
+    //
+    // Precedence: Lua wins. If the same path is defined by both, the Lua
+    // handler is invoked. This is the inverse of `axum::Router::merge` (where
+    // a duplicate panics) and was chosen because the Lua side is the
+    // existing surface — the extra router is purely additive routes the
+    // host binary contributes (typically engine APIs under a non-overlapping
+    // path prefix like `/api/v1/engine/*`).
+    //
+    // The extra router is cloned per-connection (`axum::Router: Clone` is a
+    // shallow `Arc` clone — cheap).
+    #[cfg(feature = "server")]
+    let serve_with_extra_fn = lua.create_async_function(|lua, args: mlua::MultiValue| async move {
+        let mut args_iter = args.into_iter();
+
+        let port: u16 = match args_iter.next() {
+            Some(Value::Integer(n)) => n as u16,
+            _ => {
+                return Err::<(), _>(mlua::Error::runtime(
+                    "http.serve_with_extra: first argument must be a port number",
+                ));
+            }
+        };
+
+        let routes_table = match args_iter.next() {
+            Some(Value::Table(t)) => t,
+            _ => {
+                return Err::<(), _>(mlua::Error::runtime(
+                    "http.serve_with_extra: second argument must be a routes table",
+                ));
+            }
+        };
+
+        let extra_router: axum::Router = match args_iter.next() {
+            Some(Value::UserData(ud)) => {
+                let r = ud.borrow::<LuaAxumRouter>().map_err(|_| {
+                    mlua::Error::runtime(
+                        "http.serve_with_extra: third argument must be a LuaAxumRouter userdata",
+                    )
+                })?;
+                r.0.clone()
+            }
+            _ => {
+                return Err::<(), _>(mlua::Error::runtime(
+                    "http.serve_with_extra: third argument must be a LuaAxumRouter userdata",
+                ));
+            }
+        };
+
+        let routes = Rc::new(parse_routes(&routes_table)?);
+
+        let listener = TcpListener::bind(format!("0.0.0.0:{port}"))
+            .await
+            .map_err(|e| {
+                mlua::Error::runtime(format!("http.serve_with_extra: bind failed: {e}"))
+            })?;
+
+        let actual_port = listener
+            .local_addr()
+            .map_err(|e| {
+                mlua::Error::runtime(format!(
+                    "http.serve_with_extra: failed to get local addr: {e}"
+                ))
+            })?
+            .port();
+        lua.globals().set("_SERVER_PORT", actual_port)?;
+
+        loop {
+            let (stream, addr) = listener.accept().await.map_err(|e| {
+                mlua::Error::runtime(format!("http.serve_with_extra: accept failed: {e}"))
+            })?;
+            let peer_addr = addr.to_string();
+
+            let routes = routes.clone();
+            let lua_clone = lua.clone();
+            let extra_router = extra_router.clone();
+
+            tokio::task::spawn_local(async move {
+                let io = hyper_util::rt::TokioIo::new(stream);
+                let routes = routes.clone();
+                let lua = lua_clone.clone();
+                let peer_addr = peer_addr.clone();
+                let extra_router = extra_router.clone();
+
+                let service = service_fn(move |req: Request<Incoming>| {
+                    let routes = routes.clone();
+                    let lua = lua.clone();
+                    let peer_addr = peer_addr.clone();
+                    let extra_router = extra_router.clone();
+                    async move {
+                        handle_request(&lua, &routes, Some(extra_router), peer_addr, req).await
+                    }
+                });
+
+                if let Err(e) = http1::Builder::new()
+                    .serve_connection(io, service)
+                    .with_upgrades()
+                    .await
+                    && !e.to_string().contains("connection closed")
+                {
+                    error!("http.serve_with_extra: connection error: {e}");
+                }
+            });
+        }
+    })?;
+    #[cfg(feature = "server")]
+    http_table.set("serve_with_extra", serve_with_extra_fn)?;
 
     lua.globals().set("http", http_table)?;
     Ok(())
@@ -529,8 +660,17 @@ fn parse_routes(routes_table: &Table) -> mlua::Result<HashMap<(String, String), 
     Ok(routes)
 }
 
+/// Unified response body type.
+///
+/// Originally `Either<Full<Bytes>, SseBody>`; widened to [`axum::body::Body`]
+/// so we can transparently forward responses produced by an external
+/// `axum::Router` (see `http.serve_with_extra`). `axum::body::Body` is a
+/// thin wrapper over `UnsyncBoxBody<Bytes, axum::Error>` and accepts any
+/// `http_body::Body<Data = Bytes>` via [`axum::body::Body::new`], so all
+/// existing body shapes (static `Full<Bytes>`, the SSE channel body) still
+/// fit; only the construction surface changes.
 #[cfg(feature = "server")]
-type ServerBody = Either<Full<Bytes>, SseBody>;
+type ServerBody = axum::body::Body;
 
 #[cfg(feature = "server")]
 fn lookup_route<'a>(
@@ -604,10 +744,38 @@ fn compute_ws_accept(key: &str) -> String {
     data_encoding::BASE64.encode(&digest)
 }
 
+/// Forward a `hyper` request into an `axum::Router` (used as a [`tower::Service`])
+/// and return its response.
+///
+/// `axum::Router` implements `Service<Request<B>>` for any `B` that is an
+/// `HttpBody<Data = Bytes>`, which `hyper::body::Incoming` is. The router's
+/// response body is `axum::body::Body`, which is exactly our unified
+/// [`ServerBody`].
+///
+/// The router's `Service::call` signature is `Infallible`, so the only way
+/// this can fail is if there's a `hyper::Error` upstream — there isn't —
+/// hence the `unreachable!()` on the error branch.
+#[cfg(feature = "server")]
+async fn forward_to_axum_router(
+    mut router: axum::Router,
+    req: Request<Incoming>,
+) -> Result<Response<ServerBody>, hyper::Error> {
+    use tower::Service;
+    // `axum::Router::poll_ready` is `Poll::Ready(Ok(()))`, so we can call
+    // straight through without driving readiness. We rely on the
+    // `Service<Request<B>>` impl (not the `Service<IncomingStream>` one)
+    // which is selected by the `Request<Incoming>` argument type.
+    match <axum::Router as Service<Request<Incoming>>>::call(&mut router, req).await {
+        Ok(resp) => Ok(resp),
+        Err(_) => unreachable!("axum::Router::call is Infallible"),
+    }
+}
+
 #[cfg(feature = "server")]
 async fn handle_request(
     lua: &Lua,
     routes: &HashMap<(String, String), mlua::Function>,
+    extra_router: Option<axum::Router>,
     peer_addr: String,
     req: Request<Incoming>,
 ) -> Result<Response<ServerBody>, hyper::Error> {
@@ -625,10 +793,17 @@ async fn handle_request(
     let handler = match lookup_route(routes, &method, &path) {
         Some(h) => h.clone(),
         None => {
+            // Lua dispatch missed. If an extra `axum::Router` was supplied via
+            // `http.serve_with_extra`, hand the request off to it so its routes
+            // (typically Rust-built, e.g. `assay-engine`'s `/api/v1/engine/*`)
+            // can produce the response. Otherwise, fall back to a 404.
+            if let Some(router) = extra_router {
+                return forward_to_axum_router(router, req).await;
+            }
             return Ok(Response::builder()
                 .status(StatusCode::NOT_FOUND)
                 .header("content-type", "text/plain")
-                .body(Either::Left(Full::new(Bytes::from("not found"))))
+                .body(axum::body::Body::new(Full::new(Bytes::from("not found"))))
                 .unwrap());
         }
     };
@@ -644,7 +819,7 @@ async fn handle_request(
                 return Ok(Response::builder()
                     .status(StatusCode::INTERNAL_SERVER_ERROR)
                     .header("content-type", "text/plain")
-                    .body(Either::Left(Full::new(Bytes::from(format!(
+                    .body(axum::body::Body::new(Full::new(Bytes::from(format!(
                         "handler error: {e}"
                     )))))
                     .unwrap());
@@ -671,7 +846,7 @@ async fn handle_request(
         Err(e) => Ok(Response::builder()
             .status(StatusCode::INTERNAL_SERVER_ERROR)
             .header("content-type", "text/plain")
-            .body(Either::Left(Full::new(Bytes::from(format!(
+            .body(axum::body::Body::new(Full::new(Bytes::from(format!(
                 "handler error: {e}"
             )))))
             .unwrap()),
@@ -693,7 +868,7 @@ fn build_ws_upgrade_response(
             return Ok(Response::builder()
                 .status(StatusCode::BAD_REQUEST)
                 .header("content-type", "text/plain")
-                .body(Either::Left(Full::new(Bytes::from(format!(
+                .body(axum::body::Body::new(Full::new(Bytes::from(format!(
                     "websocket upgrade rejected: {msg}"
                 )))))
                 .unwrap());
@@ -726,7 +901,7 @@ fn build_ws_upgrade_response(
     }
 
     let response = builder
-        .body(Either::Left(Full::new(Bytes::new())))
+        .body(axum::body::Body::new(Full::new(Bytes::new())))
         .unwrap();
 
     let lua_clone = lua.clone();
@@ -839,7 +1014,7 @@ fn lua_response_to_http(
             }
         }
 
-        let mut response = builder.body(Either::Right(SseBody { rx })).unwrap();
+        let mut response = builder.body(axum::body::Body::new(SseBody { rx })).unwrap();
         let response_headers = response.headers_mut();
         if !response_headers.contains_key(hyper::header::CONTENT_TYPE) {
             response_headers.insert(
@@ -957,6 +1132,58 @@ fn lua_response_to_http(
         Bytes::new()
     };
 
-    Ok(builder.body(Either::Left(Full::new(body_bytes))).unwrap())
+    Ok(builder.body(axum::body::Body::new(Full::new(body_bytes))).unwrap())
 }
 
+// ── tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(all(test, feature = "server"))]
+mod tests {
+    use super::*;
+    use axum::Router;
+    use axum::routing::get;
+    use mlua::Lua;
+
+    /// `LuaAxumRouter` wraps an `axum::Router` so it can be passed through Lua
+    /// as `mlua` userdata. This test mirrors what knowhere does at startup:
+    /// build a Router in Rust, wrap it in `LuaAxumRouter`, hand it to the Lua
+    /// VM via `create_userdata`, stash it as a global, then read it back out
+    /// and confirm the round-trip preserves the underlying type.
+    #[test]
+    fn lua_axum_router_round_trips_through_mlua_globals() {
+        let lua = Lua::new();
+        let router = Router::new().route("/ping", get(|| async { "pong" }));
+        let wrapped = LuaAxumRouter(router);
+
+        let ud = lua
+            .create_userdata(wrapped)
+            .expect("create_userdata for LuaAxumRouter");
+        lua.globals()
+            .set("EXTRA_ROUTER", ud)
+            .expect("stash userdata in globals");
+
+        let value: mlua::Value = lua
+            .globals()
+            .get("EXTRA_ROUTER")
+            .expect("read userdata back from globals");
+        let ud = match value {
+            mlua::Value::UserData(u) => u,
+            other => panic!("expected UserData, got {other:?}"),
+        };
+        let _borrowed = ud
+            .borrow::<LuaAxumRouter>()
+            .expect("downcast to LuaAxumRouter");
+    }
+
+    /// `Clone` on `LuaAxumRouter` should be cheap and preserve route
+    /// dispatch — `axum::Router::clone` is a shallow `Arc` clone, so cloning
+    /// the wrapper just clones that handle. We verify both clones still
+    /// produce the same route at the type level (compile check).
+    #[test]
+    fn lua_axum_router_is_clone_and_preserves_routes() {
+        let router = Router::<()>::new().route("/health", get(|| async { "ok" }));
+        let wrapped = LuaAxumRouter(router);
+        let _cloned = wrapped.clone();
+        // If this compiles and `clone()` is callable, the public bound holds.
+    }
+}

--- a/crates/assay/src/lua/builtins/http.rs
+++ b/crates/assay/src/lua/builtins/http.rs
@@ -30,9 +30,9 @@ use tracing::error;
 /// Public newtype wrapping an [`axum::Router`] so it can round-trip through
 /// the Lua VM as a [`mlua::AnyUserData`].
 ///
-/// Downstream binaries (e.g. knowhere) build a Rust-side `axum::Router`
-/// (typically holding `assay-engine` HTTP routes), wrap it in this type,
-/// stash it in a Lua global (or pass it positionally), and the Lua-defined
+/// Downstream binaries build a Rust-side `axum::Router` (typically
+/// holding `assay-engine` HTTP routes), wrap it in this type, stash it in
+/// a Lua global (or pass it positionally), and the Lua-defined
 /// `http.serve_with_extra(port, routes, extra)` builtin pulls the router
 /// back out and folds its routes into the dispatcher.
 ///
@@ -1145,10 +1145,10 @@ mod tests {
     use mlua::Lua;
 
     /// `LuaAxumRouter` wraps an `axum::Router` so it can be passed through Lua
-    /// as `mlua` userdata. This test mirrors what knowhere does at startup:
-    /// build a Router in Rust, wrap it in `LuaAxumRouter`, hand it to the Lua
-    /// VM via `create_userdata`, stash it as a global, then read it back out
-    /// and confirm the round-trip preserves the underlying type.
+    /// as `mlua` userdata. This test mirrors a typical downstream embedding
+    /// pattern: build a Router in Rust, wrap it in `LuaAxumRouter`, hand it
+    /// to the Lua VM via `create_userdata`, stash it as a global, then read
+    /// it back out and confirm the round-trip preserves the underlying type.
     #[test]
     fn lua_axum_router_round_trips_through_mlua_globals() {
         let lua = Lua::new();

--- a/crates/assay/src/lua/builtins/mod.rs
+++ b/crates/assay/src/lua/builtins/mod.rs
@@ -6,7 +6,7 @@ mod crypto;
 #[cfg(feature = "db")]
 mod db;
 mod disk;
-mod http;
+pub mod http;
 mod json;
 mod linux;
 mod markdown;
@@ -18,6 +18,9 @@ mod shell;
 mod systemd;
 mod template;
 mod ws;
+
+#[cfg(feature = "server")]
+pub use http::LuaAxumRouter;
 
 pub fn register_all(lua: &mlua::Lua, client: reqwest::Client) -> mlua::Result<()> {
     http::register_http(lua, client)?;

--- a/crates/assay/src/lua/mod.rs
+++ b/crates/assay/src/lua/mod.rs
@@ -2,6 +2,10 @@ pub mod async_bridge;
 pub mod builtins;
 pub mod file_source;
 
+#[cfg(feature = "server")]
+#[allow(unused_imports)]
+pub use builtins::LuaAxumRouter;
+
 use anyhow::Result;
 use include_dir::{Dir, include_dir};
 use mlua::{Lua, LuaOptions, StdLib};


### PR DESCRIPTION
## Summary

Adds two complementary public surfaces so a parent binary can compose **both** the Lua VM and `assay-engine` into a single process listening on a single port:

1. **`assay::lua::LuaAxumRouter`** + **`http.serve_with_extra(port, routes, extra)`** Lua builtin (`crates/assay/`)
2. **`assay_engine::embedded::{EmbeddedEngine, EmbeddedPool, build, migrate}`** (`crates/assay-engine/`)

These were originally split across two PRs (this one and #106 for the embedded module). They ship as a unit for the embedding use case so consolidating into one review unit. #106 is closed; its commits live on this branch.

## Public API

### `crates/assay/` — Lua HTTP composition

```rust
// New public type, accessible as assay::lua::LuaAxumRouter
pub struct LuaAxumRouter(pub axum::Router);
impl mlua::UserData for LuaAxumRouter {}
```

```lua
-- New Lua builtin, sibling to http.serve. Same shape plus a third arg.
http.serve_with_extra(PORT, {
  GET  = { ... },
  POST = { ... },
}, EXTRA_ROUTER) -- EXTRA_ROUTER = LuaAxumRouter userdata stashed in globals
```

### `crates/assay-engine/` — Embedded engine API

```rust
pub mod embedded {
    pub struct EmbeddedEngine {
        pub router: axum::Router,
        pub pool: EmbeddedPool,
        pub instance_id: uuid::Uuid,
        pub modules: Vec<String>,
        pub engine_version: &'static str,
    }
    pub enum EmbeddedPool { Postgres(sqlx::PgPool), Sqlite(sqlx::SqlitePool) }
    pub async fn build(cfg: EngineConfig) -> Result<EmbeddedEngine>;
    pub async fn migrate(cfg: &EngineConfig) -> Result<()>;
}
```

`embedded::build` opens the pool, runs migrations, bootstraps module contexts, **enforces the auth precondition** that previously lived inside `run_with_store` (no zero-users-no-keys lockout), composes the `axum::Router` via `build_app`, and spawns engine_events cleanup. Standalone `pub async fn run(cfg)` becomes a thin wrapper around `embedded::build` that hands the resulting router to a new `server::bind_and_serve` helper.

The four ctx-builders (`build_auth_ctx_{pg,sqlite}`, `build_vault_ctx_{pg,sqlite}`) stay `pub(crate)`. They are implementation details, not API. `run_with_store` is removed; its body lives in private `embedded::compose`.

Both `EmbeddedEngine` and `EmbeddedPool` are `#[non_exhaustive]` so future fields/variants extend without breaking pattern-matching.

## Why this shape (lua + engine together, vendor-neutral)

A parent binary that wants to compose `assay-engine` HTTP routes alongside Lua-defined routes on a single port previously had two options:
- Reimplement every Lua route in axum (lots of code, gives up the assay-lua scripting model).
- Run two listeners on different ports + reverse-proxy (extra hop, ops complexity).

This PR adds the third option: keep the Lua routes, build a Rust-side `axum::Router` for the engine, hand it back through Lua via `LuaAxumRouter` + `http.serve_with_extra`. Engine's first-class `embedded::build` API means the parent binary doesn't replicate engine's orchestration (pool open, migrations, ctx construction, preconditions) — they're all behind one function call.

## Design notes

### Lua HTTP composition

- The original sketch (`extra` merged via `axum::Router::merge` at serve time) assumed `http.serve` was axum-based. It isn't — it's hyper + a `HashMap<(method, path), Function>` lookup. `axum::Router::merge` is therefore not applicable.
- Instead, the existing hyper `service_fn` dispatcher tries Lua routes first; on miss, the request is handed to the extra `axum::Router` via `<Router as tower::Service>::call(req)`. The router can produce its own 404, so the host binary stays in control of the not-found surface for forwarded paths.
- **Precedence:** Lua wins on path collision. This is intentional and the inverse of `axum::Router::merge` (which panics on duplicate routes). The extra router is purely additive routes the host binary contributes (typically a non-overlapping prefix like `/api/v1/engine/*`).
- Internal refactor: `ServerBody` was widened from `Either<Full<Bytes>, SseBody>` to `axum::body::Body` so both the existing Lua-side responses (static `Full<Bytes>`, the SSE channel body) and forwarded axum responses share a single unified body type. ~7 mechanical body-construction sites updated.
- Adds `tower = "0.5"` (features=["util"]) as a direct dep. Already pulled in transitively by axum 0.8, so this is a registry-resolution change only.

### Embedded engine API

- Supersedes the closed [#103](https://github.com/developerinlondon/assay/pull/103), which exposed four ctx-builders publicly. That approach grew the public API linearly with module count and let downstream callers bypass the auth precondition. This PR makes embedded mode a real concept in the public API instead.
- Preconditions live inside `build` and cannot be skipped. The `EmbeddedEngine` struct is `#[non_exhaustive]` so future fields (graceful-shutdown handle, metrics handle, …) extend without breaking pattern-matching. `EmbeddedPool` is also `#[non_exhaustive]` — future backends can be added without breaking exhaustive matches.

## Net public-API change vs main

- **Added** (`crates/assay/`): `LuaAxumRouter` type; `http.serve_with_extra` Lua builtin.
- **Added** (`crates/assay-engine/`): `embedded` module (1 struct, 1 enum, 2 functions); `server::bind_and_serve`.
- **Unchanged**: existing public surfaces (`http.serve`, `run`, `EngineConfig`, `EngineState`, `server::build_app`, `server::serve`, `server::build_workflow_ctx[_with_bus]`, `init::EngineBoot`).
- **Removed**: nothing public. Internally, `run_with_store` is gone (replaced by private `embedded::compose`).

## Behavioural parity

`http.serve` and `assay_engine::run` are untouched at the API layer — same arguments, same routing rules, same observable behaviour. The internal refactor (run delegating to embedded::build + bind_and_serve) is transparent to existing callers.

## Test plan

- [x] `cargo test -p assay-engine --lib` — 19 tests pass (existing engine internals)
- [x] `cargo test -p assay-lua --lib` — passes; includes 2 new unit tests for `LuaAxumRouter` round-trip + clone
- [x] Standalone `assay_engine::run` behaviour preserved — internal refactor, identical observable result
- [x] Validated end-to-end on a downstream binary embedding both the Lua VM and `assay-engine` on a single port; engine endpoints (`/api/v1/engine/*`, `/auth/*`, `/api/v1/vault/*`, `/workflow/`, `/auth/console`, `/engine/console`, `/vault/console`) all reachable, Lua dashboard at `/` still works
- [ ] Add explicit `embedded::build` integration test (follow-up; currently covered transitively by the `run()` test path which exercises the same code)