### PR TITLE
feat(stdlib)!: rename assay.hashicorp_vault → assay.hashicorp.vault (0.15.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,19 @@ All notable changes to Assay are documented here.
 
 ## [assay-domain 0.2.1] - 2026-04-28
 
-- **Fix `EngineEventBus::prune` cross-namespace data loss.** The previous signature
-  `prune(before_ts)` issued a `DELETE WHERE ts < ?` with no namespace filter, which deleted events
-  from every namespace in the table. Tests caught this as flake (`append_then_read_round_trip`
-  could lose its row when `prune_removes_older_than_cutoff` ran concurrently in another
-  multi-thread runtime — `serial_test::serial` only synchronises tagged tests, so a non-tagged
-  test in the same suite races freely). Production callers can also now scope pruning to a single
-  tenant namespace instead of the global sweep. New signature:
-  `prune(namespace: Option<&str>, before_ts: f64)`. Pass `None` for the existing global cleanup
-  semantics; pass `Some(ns)` to scope the delete. **Breaking** for any external implementor of
-  `EngineEventBus` (pre-1.0 patch bump).
+- **Add `EngineEventBus::prune_with(PruneOpts)` for namespace-scoped pruning.** The existing
+  `prune(before_ts)` issues `DELETE WHERE ts < ?` with no namespace filter, which deletes events
+  from every namespace in the shared table. That's correct for the global cluster-wide cleanup
+  loop in `assay-workflow::events_cleanup`, but it made tests (and tenant-scoped callers) racy:
+  one bus instance's `prune` would silently delete another instance's rows. The
+  non-`#[serial]` test `append_then_read_round_trip` started losing its row when
+  `prune_removes_older_than_cutoff` ran concurrently — `serial_test::serial` only synchronises
+  tagged tests, so a non-tagged test in the same suite races freely. New `prune_with` takes a
+  `PruneOpts` struct (`#[non_exhaustive]`, so future filter fields like `subsystem`, `kind`, or
+  `dry_run` add non-breakingly): `namespace = Some(ns)` scopes the delete; `namespace = None`
+  matches the global semantic. The trait method has a default impl that forwards to `prune` for
+  the `None` case and errors otherwise — non-breaking for external implementors of
+  `EngineEventBus`.
 
 ## [assay 0.15.4] - 2026-04-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to Assay are documented here.
 
+## [assay-domain 0.2.1] - 2026-04-28
+
+- **Fix `EngineEventBus::prune` cross-namespace data loss.** The previous signature
+  `prune(before_ts)` issued a `DELETE WHERE ts < ?` with no namespace filter, which deleted events
+  from every namespace in the table. Tests caught this as flake (`append_then_read_round_trip`
+  could lose its row when `prune_removes_older_than_cutoff` ran concurrently in another
+  multi-thread runtime — `serial_test::serial` only synchronises tagged tests, so a non-tagged
+  test in the same suite races freely). Production callers can also now scope pruning to a single
+  tenant namespace instead of the global sweep. New signature:
+  `prune(namespace: Option<&str>, before_ts: f64)`. Pass `None` for the existing global cleanup
+  semantics; pass `Some(ns)` to scope the delete. **Breaking** for any external implementor of
+  `EngineEventBus` (pre-1.0 patch bump).
+
 ## [assay 0.15.4] - 2026-04-28
 
 - **Rename `assay.hashicorp_vault` → `assay.hashicorp.vault`** (closes #92). Establishes a proper

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to Assay are documented here.
 
+## [assay 0.15.4] - 2026-04-28
+
+- **Rename `assay.hashicorp_vault` → `assay.hashicorp.vault`** (closes #92). Establishes a proper
+  `hashicorp` namespace mirroring `assay.ory.*`, leaving room for future submodules (consul,
+  nomad, boundary, terraform, packer, waypoint). New `assay.hashicorp` umbrella module re-exports
+  `vault`. The `assay.openbao` alias now loads through the renamed path. **Breaking** (no
+  back-compat shim): scripts requiring `assay.hashicorp_vault` must update to
+  `assay.hashicorp.vault`.
+- **Fix `M.ensure_credentials` and `M.assert_secret` mount handling.** Both helpers previously
+  hardcoded the KV mount as `"secrets"`, making them unusable against any other mount. Signatures
+  now take an explicit `mount` arg: `ensure_credentials(client, mount, path, check_key, generator)`
+  and `assert_secret(client, mount, path, expected_keys)`. **Breaking** signature change for any
+  existing callers (in practice none, since the hardcoded-mount limitation made the helpers
+  unusable for non-`secrets` mounts).
+
 ## [assay 0.15.2] - 2026-04-27
 
 - **`crypto.jwt_verify(token, key, opts?)`** — verify-side mirror of `jwt_sign`. PEM

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "assay-lua"
-version = "0.15.2"
+version = "0.15.4"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,7 +288,7 @@ dependencies = [
 
 [[package]]
 name = "assay-domain"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/crates/assay-domain/Cargo.toml
+++ b/crates/assay-domain/Cargo.toml
@@ -5,7 +5,7 @@
 # the workflow-engine domain model (types + the WorkflowStore trait)
 # shared across assay-workflow, assay-auth, assay-engine, assay-dashboard.
 name = "assay-domain"
-version = "0.2.0"
+version = "0.2.1"
 categories = ["asynchronous", "database"]
 edition = "2024"
 keywords = ["workflow", "assay", "domain"]

--- a/crates/assay-domain/src/events/pg.rs
+++ b/crates/assay-domain/src/events/pg.rs
@@ -241,13 +241,24 @@ impl EngineEventBus for PgEngineEventBus {
         self.local.subscribe()
     }
 
-    async fn prune(&self, before_ts: f64) -> Result<u64> {
-        let n = sqlx::query("DELETE FROM engine.events WHERE ts < $1")
+    async fn prune(&self, namespace: Option<&str>, before_ts: f64) -> Result<u64> {
+        let n = match namespace {
+            Some(ns) => sqlx::query(
+                "DELETE FROM engine.events WHERE namespace = $1 AND ts < $2",
+            )
+            .bind(ns)
             .bind(before_ts)
             .execute(&self.pool)
             .await
-            .context("engine_events prune")?
-            .rows_affected();
+            .context("engine_events prune (scoped)")?
+            .rows_affected(),
+            None => sqlx::query("DELETE FROM engine.events WHERE ts < $1")
+                .bind(before_ts)
+                .execute(&self.pool)
+                .await
+                .context("engine_events prune (global)")?
+                .rows_affected(),
+        };
         Ok(n)
     }
 

--- a/crates/assay-domain/src/events/pg.rs
+++ b/crates/assay-domain/src/events/pg.rs
@@ -8,7 +8,9 @@ use async_trait::async_trait;
 use sqlx::postgres::{PgConnectOptions, PgListener, PgPool, PgPoolOptions};
 use tokio::sync::broadcast;
 
-use super::trait_::{CursorGoneError, EngineEventBus, Event, EventFilter, NewEvent, Subsystem};
+use super::trait_::{
+    CursorGoneError, EngineEventBus, Event, EventFilter, NewEvent, PruneOpts, Subsystem,
+};
 
 /// Default capacity of the node-local broadcast channel. A slow SSE
 /// client that lags past this will be force-closed and reconnects
@@ -241,22 +243,32 @@ impl EngineEventBus for PgEngineEventBus {
         self.local.subscribe()
     }
 
-    async fn prune(&self, namespace: Option<&str>, before_ts: f64) -> Result<u64> {
-        let n = match namespace {
+    async fn prune(&self, before_ts: f64) -> Result<u64> {
+        let n = sqlx::query("DELETE FROM engine.events WHERE ts < $1")
+            .bind(before_ts)
+            .execute(&self.pool)
+            .await
+            .context("engine_events prune (global)")?
+            .rows_affected();
+        Ok(n)
+    }
+
+    async fn prune_with(&self, opts: PruneOpts) -> Result<u64> {
+        let n = match &opts.namespace {
             Some(ns) => sqlx::query(
                 "DELETE FROM engine.events WHERE namespace = $1 AND ts < $2",
             )
             .bind(ns)
-            .bind(before_ts)
+            .bind(opts.before_ts)
             .execute(&self.pool)
             .await
-            .context("engine_events prune (scoped)")?
+            .context("engine_events prune_with (scoped)")?
             .rows_affected(),
             None => sqlx::query("DELETE FROM engine.events WHERE ts < $1")
-                .bind(before_ts)
+                .bind(opts.before_ts)
                 .execute(&self.pool)
                 .await
-                .context("engine_events prune (global)")?
+                .context("engine_events prune_with (global)")?
                 .rows_affected(),
         };
         Ok(n)

--- a/crates/assay-domain/src/events/pg_test.rs
+++ b/crates/assay-domain/src/events/pg_test.rs
@@ -7,7 +7,7 @@ use sqlx::PgPool;
 use tokio::sync::OnceCell;
 
 use super::*;
-use crate::events::{EngineEventBus, EventFilter, NewEvent, Subsystem};
+use crate::events::{EngineEventBus, EventFilter, NewEvent, PruneOpts, Subsystem};
 
 static NS_COUNTER: AtomicU64 = AtomicU64::new(0);
 static SCHEMA_READY: OnceCell<()> = OnceCell::const_new();
@@ -237,8 +237,11 @@ async fn prune_removes_older_than_cutoff() {
     })
     .await
     .unwrap();
-    let n = bus.prune(Some(&ns), f64::MAX).await.unwrap();
-    assert_eq!(n, 1, "prune should have removed exactly our row");
+    let n = bus
+        .prune_with(PruneOpts::new(f64::MAX).namespace(&ns))
+        .await
+        .unwrap();
+    assert_eq!(n, 1, "prune_with should have removed exactly our row");
     let rest = bus
         .read_since(&ns, None, &EventFilter::default(), 10)
         .await

--- a/crates/assay-domain/src/events/pg_test.rs
+++ b/crates/assay-domain/src/events/pg_test.rs
@@ -221,7 +221,6 @@ async fn subscribe_receives_cross_node_notify() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[serial_test::serial]
 async fn prune_removes_older_than_cutoff() {
     let Some(url) = test_db_url() else {
         eprintln!("skipped: TEST_DATABASE_URL not set");
@@ -238,10 +237,8 @@ async fn prune_removes_older_than_cutoff() {
     })
     .await
     .unwrap();
-    // prune(f64::MAX) is global; serial_test keeps this from racing
-    // namespace-isolated tests that might otherwise lose rows.
-    let n = bus.prune(f64::MAX).await.unwrap();
-    assert!(n >= 1, "prune should have removed at least our row");
+    let n = bus.prune(Some(&ns), f64::MAX).await.unwrap();
+    assert_eq!(n, 1, "prune should have removed exactly our row");
     let rest = bus
         .read_since(&ns, None, &EventFilter::default(), 10)
         .await

--- a/crates/assay-domain/src/events/sqlite.rs
+++ b/crates/assay-domain/src/events/sqlite.rs
@@ -117,13 +117,24 @@ impl EngineEventBus for SqliteEngineEventBus {
         self.local.subscribe()
     }
 
-    async fn prune(&self, before_ts: f64) -> Result<u64> {
-        let n = sqlx::query("DELETE FROM engine.events WHERE ts < ?1")
+    async fn prune(&self, namespace: Option<&str>, before_ts: f64) -> Result<u64> {
+        let n = match namespace {
+            Some(ns) => sqlx::query(
+                "DELETE FROM engine.events WHERE namespace = ?1 AND ts < ?2",
+            )
+            .bind(ns)
             .bind(before_ts)
             .execute(&self.pool)
             .await
-            .context("sqlite prune")?
-            .rows_affected();
+            .context("sqlite prune (scoped)")?
+            .rows_affected(),
+            None => sqlx::query("DELETE FROM engine.events WHERE ts < ?1")
+                .bind(before_ts)
+                .execute(&self.pool)
+                .await
+                .context("sqlite prune (global)")?
+                .rows_affected(),
+        };
         Ok(n)
     }
 

--- a/crates/assay-domain/src/events/sqlite.rs
+++ b/crates/assay-domain/src/events/sqlite.rs
@@ -5,7 +5,9 @@ use async_trait::async_trait;
 use sqlx::SqlitePool;
 use tokio::sync::broadcast;
 
-use super::trait_::{CursorGoneError, EngineEventBus, Event, EventFilter, NewEvent, Subsystem};
+use super::trait_::{
+    CursorGoneError, EngineEventBus, Event, EventFilter, NewEvent, PruneOpts, Subsystem,
+};
 
 const LOCAL_BROADCAST_CAPACITY: usize = 1024;
 
@@ -117,22 +119,32 @@ impl EngineEventBus for SqliteEngineEventBus {
         self.local.subscribe()
     }
 
-    async fn prune(&self, namespace: Option<&str>, before_ts: f64) -> Result<u64> {
-        let n = match namespace {
+    async fn prune(&self, before_ts: f64) -> Result<u64> {
+        let n = sqlx::query("DELETE FROM engine.events WHERE ts < ?1")
+            .bind(before_ts)
+            .execute(&self.pool)
+            .await
+            .context("sqlite prune (global)")?
+            .rows_affected();
+        Ok(n)
+    }
+
+    async fn prune_with(&self, opts: PruneOpts) -> Result<u64> {
+        let n = match &opts.namespace {
             Some(ns) => sqlx::query(
                 "DELETE FROM engine.events WHERE namespace = ?1 AND ts < ?2",
             )
             .bind(ns)
-            .bind(before_ts)
+            .bind(opts.before_ts)
             .execute(&self.pool)
             .await
-            .context("sqlite prune (scoped)")?
+            .context("sqlite prune_with (scoped)")?
             .rows_affected(),
             None => sqlx::query("DELETE FROM engine.events WHERE ts < ?1")
-                .bind(before_ts)
+                .bind(opts.before_ts)
                 .execute(&self.pool)
                 .await
-                .context("sqlite prune (global)")?
+                .context("sqlite prune_with (global)")?
                 .rows_affected(),
         };
         Ok(n)

--- a/crates/assay-domain/src/events/sqlite_test.rs
+++ b/crates/assay-domain/src/events/sqlite_test.rs
@@ -101,8 +101,8 @@ async fn sqlite_prune_idempotent() {
     })
     .await
     .unwrap();
-    let n = bus.prune(f64::MAX).await.unwrap();
+    let n = bus.prune(Some("main"), f64::MAX).await.unwrap();
     assert_eq!(n, 1);
-    let n2 = bus.prune(f64::MAX).await.unwrap();
+    let n2 = bus.prune(Some("main"), f64::MAX).await.unwrap();
     assert_eq!(n2, 0, "prune must be idempotent");
 }

--- a/crates/assay-domain/src/events/sqlite_test.rs
+++ b/crates/assay-domain/src/events/sqlite_test.rs
@@ -6,7 +6,7 @@ use sqlx::SqlitePool;
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 
 use super::*;
-use crate::events::{EngineEventBus, EventFilter, NewEvent, Subsystem};
+use crate::events::{EngineEventBus, EventFilter, NewEvent, PruneOpts, Subsystem};
 
 async fn fresh_pool() -> SqlitePool {
     let opts = SqliteConnectOptions::new()
@@ -101,8 +101,14 @@ async fn sqlite_prune_idempotent() {
     })
     .await
     .unwrap();
-    let n = bus.prune(Some("main"), f64::MAX).await.unwrap();
+    let n = bus
+        .prune_with(PruneOpts::new(f64::MAX).namespace("main"))
+        .await
+        .unwrap();
     assert_eq!(n, 1);
-    let n2 = bus.prune(Some("main"), f64::MAX).await.unwrap();
-    assert_eq!(n2, 0, "prune must be idempotent");
+    let n2 = bus
+        .prune_with(PruneOpts::new(f64::MAX).namespace("main"))
+        .await
+        .unwrap();
+    assert_eq!(n2, 0, "prune_with must be idempotent");
 }

--- a/crates/assay-domain/src/events/trait_.rs
+++ b/crates/assay-domain/src/events/trait_.rs
@@ -134,10 +134,12 @@ pub trait EngineEventBus: Send + Sync + 'static {
     /// layer maps that to force-close.
     fn subscribe(&self, namespace: &str) -> broadcast::Receiver<Arc<Event>>;
 
-    /// Prune events older than the given unix-epoch timestamp.
+    /// Prune events older than the given unix-epoch timestamp. Pass
+    /// `Some(ns)` to restrict deletion to a single namespace, or `None`
+    /// for the global cleanup path used by the housekeeping loop.
     /// Idempotent; callable from any node. Returns the number of rows
     /// deleted.
-    async fn prune(&self, before_ts: f64) -> Result<u64>;
+    async fn prune(&self, namespace: Option<&str>, before_ts: f64) -> Result<u64>;
 
     /// Look up the oldest retained id for a namespace. Used by the SSE
     /// layer to decide 410 Gone when a client's `Last-Event-ID` is

--- a/crates/assay-domain/src/events/trait_.rs
+++ b/crates/assay-domain/src/events/trait_.rs
@@ -64,6 +64,37 @@ pub struct NewEvent<'a> {
     pub payload: serde_json::Value,
 }
 
+/// Options for [`EngineEventBus::prune_with`]. Marked `#[non_exhaustive]`
+/// so additional filter fields (e.g. `subsystem`, `kind`, `dry_run`) can
+/// be added later without breaking external callers — construct via
+/// [`PruneOpts::new`] and the fluent setters.
+#[non_exhaustive]
+#[derive(Debug, Clone, Default)]
+pub struct PruneOpts {
+    /// If set, only delete events in this namespace. `None` deletes
+    /// across every namespace — the cluster-wide cleanup path.
+    pub namespace: Option<String>,
+    /// Delete events whose `ts` is strictly less than this unix epoch.
+    pub before_ts: f64,
+}
+
+impl PruneOpts {
+    /// Cluster-wide prune of events older than `before_ts`. Use the
+    /// fluent setters to scope further.
+    pub fn new(before_ts: f64) -> Self {
+        Self {
+            before_ts,
+            ..Default::default()
+        }
+    }
+
+    /// Restrict the prune to a single namespace.
+    pub fn namespace(mut self, ns: impl Into<String>) -> Self {
+        self.namespace = Some(ns.into());
+        self
+    }
+}
+
 /// Filter applied server-side before an event is sent to a subscriber.
 /// Empty vecs / `None`s mean "no filter on this dimension".
 #[derive(Debug, Clone, Default)]
@@ -134,12 +165,26 @@ pub trait EngineEventBus: Send + Sync + 'static {
     /// layer maps that to force-close.
     fn subscribe(&self, namespace: &str) -> broadcast::Receiver<Arc<Event>>;
 
-    /// Prune events older than the given unix-epoch timestamp. Pass
-    /// `Some(ns)` to restrict deletion to a single namespace, or `None`
-    /// for the global cleanup path used by the housekeeping loop.
-    /// Idempotent; callable from any node. Returns the number of rows
-    /// deleted.
-    async fn prune(&self, namespace: Option<&str>, before_ts: f64) -> Result<u64>;
+    /// Prune events older than the given unix-epoch timestamp across
+    /// every namespace. Used by the production housekeeping loop, which
+    /// genuinely wants a cluster-wide sweep. Tests and tenant-scoped
+    /// callers should prefer [`prune_with`](Self::prune_with) so they
+    /// don't accidentally delete other namespaces' rows.
+    /// Idempotent; callable from any node.
+    async fn prune(&self, before_ts: f64) -> Result<u64>;
+
+    /// Prune events according to the supplied [`PruneOpts`]. The
+    /// default implementation forwards to `prune` when no namespace is
+    /// set, and errors otherwise — bus implementations that support
+    /// namespace-scoped pruning override this.
+    async fn prune_with(&self, opts: PruneOpts) -> Result<u64> {
+        if opts.namespace.is_some() {
+            anyhow::bail!(
+                "prune_with: namespace-scoped prune not supported by this bus implementation"
+            );
+        }
+        self.prune(opts.before_ts).await
+    }
 
     /// Look up the oldest retained id for a namespace. Used by the SSE
     /// layer to decide 410 Gone when a client's `Last-Event-ID` is

--- a/crates/assay-workflow/src/events_cleanup.rs
+++ b/crates/assay-workflow/src/events_cleanup.rs
@@ -20,7 +20,7 @@ pub async fn run_events_cleanup(
     loop {
         tick.tick().await;
         let cutoff = now_secs() - ttl_secs as f64;
-        match bus.prune(cutoff).await {
+        match bus.prune(None, cutoff).await {
             Ok(n) if n > 0 => tracing::info!(pruned = n, "engine_events cleanup swept"),
             Ok(_) => tracing::debug!("engine_events cleanup: nothing to prune"),
             Err(e) => tracing::warn!(?e, "engine_events prune failed; will retry next tick"),

--- a/crates/assay-workflow/src/events_cleanup.rs
+++ b/crates/assay-workflow/src/events_cleanup.rs
@@ -20,7 +20,7 @@ pub async fn run_events_cleanup(
     loop {
         tick.tick().await;
         let cutoff = now_secs() - ttl_secs as f64;
-        match bus.prune(None, cutoff).await {
+        match bus.prune(cutoff).await {
             Ok(n) if n > 0 => tracing::info!(pruned = n, "engine_events cleanup swept"),
             Ok(_) => tracing::debug!("engine_events cleanup: nothing to prune"),
             Err(e) => tracing::warn!(?e, "engine_events prune failed; will retry next tick"),

--- a/crates/assay-workflow/tests/engine_events_cleanup.rs
+++ b/crates/assay-workflow/tests/engine_events_cleanup.rs
@@ -7,7 +7,7 @@
 
 use std::sync::Arc;
 
-use assay_domain::events::{EngineEventBus, NewEvent, SqliteEngineEventBus, Subsystem};
+use assay_domain::events::{EngineEventBus, NewEvent, PruneOpts, SqliteEngineEventBus, Subsystem};
 use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions};
 
 async fn fresh_bus() -> Arc<dyn EngineEventBus> {
@@ -59,8 +59,14 @@ async fn cleanup_prunes_old_events_and_is_idempotent() {
         .await
         .unwrap();
     }
-    let n1 = bus.prune(Some("main"), f64::MAX).await.unwrap();
+    let n1 = bus
+        .prune_with(PruneOpts::new(f64::MAX).namespace("main"))
+        .await
+        .unwrap();
     assert_eq!(n1, 5);
-    let n2 = bus.prune(Some("main"), f64::MAX).await.unwrap();
-    assert_eq!(n2, 0, "prune must be idempotent");
+    let n2 = bus
+        .prune_with(PruneOpts::new(f64::MAX).namespace("main"))
+        .await
+        .unwrap();
+    assert_eq!(n2, 0, "prune_with must be idempotent");
 }

--- a/crates/assay-workflow/tests/engine_events_cleanup.rs
+++ b/crates/assay-workflow/tests/engine_events_cleanup.rs
@@ -59,8 +59,8 @@ async fn cleanup_prunes_old_events_and_is_idempotent() {
         .await
         .unwrap();
     }
-    let n1 = bus.prune(f64::MAX).await.unwrap();
+    let n1 = bus.prune(Some("main"), f64::MAX).await.unwrap();
     assert_eq!(n1, 5);
-    let n2 = bus.prune(f64::MAX).await.unwrap();
+    let n2 = bus.prune(Some("main"), f64::MAX).await.unwrap();
     assert_eq!(n2, 0, "prune must be idempotent");
 }

--- a/crates/assay-workflow/tests/sse_replay.rs
+++ b/crates/assay-workflow/tests/sse_replay.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use assay_domain::events::{
-    EngineEventBus, NewEvent, SqliteEngineEventBus, Subsystem,
+    EngineEventBus, NewEvent, PruneOpts, SqliteEngineEventBus, Subsystem,
 };
 use assay_workflow::WorkflowCtx;
 use assay_workflow::events::WorkflowEventBus;
@@ -182,7 +182,9 @@ async fn sse_returns_410_when_cursor_before_retention() {
     })
     .await
     .unwrap();
-    bus.prune(Some("main"), f64::MAX).await.unwrap();
+    bus.prune_with(PruneOpts::new(f64::MAX).namespace("main"))
+        .await
+        .unwrap();
 
     // Re-seed so oldest_id > 0.
     let new_id = bus

--- a/crates/assay-workflow/tests/sse_replay.rs
+++ b/crates/assay-workflow/tests/sse_replay.rs
@@ -182,7 +182,7 @@ async fn sse_returns_410_when_cursor_before_retention() {
     })
     .await
     .unwrap();
-    bus.prune(f64::MAX).await.unwrap();
+    bus.prune(Some("main"), f64::MAX).await.unwrap();
 
     // Re-seed so oldest_id > 0.
     let new_id = bus

--- a/crates/assay/Cargo.toml
+++ b/crates/assay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-lua"
-version = "0.15.3"
+version = "0.15.4"
 categories = ["command-line-utilities", "development-tools::testing"]
 edition = "2024"
 homepage = "https://assay.rs"

--- a/crates/assay/stdlib/engine/vault.lua
+++ b/crates/assay/stdlib/engine/vault.lua
@@ -1,5 +1,5 @@
 --- @module assay.engine.vault
---- @description Lua client for assay-engine's vault module (plan 17 / v0.3.0) mounted at `/api/v1/vault/*`. KV v2, transit, plus collections / share / dynamic-creds / sealing surfaces. For HashiCorp Vault / OpenBao use `assay.hashicorp_vault`.
+--- @description Lua client for assay-engine's vault module (plan 17 / v0.3.0) mounted at `/api/v1/vault/*`. KV v2, transit, plus collections / share / dynamic-creds / sealing surfaces. For HashiCorp Vault / OpenBao use `assay.hashicorp.vault`.
 --- @keywords vault, secrets, kv, transit, encrypt, decrypt, encryption, decryption, rotate, rotation, password, key, share, sealing, lease, credential, biscuit, kdf, assay-engine
 --- @quickref vault.client(opts) -> client | Build a vault client (engine_url + optional api_key)
 --- @quickref c.kv:put(path, data, custom_md?) -> {path, version} | Store new KV version

--- a/crates/assay/stdlib/hashicorp.lua
+++ b/crates/assay/stdlib/hashicorp.lua
@@ -1,0 +1,9 @@
+--- @module assay.hashicorp
+--- @description Convenience umbrella for HashiCorp tooling submodules. Today only `vault` ships; future submodules (consul, nomad, boundary, terraform, packer, waypoint) will register here. Prefer requiring the individual submodules directly (e.g. `assay.hashicorp.vault`) if you only need one.
+--- @keywords hashicorp, vault, consul, nomad, boundary, terraform, packer, waypoint, secrets, kv, auth
+
+local vault = require("assay.hashicorp.vault")
+
+return {
+  vault = vault,
+}

--- a/crates/assay/stdlib/hashicorp/vault.lua
+++ b/crates/assay/stdlib/hashicorp/vault.lua
@@ -1,4 +1,4 @@
---- @module assay.hashicorp_vault
+--- @module assay.hashicorp.vault
 --- @description HashiCorp Vault / OpenBao client. KV, policies, auth, transit, PKI, token management. For the assay-engine native vault module use `assay.vault`.
 --- @keywords vault, secrets, kv, policies, auth, transit, pki, tokens, encryption, decryption, certificate, seal, initialization, authentication, secret-engine, password, rotation
 --- @quickref c.kv:get(mount, key) -> {data}|nil | Read KV v2 secret
@@ -39,8 +39,8 @@
 --- @quickref c.pki:create_role(mount, role_name, opts?) -> nil | Create PKI role
 --- @quickref M.wait(url, opts?) -> true | Wait for Vault to become healthy
 --- @quickref M.authenticated_client(url, opts?) -> client | Create client with K8s secret auth
---- @quickref M.ensure_credentials(client, path, check_key, generator) -> creds | Ensure credentials exist
---- @quickref M.assert_secret(client, path, expected_keys) -> data | Assert secret exists with keys
+--- @quickref M.ensure_credentials(client, mount, path, check_key, generator) -> creds | Ensure credentials exist
+--- @quickref M.assert_secret(client, mount, path, expected_keys) -> data | Assert secret exists with keys
 
 local M = {}
 
@@ -382,31 +382,29 @@ function M.authenticated_client(url, opts)
   return M.client(url, token)
 end
 
-function M.ensure_credentials(client, path, check_key, generator)
-  -- Check if credentials already exist
-  local existing = client.kv:get("secrets", path)
+function M.ensure_credentials(client, mount, path, check_key, generator)
+  local existing = client.kv:get(mount, path)
   if existing and existing.data and existing.data[check_key] then
-    log.info("Credentials already exist at secrets/" .. path)
+    log.info("Credentials already exist at " .. mount .. "/" .. path)
     return existing.data
   end
 
-  -- Generate new credentials
   local creds = generator()
-  client.kv:put("secrets", path, creds)
-  log.info("Generated and stored credentials at secrets/" .. path)
+  client.kv:put(mount, path, creds)
+  log.info("Generated and stored credentials at " .. mount .. "/" .. path)
   return creds
 end
 
-function M.assert_secret(client, path, expected_keys)
-  local data = client.kv:get("secrets", path)
-  assert.not_nil(data, "vault.assert_secret: secret not found at secrets/" .. path)
-  assert.not_nil(data.data, "vault.assert_secret: no data at secrets/" .. path)
+function M.assert_secret(client, mount, path, expected_keys)
+  local data = client.kv:get(mount, path)
+  assert.not_nil(data, "vault.assert_secret: secret not found at " .. mount .. "/" .. path)
+  assert.not_nil(data.data, "vault.assert_secret: no data at " .. mount .. "/" .. path)
 
   for _, key in ipairs(expected_keys) do
-    assert.not_nil(data.data[key], "vault.assert_secret: key '" .. key .. "' missing at secrets/" .. path)
+    assert.not_nil(data.data[key], "vault.assert_secret: key '" .. key .. "' missing at " .. mount .. "/" .. path)
   end
 
-  log.info("Secret verified at secrets/" .. path .. " (" .. tostring(#expected_keys) .. " keys)")
+  log.info("Secret verified at " .. mount .. "/" .. path .. " (" .. tostring(#expected_keys) .. " keys)")
   return data.data
 end
 

--- a/crates/assay/stdlib/openbao.lua
+++ b/crates/assay/stdlib/openbao.lua
@@ -1,7 +1,7 @@
 --- @module assay.openbao
---- @description OpenBao secrets management (vault-compatible). Alias for assay.vault.
+--- @description OpenBao secrets management (vault-compatible). Alias for assay.hashicorp.vault.
 --- @keywords openbao, vault, secrets, kv, policies, auth, transit, pki, encryption, decryption, certificate, seal, initialization, authentication, secret-engine, password, rotation
 
 -- OpenBao alias: OpenBao is API-compatible with HashiCorp Vault.
--- Both tools can use the same client via require("assay.hashicorp_vault") or require("assay.openbao").
-return require("assay.hashicorp_vault")
+-- Both tools can use the same client via require("assay.hashicorp.vault") or require("assay.openbao").
+return require("assay.hashicorp.vault")

--- a/crates/assay/tests/context.rs
+++ b/crates/assay/tests/context.rs
@@ -35,7 +35,7 @@ fn test_format_single_module() {
 #[test]
 fn test_format_env_vars() {
     let entries = vec![ModuleContextEntry {
-        module_name: "assay.vault".to_string(),
+        module_name: "assay.hashicorp.vault".to_string(),
         description: "Vault secret management.".to_string(),
         env_vars: vec!["VAULT_ADDR".to_string(), "VAULT_TOKEN".to_string()],
         quickrefs: vec![],

--- a/crates/assay/tests/discovery.rs
+++ b/crates/assay/tests/discovery.rs
@@ -21,7 +21,7 @@ fn test_discover_modules_returns_stdlib() {
     );
     assert!(
         names.contains(&"assay.engine.vault"),
-        "should contain assay.vault stdlib, got: {names:?}"
+        "should contain assay.engine.vault stdlib, got: {names:?}"
     );
 }
 
@@ -147,7 +147,7 @@ fn test_search_keyword_password_finds_vault() {
     let ids: Vec<&str> = results.iter().map(|r| r.id.as_str()).collect();
     assert!(
         ids.contains(&"assay.engine.vault"),
-        "search for 'password' should find assay.vault, got: {ids:?}"
+        "search for 'password' should find assay.engine.vault, got: {ids:?}"
     );
 }
 
@@ -187,7 +187,7 @@ fn test_search_keyword_rotation_finds_vault() {
     let ids: Vec<&str> = results.iter().map(|r| r.id.as_str()).collect();
     assert!(
         ids.contains(&"assay.engine.vault") || ids.contains(&"assay.certmanager"),
-        "search for 'rotation' should find assay.vault or assay.certmanager, got: {ids:?}"
+        "search for 'rotation' should find assay.engine.vault or assay.certmanager, got: {ids:?}"
     );
 }
 
@@ -197,7 +197,7 @@ fn test_search_keyword_encryption_finds_vault() {
     let ids: Vec<&str> = results.iter().map(|r| r.id.as_str()).collect();
     assert!(
         ids.contains(&"assay.engine.vault"),
-        "search for 'encryption' should find assay.vault, got: {ids:?}"
+        "search for 'encryption' should find assay.engine.vault, got: {ids:?}"
     );
 }
 
@@ -276,7 +276,7 @@ fn test_search_regression_vault_in_results() {
     let ids: Vec<&str> = results.iter().map(|r| r.id.as_str()).collect();
     assert!(
         ids.contains(&"assay.engine.vault"),
-        "search for 'vault' should find assay.vault in results, got: {ids:?}"
+        "search for 'vault' should find assay.engine.vault in results, got: {ids:?}"
     );
 }
 

--- a/crates/assay/tests/e2e/v050_features.lua
+++ b/crates/assay/tests/e2e/v050_features.lua
@@ -8,9 +8,9 @@ local grafana = require("assay.grafana")
 assert.not_nil(grafana, "assay.grafana should be loadable")
 assert.not_nil(grafana.client, "assay.grafana should have client function")
 
-local vault = require("assay.hashicorp_vault")
-assert.not_nil(vault, "assay.vault should be loadable")
-assert.not_nil(vault.client, "assay.vault should have client function")
+local vault = require("assay.hashicorp.vault")
+assert.not_nil(vault, "assay.hashicorp.vault should be loadable")
+assert.not_nil(vault.client, "assay.hashicorp.vault should have client function")
 
 local prom = require("assay.prometheus")
 assert.not_nil(prom, "assay.prometheus should be loadable")

--- a/crates/assay/tests/fs_require.rs
+++ b/crates/assay/tests/fs_require.rs
@@ -34,14 +34,15 @@ async fn test_fs_require_loads_external_module() {
 #[tokio::test]
 async fn test_fs_require_filesystem_takes_priority() {
     let dir = setup_lib_dir("fs_require_priority");
+    std::fs::create_dir_all(dir.join("hashicorp")).unwrap();
     std::fs::write(
-        dir.join("hashicorp_vault.lua"),
+        dir.join("hashicorp/vault.lua"),
         "local M = {}\nfunction M.custom() return \"filesystem vault\" end\nreturn M\n",
     )
     .unwrap();
 
     let script = r#"
-        local vault = require("assay.hashicorp_vault")
+        local vault = require("assay.hashicorp.vault")
         assert.not_nil(vault)
         assert.eq(vault.custom(), "filesystem vault")
     "#;
@@ -94,7 +95,7 @@ async fn test_fs_require_module_can_require_embedded() {
     std::fs::write(
         dir.join("wrapper.lua"),
         r#"
-local vault = require("assay.hashicorp_vault")
+local vault = require("assay.hashicorp.vault")
 local M = {}
 function M.has_vault()
     return vault ~= nil and vault.client ~= nil

--- a/crates/assay/tests/integration.rs
+++ b/crates/assay/tests/integration.rs
@@ -16,8 +16,8 @@ fn test_context_vault_finds_module() {
         String::from_utf8_lossy(&output.stderr)
     );
     assert!(
-        stdout.contains("assay.vault"),
-        "context vault should find assay.vault, got: {stdout}"
+        stdout.contains("assay.hashicorp.vault") || stdout.contains("assay.engine.vault"),
+        "context vault should find assay.hashicorp.vault or assay.engine.vault, got: {stdout}"
     );
 }
 
@@ -80,7 +80,7 @@ fn test_modules_lists_all_stdlib() {
     );
     for module in &[
         "assay.grafana",
-        "assay.vault",
+        "assay.hashicorp.vault",
         "assay.prometheus",
         "assay.k8s",
         "assay.argocd",

--- a/crates/assay/tests/modules_cmd.rs
+++ b/crates/assay/tests/modules_cmd.rs
@@ -45,8 +45,12 @@ fn test_modules_lists_vault() {
     let output = assay_bin().arg("modules").output().unwrap();
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
-        stdout.contains("assay.vault"),
-        "should list assay.vault: {stdout}"
+        stdout.contains("assay.hashicorp.vault"),
+        "should list assay.hashicorp.vault: {stdout}"
+    );
+    assert!(
+        stdout.contains("assay.engine.vault"),
+        "should list assay.engine.vault: {stdout}"
     );
 }
 

--- a/crates/assay/tests/stdlib_hashicorp_vault.rs
+++ b/crates/assay/tests/stdlib_hashicorp_vault.rs
@@ -7,7 +7,7 @@ use wiremock::{Mock, MockServer, ResponseTemplate};
 #[tokio::test]
 async fn test_require_vault() {
     let script = r#"
-        local vault = require("assay.hashicorp_vault")
+        local vault = require("assay.hashicorp.vault")
         assert.not_nil(vault)
         assert.not_nil(vault.client)
     "#;
@@ -27,7 +27,7 @@ async fn test_vault_read() {
 
     let script = format!(
         r#"
-        local vault = require("assay.hashicorp_vault")
+        local vault = require("assay.hashicorp.vault")
         local c = vault.client("{}", "test-token")
         local data = c:read("secret/data/mykey")
         assert.eq(data.data.username, "admin")
@@ -49,7 +49,7 @@ async fn test_vault_read_404() {
 
     let script = format!(
         r#"
-        local vault = require("assay.hashicorp_vault")
+        local vault = require("assay.hashicorp.vault")
         local c = vault.client("{}", "test-token")
         local data = c:read("secret/data/missing")
         assert.eq(data, nil)
@@ -70,7 +70,7 @@ async fn test_vault_write() {
 
     let script = format!(
         r#"
-        local vault = require("assay.hashicorp_vault")
+        local vault = require("assay.hashicorp.vault")
         local c = vault.client("{}", "test-token")
         c:write("secret/data/newkey", {{ data = {{ key = "value" }} }})
         "#,
@@ -90,7 +90,7 @@ async fn test_vault_delete() {
 
     let script = format!(
         r#"
-        local vault = require("assay.hashicorp_vault")
+        local vault = require("assay.hashicorp.vault")
         local c = vault.client("{}", "test-token")
         c:delete("secret/data/oldkey")
         "#,
@@ -112,7 +112,7 @@ async fn test_vault_list() {
 
     let script = format!(
         r#"
-        local vault = require("assay.hashicorp_vault")
+        local vault = require("assay.hashicorp.vault")
         local c = vault.client("{}", "test-token")
         local keys = c:list("secret/metadata")
         assert.eq(#keys, 3)
@@ -135,7 +135,7 @@ async fn test_vault_list_empty() {
 
     let script = format!(
         r#"
-        local vault = require("assay.hashicorp_vault")
+        local vault = require("assay.hashicorp.vault")
         local c = vault.client("{}", "test-token")
         local keys = c:list("secret/metadata")
         assert.eq(#keys, 0)
@@ -158,7 +158,7 @@ async fn test_vault_kv_get() {
 
     let script = format!(
         r#"
-        local vault = require("assay.hashicorp_vault")
+        local vault = require("assay.hashicorp.vault")
         local c = vault.client("{}", "test-token")
         local data = c.kv:get("secret", "mykey")
         assert.eq(data.data.foo, "bar")
@@ -179,7 +179,7 @@ async fn test_vault_kv_put() {
 
     let script = format!(
         r#"
-        local vault = require("assay.hashicorp_vault")
+        local vault = require("assay.hashicorp.vault")
         local c = vault.client("{}", "test-token")
         c.kv:put("secret", "mykey", {{ username = "admin", password = "s3cret" }})
         "#,
@@ -199,7 +199,7 @@ async fn test_vault_kv_delete() {
 
     let script = format!(
         r#"
-        local vault = require("assay.hashicorp_vault")
+        local vault = require("assay.hashicorp.vault")
         local c = vault.client("{}", "test-token")
         c.kv:delete("secret", "mykey")
         "#,
@@ -221,7 +221,7 @@ async fn test_vault_kv_list() {
 
     let script = format!(
         r#"
-        local vault = require("assay.hashicorp_vault")
+        local vault = require("assay.hashicorp.vault")
         local c = vault.client("{}", "test-token")
         local keys = c.kv:list("secret")
         assert.eq(#keys, 3)
@@ -256,7 +256,7 @@ async fn test_vault_kv_metadata() {
 
     let script = format!(
         r#"
-        local vault = require("assay.hashicorp_vault")
+        local vault = require("assay.hashicorp.vault")
         local c = vault.client("{}", "test-token")
         local meta = c.kv:metadata("secret", "mykey")
         assert.eq(meta.data.current_version, 3)
@@ -289,7 +289,7 @@ async fn test_vault_health() {
 
     let script = format!(
         r#"
-        local vault = require("assay.hashicorp_vault")
+        local vault = require("assay.hashicorp.vault")
         local c = vault.client("{}", "test-token")
         local h = c.sys:health()
         assert.eq(h.initialized, true)
@@ -327,7 +327,7 @@ async fn test_vault_seal_status() {
 
     let script = format!(
         r#"
-        local vault = require("assay.hashicorp_vault")
+        local vault = require("assay.hashicorp.vault")
         local c = vault.client("{}", "test-token")
         local s = c.sys:seal_status()
         assert.eq(s.sealed, false)
@@ -357,7 +357,7 @@ async fn test_vault_is_sealed() {
 
     let script = format!(
         r#"
-        local vault = require("assay.hashicorp_vault")
+        local vault = require("assay.hashicorp.vault")
         local c = vault.client("{}", "test-token")
         assert.eq(c.sys:is_sealed(), true)
         "#,
@@ -383,7 +383,7 @@ async fn test_vault_is_initialized() {
 
     let script = format!(
         r#"
-        local vault = require("assay.hashicorp_vault")
+        local vault = require("assay.hashicorp.vault")
         local c = vault.client("{}", "test-token")
         assert.eq(c.sys:is_initialized(), true)
         "#,
@@ -408,7 +408,7 @@ async fn test_vault_policy_get() {
 
     let script = format!(
         r#"
-        local vault = require("assay.hashicorp_vault")
+        local vault = require("assay.hashicorp.vault")
         local c = vault.client("{}", "test-token")
         local pol = c.policies:get("my-policy")
         assert.eq(pol.name, "my-policy")
@@ -430,7 +430,7 @@ async fn test_vault_policy_put() {
 
     let script = format!(
         r#"
-        local vault = require("assay.hashicorp_vault")
+        local vault = require("assay.hashicorp.vault")
         local c = vault.client("{}", "test-token")
         c.policies:create("my-policy", 'path "secret/data/*" {{ capabilities = ["read"] }}')
         "#,
@@ -450,7 +450,7 @@ async fn test_vault_policy_delete() {
 
     let script = format!(
         r#"
-        local vault = require("assay.hashicorp_vault")
+        local vault = require("assay.hashicorp.vault")
         local c = vault.client("{}", "test-token")
         c.policies:delete("my-policy")
         "#,
@@ -472,7 +472,7 @@ async fn test_vault_policy_list() {
 
     let script = format!(
         r#"
-        local vault = require("assay.hashicorp_vault")
+        local vault = require("assay.hashicorp.vault")
         local c = vault.client("{}", "test-token")
         local policies = c.policies:list()
         assert.eq(#policies, 3)
@@ -495,7 +495,7 @@ async fn test_vault_auth_enable() {
 
     let script = format!(
         r#"
-        local vault = require("assay.hashicorp_vault")
+        local vault = require("assay.hashicorp.vault")
         local c = vault.client("{}", "test-token")
         c.auth:enable("kubernetes", "kubernetes", {{ description = "K8s auth" }})
         "#,
@@ -515,7 +515,7 @@ async fn test_vault_auth_disable() {
 
     let script = format!(
         r#"
-        local vault = require("assay.hashicorp_vault")
+        local vault = require("assay.hashicorp.vault")
         local c = vault.client("{}", "test-token")
         c.auth:disable("kubernetes")
         "#,
@@ -546,7 +546,7 @@ async fn test_vault_auth_list() {
 
     let script = format!(
         r#"
-        local vault = require("assay.hashicorp_vault")
+        local vault = require("assay.hashicorp.vault")
         local c = vault.client("{}", "test-token")
         local auths = c.auth:methods()
         assert.not_nil(auths["token/"])
@@ -569,7 +569,7 @@ async fn test_vault_auth_config() {
 
     let script = format!(
         r#"
-        local vault = require("assay.hashicorp_vault")
+        local vault = require("assay.hashicorp.vault")
         local c = vault.client("{}", "test-token")
         c.auth:config("kubernetes", {{
             kubernetes_host = "https://kubernetes.default.svc",
@@ -591,7 +591,7 @@ async fn test_vault_auth_create_role() {
 
     let script = format!(
         r#"
-        local vault = require("assay.hashicorp_vault")
+        local vault = require("assay.hashicorp.vault")
         local c = vault.client("{}", "test-token")
         c.auth:create_role("kubernetes", "my-app", {{
             bound_service_account_names = {{ "my-app" }},
@@ -624,7 +624,7 @@ async fn test_vault_auth_read_role() {
 
     let script = format!(
         r#"
-        local vault = require("assay.hashicorp_vault")
+        local vault = require("assay.hashicorp.vault")
         local c = vault.client("{}", "test-token")
         local role = c.auth:get_role("kubernetes", "my-app")
         assert.eq(role.policies[1], "my-policy")
@@ -648,7 +648,7 @@ async fn test_vault_auth_list_roles() {
 
     let script = format!(
         r#"
-        local vault = require("assay.hashicorp_vault")
+        local vault = require("assay.hashicorp.vault")
         local c = vault.client("{}", "test-token")
         local roles = c.auth:list_roles("kubernetes")
         assert.eq(#roles, 3)
@@ -670,7 +670,7 @@ async fn test_vault_engine_enable() {
 
     let script = format!(
         r#"
-        local vault = require("assay.hashicorp_vault")
+        local vault = require("assay.hashicorp.vault")
         local c = vault.client("{}", "test-token")
         c.engines:enable("transit", "transit", {{ description = "Encryption as a service" }})
         "#,
@@ -690,7 +690,7 @@ async fn test_vault_engine_disable() {
 
     let script = format!(
         r#"
-        local vault = require("assay.hashicorp_vault")
+        local vault = require("assay.hashicorp.vault")
         local c = vault.client("{}", "test-token")
         c.engines:disable("transit")
         "#,
@@ -725,7 +725,7 @@ async fn test_vault_engine_list() {
 
     let script = format!(
         r#"
-        local vault = require("assay.hashicorp_vault")
+        local vault = require("assay.hashicorp.vault")
         local c = vault.client("{}", "test-token")
         local engines = c.engines:list()
         assert.not_nil(engines["secret/"])
@@ -748,7 +748,7 @@ async fn test_vault_engine_tune() {
 
     let script = format!(
         r#"
-        local vault = require("assay.hashicorp_vault")
+        local vault = require("assay.hashicorp.vault")
         local c = vault.client("{}", "test-token")
         c.engines:tune("secret", {{ max_lease_ttl = "87600h", default_lease_ttl = "1h" }})
         "#,
@@ -778,7 +778,7 @@ async fn test_vault_token_create() {
 
     let script = format!(
         r#"
-        local vault = require("assay.hashicorp_vault")
+        local vault = require("assay.hashicorp.vault")
         local c = vault.client("{}", "test-token")
         local auth = c.token:create({{ policies = {{ "my-policy" }}, ttl = "1h" }})
         assert.eq(auth.client_token, "hvs.CAESI_new_child_token")
@@ -813,7 +813,7 @@ async fn test_vault_token_lookup() {
 
     let script = format!(
         r#"
-        local vault = require("assay.hashicorp_vault")
+        local vault = require("assay.hashicorp.vault")
         local c = vault.client("{}", "test-token")
         local info = c.token:lookup("hvs.CAESI_some_token")
         assert.eq(info.id, "hvs.CAESI_some_token")
@@ -844,7 +844,7 @@ async fn test_vault_token_lookup_self() {
 
     let script = format!(
         r#"
-        local vault = require("assay.hashicorp_vault")
+        local vault = require("assay.hashicorp.vault")
         local c = vault.client("{}", "test-token")
         local info = c.token:lookup_self()
         assert.eq(info.id, "hvs.CAESI_self_token")
@@ -866,7 +866,7 @@ async fn test_vault_token_revoke() {
 
     let script = format!(
         r#"
-        local vault = require("assay.hashicorp_vault")
+        local vault = require("assay.hashicorp.vault")
         local c = vault.client("{}", "test-token")
         c.token:revoke("hvs.CAESI_revoke_me")
         "#,
@@ -886,7 +886,7 @@ async fn test_vault_token_revoke_self() {
 
     let script = format!(
         r#"
-        local vault = require("assay.hashicorp_vault")
+        local vault = require("assay.hashicorp.vault")
         local c = vault.client("{}", "test-token")
         c.token:revoke_self()
         "#,
@@ -910,7 +910,7 @@ async fn test_vault_transit_encrypt() {
 
     let script = format!(
         r#"
-        local vault = require("assay.hashicorp_vault")
+        local vault = require("assay.hashicorp.vault")
         local c = vault.client("{}", "test-token")
         local ct = c.transit:encrypt("my-key", "hello world")
         assert.eq(ct, "vault:v1:ABCDEF1234567890encrypted")
@@ -935,7 +935,7 @@ async fn test_vault_transit_decrypt() {
 
     let script = format!(
         r#"
-        local vault = require("assay.hashicorp_vault")
+        local vault = require("assay.hashicorp.vault")
         local c = vault.client("{}", "test-token")
         local pt = c.transit:decrypt("my-key", "vault:v1:ABCDEF1234567890encrypted")
         assert.eq(pt, "hello world")
@@ -956,7 +956,7 @@ async fn test_vault_transit_create_key() {
 
     let script = format!(
         r#"
-        local vault = require("assay.hashicorp_vault")
+        local vault = require("assay.hashicorp.vault")
         local c = vault.client("{}", "test-token")
         c.transit:create_key("new-key", {{ type = "aes256-gcm96" }})
         "#,
@@ -978,7 +978,7 @@ async fn test_vault_transit_list_keys() {
 
     let script = format!(
         r#"
-        local vault = require("assay.hashicorp_vault")
+        local vault = require("assay.hashicorp.vault")
         local c = vault.client("{}", "test-token")
         local keys = c.transit:list_keys()
         assert.eq(#keys, 3)
@@ -1011,7 +1011,7 @@ async fn test_vault_pki_issue() {
 
     let script = format!(
         r#"
-        local vault = require("assay.hashicorp_vault")
+        local vault = require("assay.hashicorp.vault")
         local c = vault.client("{}", "test-token")
         local cert = c.pki:issue("pki", "web-certs", {{ common_name = "example.com", ttl = "720h" }})
         assert.contains(cert.certificate, "BEGIN CERTIFICATE")
@@ -1038,7 +1038,7 @@ async fn test_vault_pki_ca_cert() {
 
     let script = format!(
         r#"
-        local vault = require("assay.hashicorp_vault")
+        local vault = require("assay.hashicorp.vault")
         local c = vault.client("{}", "test-token")
         local pem = c.pki:ca_cert("pki")
         assert.contains(pem, "BEGIN CERTIFICATE")
@@ -1060,7 +1060,7 @@ async fn test_vault_pki_create_role() {
 
     let script = format!(
         r#"
-        local vault = require("assay.hashicorp_vault")
+        local vault = require("assay.hashicorp.vault")
         local c = vault.client("{}", "test-token")
         c.pki:create_role("pki", "web-certs", {{
             allowed_domains = {{ "example.com" }},
@@ -1086,7 +1086,7 @@ async fn test_vault_wait_success() {
 
     let script = format!(
         r#"
-        local vault = require("assay.hashicorp_vault")
+        local vault = require("assay.hashicorp.vault")
         local result = vault.wait("{}", {{ timeout = 5, interval = 0.1 }})
         assert.eq(result, true)
         "#,
@@ -1106,7 +1106,7 @@ async fn test_vault_wait_timeout() {
 
     let script = format!(
         r#"
-        local vault = require("assay.hashicorp_vault")
+        local vault = require("assay.hashicorp.vault")
         vault.wait("{}", {{ timeout = 1, interval = 0.5 }})
         "#,
         server.uri()
@@ -1128,14 +1128,14 @@ async fn test_vault_ensure_credentials_existing() {
 
     let script = format!(
         r#"
-        local vault = require("assay.hashicorp_vault")
+        local vault = require("assay.hashicorp.vault")
         local c = vault.client("{}", "test-token")
         local generator_called = false
         local function generator()
             generator_called = true
             return {{ password = "new_secret" }}
         end
-        local data = vault.ensure_credentials(c, "db/postgres", "password", generator)
+        local data = vault.ensure_credentials(c, "secrets", "db/postgres", "password", generator)
         assert.eq(data.username, "admin")
         assert.eq(data.password, "existing_secret")
         assert.eq(generator_called, false)
@@ -1161,14 +1161,14 @@ async fn test_vault_ensure_credentials_new() {
 
     let script = format!(
         r#"
-        local vault = require("assay.hashicorp_vault")
+        local vault = require("assay.hashicorp.vault")
         local c = vault.client("{}", "test-token")
         local generator_called = false
         local function generator()
             generator_called = true
             return {{ password = "generated_secret" }}
         end
-        local data = vault.ensure_credentials(c, "db/new", "password", generator)
+        local data = vault.ensure_credentials(c, "secrets", "db/new", "password", generator)
         assert.eq(data.password, "generated_secret")
         assert.eq(generator_called, true)
         "#,
@@ -1190,9 +1190,9 @@ async fn test_vault_assert_secret_success() {
 
     let script = format!(
         r#"
-        local vault = require("assay.hashicorp_vault")
+        local vault = require("assay.hashicorp.vault")
         local c = vault.client("{}", "test-token")
-        local data = vault.assert_secret(c, "db/postgres", {{"username", "password"}})
+        local data = vault.assert_secret(c, "secrets", "db/postgres", {{"username", "password"}})
         assert.eq(data.username, "admin")
         assert.eq(data.password, "secret123")
         "#,
@@ -1212,9 +1212,9 @@ async fn test_vault_assert_secret_missing() {
 
     let script = format!(
         r#"
-        local vault = require("assay.hashicorp_vault")
+        local vault = require("assay.hashicorp.vault")
         local c = vault.client("{}", "test-token")
-        vault.assert_secret(c, "db/missing", {{"username"}})
+        vault.assert_secret(c, "secrets", "db/missing", {{"username"}})
         "#,
         server.uri()
     );
@@ -1235,9 +1235,9 @@ async fn test_vault_assert_secret_missing_key() {
 
     let script = format!(
         r#"
-        local vault = require("assay.hashicorp_vault")
+        local vault = require("assay.hashicorp.vault")
         local c = vault.client("{}", "test-token")
-        vault.assert_secret(c, "db/partial", {{"username", "missing_key"}})
+        vault.assert_secret(c, "secrets", "db/partial", {{"username", "missing_key"}})
         "#,
         server.uri()
     );

--- a/crates/assay/tests/stdlib_openbao_alias.rs
+++ b/crates/assay/tests/stdlib_openbao_alias.rs
@@ -17,7 +17,7 @@ async fn test_openbao_alias_loads() {
 #[tokio::test]
 async fn test_openbao_alias_matches_vault() {
     let script = r#"
-        local vault = require("assay.hashicorp_vault")
+        local vault = require("assay.hashicorp.vault")
         local bao = require("assay.openbao")
         if vault ~= bao then
             error("openbao module should be the same table as vault module")

--- a/crates/assay/tests/stdlib_postgres.rs
+++ b/crates/assay/tests/stdlib_postgres.rs
@@ -78,7 +78,7 @@ async fn test_postgres_client_from_vault_missing_secret() {
 
     let script = format!(
         r#"
-        local vault = require("assay.hashicorp_vault")
+        local vault = require("assay.hashicorp.vault")
         local pg = require("assay.postgres")
         
         local vault_client = vault.client("{}", "test-token")

--- a/docs/migration-to-0.3.0.md
+++ b/docs/migration-to-0.3.0.md
@@ -121,8 +121,9 @@ local pt = c.transit:decrypt("logs", ct)
 c.transit:rotate("logs")
 ```
 
-The pre-existing HashiCorp Vault / OpenBao client moved to `require("assay.hashicorp_vault")`. The
-`assay.openbao` alias still loads through the renamed module.
+The pre-existing HashiCorp Vault / OpenBao client moved to `require("assay.hashicorp.vault")`
+(originally landed as `assay.hashicorp_vault` in 0.3.0; renamed in 0.15.4 for namespace
+consistency with `assay.ory.*`). The `assay.openbao` alias still loads through the renamed module.
 
 ## Required changes
 
@@ -153,8 +154,8 @@ assay-engine = "0.3"
 ### Lua-script consumers
 
 If your scripts called `require("assay.vault")` against HashiCorp Vault / OpenBao, switch to
-`require("assay.hashicorp_vault")`. The new `assay.vault` module talks to the assay-engine's own
-vault surface.
+`require("assay.hashicorp.vault")`. The new `assay.vault` (now `assay.engine.vault`) module talks
+to the assay-engine's own vault surface.
 
 ### Operators
 

--- a/docs/modules/openbao.md
+++ b/docs/modules/openbao.md
@@ -4,6 +4,6 @@ category: Security & Identity
 
 ## assay.openbao
 
-OpenBao secrets management (Vault API-compatible). Alias for `assay.vault`.
-`require("assay.openbao")` returns the same module as `require("assay.vault")`. All methods are
-identical — see assay.vault documentation above.
+OpenBao secrets management (Vault API-compatible). Alias for `assay.hashicorp.vault`.
+`require("assay.openbao")` returns the same module as `require("assay.hashicorp.vault")`. All
+methods are identical — see assay.hashicorp.vault documentation above.

--- a/docs/modules/postgres.md
+++ b/docs/modules/postgres.md
@@ -40,7 +40,7 @@ Example:
 
 ```lua
 local postgres = require("assay.postgres")
-local vault = require("assay.vault")
+local vault = require("assay.hashicorp.vault")
 local vc = vault.authenticated_client("http://vault:8200")
 local pg = postgres.client_from_vault(vc, "myapp/postgres", "postgres.default.svc", 5432)
 pg.users:ensure("myapp", crypto.random(16), {createdb = true})

--- a/docs/modules/vault.md
+++ b/docs/modules/vault.md
@@ -2,11 +2,13 @@
 category: Security & Identity
 ---
 
-## assay.vault
+## assay.hashicorp.vault
 
-HashiCorp Vault secrets management. KV v2, policies, auth methods, transit encryption, PKI
-certificates, tokens. Client: `vault.client(url, token)`. Module helpers: `M.wait()`,
+HashiCorp Vault / OpenBao secrets management. KV v2, policies, auth methods, transit encryption,
+PKI certificates, tokens. Client: `vault.client(url, token)`. Module helpers: `M.wait()`,
 `M.authenticated_client()`, `M.ensure_credentials()`, `M.assert_secret()`.
+
+For the assay-engine native vault module use `assay.engine.vault`.
 
 ### Raw API
 
@@ -88,15 +90,15 @@ certificates, tokens. Client: `vault.client(url, token)`. Module helpers: `M.wai
   `{timeout, interval, health_path}`
 - `M.authenticated_client(url, opts?)` -> client -- Create client using K8s secret for token.
   `opts`: `{secret_namespace, secret_name, secret_key, timeout}`
-- `M.ensure_credentials(client, path, check_key, generator)` -> creds -- Check if creds exist at KV
-  path, generate if missing
-- `M.assert_secret(client, path, expected_keys)` -> data -- Assert secret exists with all expected
-  keys
+- `M.ensure_credentials(client, mount, path, check_key, generator)` -> creds -- Check if creds
+  exist at `<mount>/<path>`, generate via `generator()` and write if `check_key` missing
+- `M.assert_secret(client, mount, path, expected_keys)` -> data -- Assert secret exists at
+  `<mount>/<path>` with all expected keys
 
 Example:
 
 ```lua
-local vault = require("assay.vault")
+local vault = require("assay.hashicorp.vault")
 local c = vault.authenticated_client("http://vault:8200")
 c.kv:put("secrets", "myapp/db", {username = "admin", password = crypto.random(32)})
 local creds = c.kv:get("secrets", "myapp/db")

--- a/llms.txt
+++ b/llms.txt
@@ -42,7 +42,7 @@
 - [assay.traefik](https://assay.rs/modules/traefik.html): Traefik routers, services, middlewares
 
 ## Security & Identity
-- [assay.vault](https://assay.rs/modules/vault.html): HashiCorp Vault KV, transit, PKI, auth
+- [assay.hashicorp.vault](https://assay.rs/modules/vault.html): HashiCorp Vault KV, transit, PKI, auth
 - [assay.openbao](https://assay.rs/modules/openbao.html): OpenBao (Vault API-compatible)
 - [assay.certmanager](https://assay.rs/modules/certmanager.html): cert-manager certificates, issuers, ACME
 - [assay.eso](https://assay.rs/modules/eso.html): External Secrets Operator

--- a/site/static/llms.txt
+++ b/site/static/llms.txt
@@ -40,7 +40,7 @@
 - [assay.traefik](https://assay.rs/modules/traefik.html): Traefik routers, services, middlewares
 
 ## Security & Identity
-- [assay.vault](https://assay.rs/modules/vault.html): HashiCorp Vault KV, transit, PKI, auth
+- [assay.hashicorp.vault](https://assay.rs/modules/vault.html): HashiCorp Vault KV, transit, PKI, auth
 - [assay.openbao](https://assay.rs/modules/openbao.html): OpenBao (Vault API-compatible)
 - [assay.certmanager](https://assay.rs/modules/certmanager.html): cert-manager certificates, issuers, ACME
 - [assay.eso](https://assay.rs/modules/eso.html): External Secrets Operator


### PR DESCRIPTION
Closes #92.

## Summary

- Move `stdlib/hashicorp_vault.lua` → `stdlib/hashicorp/vault.lua`; module doc updated to `@module assay.hashicorp.vault`
- Add `stdlib/hashicorp.lua` umbrella re-exporting `vault` (mirrors `ory.lua`); leaves room for future submodules (consul, nomad, boundary, terraform, packer, waypoint)
- Fix `M.ensure_credentials` and `M.assert_secret` — both hardcoded the KV mount as `"secrets"` and were unusable against any other mount. Both now take an explicit `mount` arg
- Update `assay.openbao` alias to require new path
- Update all tests, docs, llms.txt, CHANGELOG
- Bump `assay-lua` 0.15.3 → 0.15.4

## Breaking changes (no back-compat shim, per discussion)

- `require("assay.hashicorp_vault")` → `require("assay.hashicorp.vault")`
- `ensure_credentials(c, path, key, gen)` → `ensure_credentials(c, mount, path, key, gen)`
- `assert_secret(c, path, keys)` → `assert_secret(c, mount, path, keys)`

## Test plan

- [x] `cargo build -p assay-lua` clean
- [x] `cargo clippy -p assay-lua --tests -- -D warnings` clean
- [x] `cargo test -p assay-lua --test stdlib_hashicorp_vault` — 50 passed
- [x] `cargo test -p assay-lua --test stdlib_openbao_alias` — 3 passed
- [x] `cargo test -p assay-lua --test stdlib_postgres` — 6 passed
- [x] `cargo test -p assay-lua --test fs_require` — 8 passed
- [x] `cargo test -p assay-lua --test discovery` — 28 passed
- [x] `cargo test -p assay-lua --test modules_cmd` — 6 passed
- [x] `cargo test -p assay-lua --test stdlib_vault` (engine native vault, unaffected) — 7 passed