### PR TITLE
fix(hostops): link the Admin parent in /audit's page-eyebrow

### DIFF
--- a/libs/hostops/templates/audit.html
+++ b/libs/hostops/templates/audit.html
@@ -1,6 +1,6 @@
 <header class="page-header">
   <div>
-    <div class="page-eyebrow">Admin · audit log</div>
+    <div class="page-eyebrow"><a href="/audit">Admin</a> · audit log</div>
     <h1 class="page-title">Audit log</h1>
   </div>
   <div class="page-meta">


### PR DESCRIPTION
The /audit page is the Admin landing page in the sidebar, but its breadcrumb rendered "Admin" as plain text while every other page that has a sibling sidebar entry links its parent (e.g. /tunnels uses <a href="/tunnels">Networks</a> · tunnels — link to itself, mirroring how Networks itself opens /tunnels). Apply the same pattern so /audit reads <a href="/audit">Admin</a> · audit log; the link is now clickable and consistent with the rest of the chrome.