### PR TITLE
release: assay-lua 0.15.9 (bundles hostops 0.1.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to Assay are documented here.
 
+## hostops 0.1.3 — 2026-05-04
+
+### Added
+
+- `hostops.mount` `extra_sidebar_links` accepts a grouped entry shape in addition to the flat one. A
+  grouped entry (`{label, children = { {href, label, nav_active}, ... }}`) renders as a
+  `<details data-section><summary>label</summary>children</details>` block in the sidebar. The
+  existing `app.js` disclosure script persists open state in localStorage; children sit one level
+  indented and pick up the base `.nav a` typography.
+- Mutex sidebar highlight: clicking a group summary moves the active treatment (background + accent
+  left bar) onto the summary while clearing `.active` from any other sidebar link, so only one entry
+  highlights at a time. Reload re-syncs to whatever the URL is.
+- Smoke-test fixture in `tests-lua/smoke.test.lua` covers both shapes — flat link plus grouped entry
+  render assertions.
+
+### Changed
+
+- `templates/audit.html` page-eyebrow now reads `<a href="/audit">Admin</a> · audit log` so the
+  parent segment is a real link, matching how `Networks` is linked from `/tunnels` and the rest of
+  hostops's eyebrow chrome.
+
+## 0.15.9 — 2026-05-04
+
+### Changed
+
+- Bundles `hostops 0.1.3` (grouped sidebar entries + audit breadcrumb fix). No assay-lua source
+  changes vs `0.15.8` — this release packages the merged hostops library updates as
+  `assay-lib-hostops-0.1.3.tar.gz` alongside the runtime binary.
+
 ## hostops 0.1.2 — 2026-05-03
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "assay-lua"
-version = "0.15.8"
+version = "0.15.9"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/assay/Cargo.toml
+++ b/crates/assay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-lua"
-version = "0.15.8"
+version = "0.15.9"
 categories = ["command-line-utilities", "development-tools::testing"]
 edition = "2024"
 homepage = "https://assay.rs"


### PR DESCRIPTION
No assay-lua source changes vs 0.15.8. The bump exists to trigger the release pipeline so it packages libs/hostops at its current VERSION (0.1.3) as a release asset (assay-lib-hostops-0.1.3.tar.gz). Without this bump, detect.assay-lua-bumped stays false, libraries+binaries skip, and release-assay-lua short-circuits on "release already exists" — so hostops 0.1.3 never ships as a tarball.

What's in hostops 0.1.3 (already merged on main):

  - Grouped sidebar entries via <details data-section>: extra_sidebar_links accepts a {label, children = {...}} shape that renders as a collapsible group with localStorage-persisted state. (#121)
  - audit.html page-eyebrow now links Admin → /audit instead of plain text, matching Networks's link-to-self pattern on /tunnels. (#122)

Once this lands on main, the release workflow auto-runs and produces:

  - tag        assay-lua-v0.15.9
  - release    title "assay-lua 0.15.9", changelog notes from § 0.15.9
  - assets     assay-linux-x86_64, assay-darwin-aarch64,
               assay-libs-0.15.9.tar.gz,
               assay-lib-hostops-0.1.3.tar.gz,
               lua-checksums.txt
  - crates.io  assay-lua@0.15.9
  - docker     ghcr.io/developerinlondon/assay:{0.15.9,latest}

Downstream gondor's Manifest.lua already pins hostops 0.1.3, so once this release lands `assay install --manifest Manifest.lua` will work on a fresh host.