### PR TITLE
engine: embedded mode as a first-class concept

### DIFF
--- a/crates/assay-engine/src/embedded.rs
+++ b/crates/assay-engine/src/embedded.rs
@@ -1,8 +1,8 @@
 //! Embedded-mode entrypoints for `assay-engine`.
 //!
-//! Use case: a parent binary (knowhere v2, …) wants to compose engine
-//! into its own [`axum::Router`] rather than running engine standalone
-//! via [`crate::run`].
+//! Use case: a parent binary wants to compose engine into its own
+//! [`axum::Router`] rather than running engine standalone via
+//! [`crate::run`].
 //!
 //! ```no_run
 //! # async fn example() -> anyhow::Result<()> {

--- a/crates/assay-engine/src/embedded.rs
+++ b/crates/assay-engine/src/embedded.rs
@@ -1,0 +1,280 @@
+//! Embedded-mode entrypoints for `assay-engine`.
+//!
+//! Use case: a parent binary (knowhere v2, …) wants to compose engine
+//! into its own [`axum::Router`] rather than running engine standalone
+//! via [`crate::run`].
+//!
+//! ```no_run
+//! # async fn example() -> anyhow::Result<()> {
+//! use assay_engine::embedded;
+//! use assay_engine::config::EngineConfig;
+//! use std::path::Path;
+//!
+//! let cfg = EngineConfig::from_file(Path::new("engine.toml"))?;
+//! let engine = embedded::build(cfg).await?;
+//! // Mount engine.router on parent's listener
+//! // Use engine.pool for parent's queries (engine confines its
+//! //   writes to its own schemas)
+//! # let _ = engine;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! The standalone [`crate::run`] is implemented as a thin wrapper
+//! around [`build`] + a serve loop; standalone behaviour is unchanged.
+//!
+//! # Compared to the previous (now-closed) PR exposing four
+//! # `pub fn build_*_ctx_*` helpers
+//!
+//! Embedded mode is a first-class concept here: one type, one
+//! function, one symmetric `migrate` helper. Internal ctx-builders
+//! (`build_auth_ctx_{pg,sqlite}`, `build_vault_ctx_{pg,sqlite}`)
+//! stay `pub(crate)` — they are implementation details. Preconditions
+//! that prevent operator lockout (no operator users + no admin
+//! api-keys + no external issuers) are enforced inside [`build`] and
+//! cannot be skipped.
+
+use std::sync::Arc;
+
+use assay_dashboard::{DashboardCtx, WhitelabelConfig};
+use assay_domain::events::EngineEventBus;
+use assay_workflow::{WorkflowStore, WorkflowCtx};
+
+use crate::config::EngineConfig;
+use crate::init::EngineBoot;
+use crate::state::EngineState;
+
+/// Engine composed for embedding into a parent binary. See module
+/// docs.
+///
+/// Marked `#[non_exhaustive]` so future fields (graceful-shutdown
+/// handle, metrics handle, …) can be added without breaking
+/// downstream pattern-matching.
+#[non_exhaustive]
+pub struct EmbeddedEngine {
+    /// Engine's [`axum::Router`]. Mount on parent's listener at root,
+    /// or under a sub-path. URL surface includes:
+    ///   - `/api/v1/engine/*` — engine + per-module APIs
+    ///   - `/auth/*` — OIDC spec endpoints (when auth module enabled)
+    ///   - `/api/v1/vault/*` — vault APIs (when vault module enabled)
+    ///   - `/workflow/`, `/auth/console`, `/engine/console`,
+    ///     `/vault/console` — assay-dashboard SPAs
+    pub router: axum::Router,
+
+    /// Backend-typed pool engine's modules use. Parent may share for
+    /// its own queries; engine confines writes to its own schemas
+    /// (`engine.*`, `workflow.*`, `auth.*`, `vault.*` on PG; per-
+    /// module `.db` files on sqlite via ATTACH).
+    pub pool: EmbeddedPool,
+
+    /// This engine instance's `engine.instances` row id. Surface in
+    /// parent's introspection endpoints if useful.
+    pub instance_id: uuid::Uuid,
+
+    /// Names of modules attached/enabled at boot. Mirrors
+    /// `EngineState::modules` but cloned out so the parent doesn't
+    /// need to keep an `Arc<EngineState>` around.
+    pub modules: Vec<String>,
+
+    /// `assay-engine` crate version.
+    pub engine_version: &'static str,
+}
+
+/// Backend-typed pool. Engine's internal code paths are backend-
+/// specific (PG advisory locks, SQLite ATTACH for multi-module DB
+/// files); we expose typed pools so downstream can dispatch on the
+/// variant explicitly rather than guess.
+///
+/// Marked `#[non_exhaustive]` so future backends (e.g., MySQL) can
+/// be added without breaking exhaustive matches.
+#[non_exhaustive]
+pub enum EmbeddedPool {
+    #[cfg(feature = "backend-postgres")]
+    Postgres(sqlx::PgPool),
+    #[cfg(feature = "backend-sqlite")]
+    Sqlite(sqlx::SqlitePool),
+}
+
+/// Build engine for embedding. Internally:
+///
+///   1. Open pool against `cfg.backend` via [`EngineBoot::run`]
+///      (which also runs engine + per-module schema migrations).
+///   2. Bootstrap module contexts (auth, vault, workflow).
+///   3. **Enforce preconditions** — refuse to start when auth is on
+///      and the deployment has no operator users, no admin api-keys,
+///      and no external OIDC issuers (would lock the operator out).
+///   4. Compose [`axum::Router`] via [`crate::server::build_app`].
+///   5. Spawn engine's background tasks (events outbox cleanup;
+///      module-specific schedulers spawn during ctx construction).
+///
+/// Returns `Err` on any of: pool-open failure, migration failure,
+/// ctx-build failure, precondition failure. The `Err` carries a
+/// helpful operator-facing message when the cause is configuration.
+pub async fn build(cfg: EngineConfig) -> anyhow::Result<EmbeddedEngine> {
+    let boot = EngineBoot::run(&cfg).await?;
+    match boot {
+        #[cfg(feature = "backend-postgres")]
+        EngineBoot::Postgres(b) => build_pg(cfg, b).await,
+        #[cfg(feature = "backend-sqlite")]
+        EngineBoot::Sqlite(b) => build_sqlite(cfg, b).await,
+    }
+}
+
+#[cfg(feature = "backend-postgres")]
+async fn build_pg(
+    cfg: EngineConfig,
+    b: crate::init::PgBoot,
+) -> anyhow::Result<EmbeddedEngine> {
+    let store = assay_workflow::PostgresStore::from_pool(b.pool.clone())
+        .await
+        .map_err(|e| anyhow::anyhow!("workflow store (pg): {e}"))?;
+    let auth_ctx = crate::build_auth_ctx_pg(&cfg, &b.pool).await?;
+    #[cfg(feature = "vault")]
+    let vault_ctx = crate::build_vault_ctx_pg(&b.modules, &b.pool).await?;
+    #[cfg(not(feature = "vault"))]
+    let vault_ctx: Option<()> = None;
+
+    compose(
+        cfg,
+        store,
+        b.bus,
+        b.modules,
+        b.instance_id,
+        Some(auth_ctx),
+        vault_ctx,
+        EmbeddedPool::Postgres(b.pool),
+    )
+    .await
+}
+
+#[cfg(feature = "backend-sqlite")]
+async fn build_sqlite(
+    cfg: EngineConfig,
+    b: crate::init::SqliteBoot,
+) -> anyhow::Result<EmbeddedEngine> {
+    let store = assay_workflow::SqliteStore::from_attached_pool(b.pool.clone())
+        .await
+        .map_err(|e| anyhow::anyhow!("workflow store (sqlite): {e}"))?;
+    let auth_ctx = crate::build_auth_ctx_sqlite(&cfg, &b.pool).await?;
+    #[cfg(feature = "vault")]
+    let vault_ctx = crate::build_vault_ctx_sqlite(&b.modules, &b.pool).await?;
+    #[cfg(not(feature = "vault"))]
+    let vault_ctx: Option<()> = None;
+
+    compose(
+        cfg,
+        store,
+        b.bus,
+        b.modules,
+        b.instance_id,
+        Some(auth_ctx),
+        vault_ctx,
+        EmbeddedPool::Sqlite(b.pool),
+    )
+    .await
+}
+
+/// Common composition step shared between PG + SQLite paths.
+///
+/// Mirrors the body of the previous private `run_with_store` (now
+/// removed) minus the final `server::serve` call: builds the Lua-
+/// VM-equivalent state container, spawns the engine_events cleanup
+/// task, and constructs the [`axum::Router`]. The caller (this
+/// module's `build`, or the standalone `run` wrapper) decides what
+/// to do with the resulting router.
+async fn compose<S: WorkflowStore + Clone + 'static>(
+    cfg: EngineConfig,
+    store: S,
+    bus: Arc<dyn EngineEventBus>,
+    modules: Vec<String>,
+    instance_id: uuid::Uuid,
+    auth_ctx: Option<assay_auth::AuthCtx>,
+    #[cfg(feature = "vault")] vault_ctx: Option<assay_vault::VaultCtx>,
+    #[cfg(not(feature = "vault"))] _vault_ctx: Option<()>,
+    pool: EmbeddedPool,
+) -> anyhow::Result<EmbeddedEngine> {
+    // Precondition: refuse to start when auth is on and no operator
+    // user / api-key / external issuer is configured. Same logic as
+    // the previous run_with_store, lifted unchanged.
+    if let Some(auth) = auth_ctx.as_ref() {
+        let user_count = auth
+            .users
+            .count_users(None)
+            .await
+            .map_err(|e| anyhow::anyhow!("count auth.users: {e}"))?;
+        if user_count == 0
+            && cfg.auth.admin_api_keys.is_empty()
+            && cfg.auth.external_issuers().is_empty()
+        {
+            anyhow::bail!(
+                "engine refuses to start: no operator users exist, \
+                 `auth.admin_api_keys` is empty, and no external issuers \
+                 are configured. Either run `assay-engine bootstrap-admin \
+                 --email <e> --password <p>` to seed the first user, add \
+                 at least one entry to `auth.admin_api_keys` in \
+                 engine.toml as a break-glass, or configure \
+                 `[[auth.external_issuers]]` with an upstream OIDC \
+                 provider (e.g. Hydra) that mints the JWTs your callers \
+                 forward."
+            );
+        }
+    }
+
+    let workflow_ctx: Arc<WorkflowCtx<S>> =
+        crate::server::build_workflow_ctx_with_bus(store, Arc::clone(&bus));
+
+    // Hourly sweep of the engine_events outbox. Detached — the handle
+    // lives for the process lifetime; nothing to await for clean
+    // shutdown (prune is idempotent, missed tick is fine).
+    tokio::spawn(assay_workflow::events_cleanup::run_events_cleanup(
+        Arc::clone(&bus),
+        std::time::Duration::from_secs(3600),
+        cfg.engine_events_ttl_secs,
+    ));
+
+    let whitelabel = Arc::new(WhitelabelConfig::from_env());
+    let asset_version = env!("CARGO_PKG_VERSION").to_string();
+    let dashboard_ctx = Arc::new(DashboardCtx::new(whitelabel, asset_version));
+    let admin_api_keys = Arc::new(cfg.auth.admin_api_keys.clone());
+    let started_at = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs_f64();
+    let engine_config = Arc::new(cfg);
+
+    let state = EngineState {
+        workflow: workflow_ctx,
+        dashboard: dashboard_ctx,
+        auth: auth_ctx,
+        #[cfg(feature = "vault")]
+        vault: vault_ctx,
+        admin_api_keys,
+        modules: Arc::new(modules.clone()),
+        instance_id,
+        engine_version: env!("CARGO_PKG_VERSION"),
+        started_at,
+        engine_config,
+    };
+
+    let router = crate::server::build_app(state);
+
+    Ok(EmbeddedEngine {
+        router,
+        pool,
+        instance_id,
+        modules,
+        engine_version: env!("CARGO_PKG_VERSION"),
+    })
+}
+
+/// Run engine + per-module schema migrations against the configured
+/// backend. No runtime state is built, no background tasks are
+/// spawned. Idempotent — calling on an up-to-date schema is a no-op.
+///
+/// Used by parent binaries that want a `migrate` subcommand without
+/// booting workflow scheduler / vault unseal / etc. Equivalent to
+/// `EngineBoot::run(cfg).await?;` with a more discoverable name.
+pub async fn migrate(cfg: &EngineConfig) -> anyhow::Result<()> {
+    let _boot = EngineBoot::run(cfg).await?;
+    Ok(())
+}

--- a/crates/assay-engine/src/lib.rs
+++ b/crates/assay-engine/src/lib.rs
@@ -39,11 +39,8 @@
 
 use std::sync::Arc;
 
-use assay_dashboard::{DashboardCtx, WhitelabelConfig};
-use assay_domain::events::EngineEventBus;
-use assay_workflow::WorkflowStore;
-
 pub mod config;
+pub mod embedded;
 pub mod engine_api;
 pub mod init;
 pub mod server;
@@ -60,53 +57,16 @@ pub use config::{
 };
 pub use state::{AdminApiKeys, EngineState};
 
-/// Top-level entrypoint: pick the backend from config, build state, serve.
+/// Top-level entrypoint for the standalone `assay-engine` binary.
+/// Picks the backend from config, composes engine via
+/// [`embedded::build`], and serves forever on `cfg.server.bind_addr`.
+///
+/// For embedded use (composing engine into a parent binary's
+/// router), call [`embedded::build`] directly.
 pub async fn run(cfg: EngineConfig) -> anyhow::Result<()> {
-    let boot = init::EngineBoot::run(&cfg).await?;
-    match boot {
-        #[cfg(feature = "backend-postgres")]
-        init::EngineBoot::Postgres(b) => {
-            let store = assay_workflow::PostgresStore::from_pool(b.pool.clone())
-                .await
-                .map_err(|e| anyhow::anyhow!("workflow store (pg): {e}"))?;
-            let auth_ctx = build_auth_ctx_pg(&cfg, &b.pool).await?;
-            #[cfg(feature = "vault")]
-            let vault_ctx = build_vault_ctx_pg(&b.modules, &b.pool).await?;
-            #[cfg(not(feature = "vault"))]
-            let vault_ctx: Option<()> = None;
-            run_with_store(
-                cfg,
-                store,
-                b.bus,
-                b.modules,
-                b.instance_id,
-                Some(auth_ctx),
-                vault_ctx,
-            )
-            .await
-        }
-        #[cfg(feature = "backend-sqlite")]
-        init::EngineBoot::Sqlite(b) => {
-            let store = assay_workflow::SqliteStore::from_attached_pool(b.pool.clone())
-                .await
-                .map_err(|e| anyhow::anyhow!("workflow store (sqlite): {e}"))?;
-            let auth_ctx = build_auth_ctx_sqlite(&cfg, &b.pool).await?;
-            #[cfg(feature = "vault")]
-            let vault_ctx = build_vault_ctx_sqlite(&b.modules, &b.pool).await?;
-            #[cfg(not(feature = "vault"))]
-            let vault_ctx: Option<()> = None;
-            run_with_store(
-                cfg,
-                store,
-                b.bus,
-                b.modules,
-                b.instance_id,
-                Some(auth_ctx),
-                vault_ctx,
-            )
-            .await
-        }
-    }
+    let bind_addr = cfg.server.bind_addr.clone();
+    let engine = embedded::build(cfg).await?;
+    server::bind_and_serve(&bind_addr, engine.router).await
 }
 
 /// Build the vault context iff the runtime `engine.modules.vault.enabled`
@@ -510,82 +470,8 @@ fn build_passkey_manager(
     }
 }
 
-async fn run_with_store<S: WorkflowStore + Clone + 'static>(
-    cfg: EngineConfig,
-    store: S,
-    bus: Arc<dyn EngineEventBus>,
-    modules: Vec<String>,
-    instance_id: uuid::Uuid,
-    auth_ctx: Option<assay_auth::AuthCtx>,
-    #[cfg(feature = "vault")] vault_ctx: Option<assay_vault::VaultCtx>,
-    #[cfg(not(feature = "vault"))] _vault_ctx: Option<()>,
-) -> anyhow::Result<()> {
-    // The engine refuses to start unless there's at least one operator
-    // user (created via `bootstrap-admin`) or at least one entry in
-    // `admin_api_keys` as a break-glass. Without either, every admin
-    // request would 401 and the operator would be locked out — fail
-    // fast with a helpful message instead.
-    if let Some(auth) = auth_ctx.as_ref() {
-        let user_count = auth
-            .users
-            .count_users(None)
-            .await
-            .map_err(|e| anyhow::anyhow!("count auth.users: {e}"))?;
-        if user_count == 0
-            && cfg.auth.admin_api_keys.is_empty()
-            && cfg.auth.external_issuers().is_empty()
-        {
-            anyhow::bail!(
-                "engine refuses to start: no operator users exist, \
-                 `auth.admin_api_keys` is empty, and no external issuers \
-                 are configured. Either run `assay-engine bootstrap-admin \
-                 --email <e> --password <p>` to seed the first user, add \
-                 at least one entry to `auth.admin_api_keys` in \
-                 engine.toml as a break-glass, or configure \
-                 `[[auth.external_issuers]]` with an upstream OIDC \
-                 provider (e.g. Hydra) that mints the JWTs your callers \
-                 forward."
-            );
-        }
-    }
-
-    let workflow_ctx = server::build_workflow_ctx_with_bus(store, Arc::clone(&bus));
-
-    // Hourly sweep of the engine_events outbox. Detached — the handle
-    // lives for the process lifetime; there's nothing to await for
-    // clean shutdown (prune is idempotent so a missed tick is fine).
-    tokio::spawn(assay_workflow::events_cleanup::run_events_cleanup(
-        Arc::clone(&bus),
-        std::time::Duration::from_secs(3600),
-        cfg.engine_events_ttl_secs,
-    ));
-
-    let whitelabel = Arc::new(WhitelabelConfig::from_env());
-    let asset_version = env!("CARGO_PKG_VERSION").to_string();
-    let dashboard_ctx = Arc::new(DashboardCtx::new(whitelabel, asset_version));
-    let admin_api_keys = Arc::new(cfg.auth.admin_api_keys.clone());
-    // Wall-clock seconds since epoch — uptime baseline for the
-    // /api/v1/engine/core/info response. Captured here (just before serve)
-    // so the value reflects the moment HTTP becomes ready, not the
-    // earlier boot-sequence start.
-    let started_at = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs_f64();
-    let bind_addr = cfg.server.bind_addr.clone();
-    let engine_config = Arc::new(cfg);
-    let state = EngineState {
-        workflow: workflow_ctx,
-        dashboard: dashboard_ctx,
-        auth: auth_ctx,
-        #[cfg(feature = "vault")]
-        vault: vault_ctx,
-        admin_api_keys,
-        modules: Arc::new(modules),
-        instance_id,
-        engine_version: env!("CARGO_PKG_VERSION"),
-        started_at,
-        engine_config,
-    };
-    server::serve(&bind_addr, state).await
-}
+// `run_with_store` (the previous private composition helper) is gone.
+// Its body lives in `embedded::compose` (this module's `embedded` sibling),
+// minus the final `server::serve` call. `pub async fn run` above
+// composes the engine via `embedded::build` and then binds + serves
+// the resulting `axum::Router` via `server::bind_and_serve`.

--- a/crates/assay-engine/src/server.rs
+++ b/crates/assay-engine/src/server.rs
@@ -219,11 +219,29 @@ async fn workflow_gate_middleware<S: WorkflowStore + Clone + 'static>(
 use axum::response::IntoResponse;
 
 /// Bind a TCP listener on `bind_addr` and serve the composed app.
+///
+/// Convenience wrapper that composes [`EngineState`] into an
+/// [`axum::Router`] via [`build_app`] and hands off to
+/// [`bind_and_serve`]. Used by the standalone `assay-engine` binary.
 pub async fn serve<S: WorkflowStore + Clone + 'static>(
     bind_addr: &str,
     state: EngineState<S>,
 ) -> anyhow::Result<()> {
     let app = build_app(state);
+    bind_and_serve(bind_addr, app).await
+}
+
+/// Bind a TCP listener on `bind_addr` and serve a pre-built
+/// [`axum::Router`].
+///
+/// Used by [`crate::run`] (after `embedded::build` returns the
+/// composed router) and by downstream embedders who want to add
+/// their own middleware / merge with their own router before
+/// serving.
+pub async fn bind_and_serve(
+    bind_addr: &str,
+    app: axum::Router,
+) -> anyhow::Result<()> {
     let listener = tokio::net::TcpListener::bind(bind_addr)
         .await
         .map_err(|e| anyhow::anyhow!("bind {bind_addr}: {e}"))?;

--- a/crates/assay/src/lua/builtins/http.rs
+++ b/crates/assay/src/lua/builtins/http.rs
@@ -30,9 +30,9 @@ use tracing::error;
 /// Public newtype wrapping an [`axum::Router`] so it can round-trip through
 /// the Lua VM as a [`mlua::AnyUserData`].
 ///
-/// Downstream binaries (e.g. knowhere) build a Rust-side `axum::Router`
-/// (typically holding `assay-engine` HTTP routes), wrap it in this type,
-/// stash it in a Lua global (or pass it positionally), and the Lua-defined
+/// Downstream binaries build a Rust-side `axum::Router` (typically
+/// holding `assay-engine` HTTP routes), wrap it in this type, stash it in
+/// a Lua global (or pass it positionally), and the Lua-defined
 /// `http.serve_with_extra(port, routes, extra)` builtin pulls the router
 /// back out and folds its routes into the dispatcher.
 ///
@@ -1145,10 +1145,10 @@ mod tests {
     use mlua::Lua;
 
     /// `LuaAxumRouter` wraps an `axum::Router` so it can be passed through Lua
-    /// as `mlua` userdata. This test mirrors what knowhere does at startup:
-    /// build a Router in Rust, wrap it in `LuaAxumRouter`, hand it to the Lua
-    /// VM via `create_userdata`, stash it as a global, then read it back out
-    /// and confirm the round-trip preserves the underlying type.
+    /// as `mlua` userdata. This test mirrors a typical downstream embedding
+    /// pattern: build a Router in Rust, wrap it in `LuaAxumRouter`, hand it
+    /// to the Lua VM via `create_userdata`, stash it as a global, then read
+    /// it back out and confirm the round-trip preserves the underlying type.
     #[test]
     fn lua_axum_router_round_trips_through_mlua_globals() {
         let lua = Lua::new();


### PR DESCRIPTION
## Summary

Replaces the closed [#103](https://github.com/developerinlondon/assay/pull/103) (which exposed four ctx-builder helpers publicly). Introduces embedded mode as a first-class concept — one type, one enum, two functions — instead of growing public surface linearly with engine's module count.

```rust
// New public surface in assay-engine
pub mod embedded {
    pub struct EmbeddedEngine {
        pub router: axum::Router,
        pub pool: EmbeddedPool,
        pub instance_id: uuid::Uuid,
        pub modules: Vec<String>,
        pub engine_version: &'static str,
    }
    pub enum EmbeddedPool { Postgres(sqlx::PgPool), Sqlite(sqlx::SqlitePool) }
    pub async fn build(cfg: EngineConfig) -> Result<EmbeddedEngine>;
    pub async fn migrate(cfg: &EngineConfig) -> Result<()>;
}
```

`build` opens the pool, runs migrations, bootstraps module contexts, **enforces preconditions** (no zero-users-no-keys lockout — same check that lived inside `run_with_store` previously), composes the `axum::Router` via `build_app`, and spawns engine_events cleanup. Standalone `pub async fn run(cfg)` becomes a thin wrapper that calls `embedded::build` then hands the router to a new `server::bind_and_serve` helper. `run_with_store` is removed (its body lives in private `embedded::compose`).

The four ctx-builders (\`build_auth_ctx_{pg,sqlite}\`, \`build_vault_ctx_{pg,sqlite}\`) stay \`pub(crate)\`. They are implementation details, not API.

## Why this shape vs. #103

#103 exposed four low-level orchestration helpers. Each new module would need its own \`pub fn build_<module>_ctx_*\` exposed; the public surface grew linearly with module count. Worse, the precondition check inside \`run_with_store\` could be bypassed by downstream callers using the public ctx-builders directly, allowing operators to ship engine binaries that boot but can't authenticate.

This PR makes embedded mode a real concept in the public API. Preconditions live inside \`build\`; downstream can't skip them. The single \`EmbeddedEngine\` struct is \`#[non_exhaustive]\` so future fields (graceful-shutdown handle, metrics handle, …) extend without breaking pattern-matching. \`EmbeddedPool\` is also \`#[non_exhaustive]\` — future backends can be added without breaking exhaustive matches.

## Net public-API change vs main

- **Added**: \`embedded\` module (1 struct, 1 enum, 2 functions). Plus \`server::bind_and_serve\`.
- **Unchanged**: \`run\`, \`EngineConfig\`, \`EngineState\`, \`server::build_app\`, \`server::serve\`, \`server::build_workflow_ctx[_with_bus]\`, \`init::EngineBoot\`.
- **Removed**: nothing public. Internally, \`run_with_store\` is gone (replaced by private \`embedded::compose\`).

vs #103 (closed): 4 public ctx-builder fns go away; 1 public module is added. Net: smaller public surface, no precondition bypass possible.

## Knowhere v2 use

Knowhere's \`engine_bridge.rs\` collapses to a one-line call:

\`\`\`rust
pub async fn boot_engine(cfg: EngineConfig) -> Result<PreparedEngine> {
    let engine = assay_engine::embedded::build(cfg).await?;
    Ok(PreparedEngine {
        router: engine.router, pool: engine.pool,
        instance_id: engine.instance_id, modules: engine.modules,
    })
}
\`\`\`

No replication of orchestration. No drift risk. Preconditions enforced upstream.

## Stacked on top of #104

This PR is rebased onto \`feature/http-serve-extra-router\` (#104), since knowhere v2 needs both. After #104 merges, the base auto-rebases.

## Test plan

- [x] \`cargo test -p assay-engine --lib\` — 19 tests pass (existing engine internals)
- [x] Standalone behaviour preserved — \`run()\` is a thin wrapper around \`embedded::build\` + \`bind_and_serve\`; identical observable behaviour
- [x] Knowhere v0.2.0-alpha.1 binary smoke (6 tests including engine endpoint coverage) passes against the new API
- [x] Knowhere v0.2.0-alpha.1 deployed to a real systemd unit; endpoints all 200, memory 4.6M / 5.6M peak
- [ ] Add explicit \`embedded::build\` integration tests (follow-up; currently relying on the \`run()\` test path which exercises the same code)