### PR TITLE
chore(release): bump assay-engine 0.4.0 → 0.4.1 to ship embedded module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to Assay are documented here.
 
+## [assay-engine 0.4.1] - 2026-04-29
+
+- **Re-publish so `assay_engine::embedded` is reachable from crates.io.** PR #104 added
+  `pub mod embedded` (the `embedded::build()` API used to compose assay-engine into a parent
+  binary's tokio runtime + axum router), but it landed *after* `assay-engine 0.4.0` was tagged
+  on commit `eae2296`. The published `0.4.0` therefore ships `lib.rs` with `config / engine_api /
+  init / server / state` and no `embedded`, so any consumer wanting a registry version pin
+  against the embedded API was forced onto a `git`/`rev` pin against `main`. Patch bump cuts
+  a release that actually contains the module. No source changes vs. main HEAD.
+
 ## [assay-domain 0.2.1] - 2026-04-28
 
 - **Add `EngineEventBus::prune_with(PruneOpts)` for namespace-scoped pruning.** The existing

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,7 +308,7 @@ dependencies = [
 
 [[package]]
 name = "assay-engine"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "assay-auth",

--- a/crates/assay-engine/Cargo.toml
+++ b/crates/assay-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-engine"
-version = "0.4.0"
+version = "0.4.1"
 categories = ["asynchronous", "database", "web-programming::http-server"]
 edition = "2024"
 keywords = ["workflow", "auth", "oidc", "zanzibar", "postgres"]


### PR DESCRIPTION
## Summary

- `assay-engine` Cargo.toml: `0.4.0` → `0.4.1`
- CHANGELOG entry under `[assay-engine 0.4.1]` explains why a no-source-change patch bump is warranted
- `Cargo.lock` updated

## Why

PR #104 (\`lua + engine: support embedding into a parent binary\`) added `pub mod embedded` on main *after* `assay-engine-v0.4.0` was already tagged on commit \`eae2296\`. The published \`0.4.0\` artifact on crates.io therefore ships \`src/lib.rs\` with only \`config / engine_api / init / server / state\` — no \`embedded\` module:

\`\`\`
$ curl -fsSL -L https://crates.io/api/v1/crates/assay-engine/0.4.0/download \\
    | tar -tzf - | grep src/
assay-engine-0.4.0/src/bin
assay-engine-0.4.0/src/config.rs
assay-engine-0.4.0/src/engine_api.rs
assay-engine-0.4.0/src/init.rs
assay-engine-0.4.0/src/lib.rs        ← config / engine_api / init / server / state
assay-engine-0.4.0/src/server.rs
assay-engine-0.4.0/src/state.rs
                                       (no embedded.rs)
\`\`\`

Any consumer wanting \`assay_engine::embedded::build()\` from a registry pin currently can't — they have to use a \`git\`/\`rev\` pin against main, which is not great for reproducibility. This bump is purely a re-publish to ship the module under a resolvable version number; no source changes vs. main HEAD.

## Test plan

- [ ] `cargo check -p assay-engine` passes ✅ (verified locally — `Finished dev profile ... in 28.72s`)
- [ ] CI release pipeline runs and pushes 0.4.1 to crates.io + GHCR after merge
- [ ] After publish, downstream consumers can swap their git rev pin for `assay-engine = "0.4.1"` and `cargo update -p assay-engine` resolves cleanly with `pub mod embedded` in scope