### PR TITLE
ci: retry playwright install on apt mirror failures

### DIFF
--- a/crates/assay-engine/tests-e2e/moon.yml
+++ b/crates/assay-engine/tests-e2e/moon.yml
@@ -22,7 +22,7 @@ tasks:
       runInCI: true
 
   install-browsers:
-    command: "npx playwright install --with-deps chromium"
+    command: "bash $workspaceRoot/scripts/playwright-install-with-retry.sh chromium"
     deps:
       - "install"
       # Serialize against dashboard-e2e:install-browsers — both run

--- a/crates/assay-workflow/tests-e2e/moon.yml
+++ b/crates/assay-workflow/tests-e2e/moon.yml
@@ -22,7 +22,7 @@ tasks:
       runInCI: true
 
   install-browsers:
-    command: "npx playwright install --with-deps chromium"
+    command: "bash $workspaceRoot/scripts/playwright-install-with-retry.sh chromium"
     deps:
       - "install"
     options:

--- a/libs/sysops/tests-e2e/moon.yml
+++ b/libs/sysops/tests-e2e/moon.yml
@@ -22,7 +22,7 @@ tasks:
       runInCI: true
 
   install-browsers:
-    command: "npx playwright install --with-deps chromium"
+    command: "bash $workspaceRoot/scripts/playwright-install-with-retry.sh chromium"
     deps:
       - "install"
       # Serialize against engine-e2e + dashboard-e2e — all three run

--- a/scripts/playwright-install-with-retry.sh
+++ b/scripts/playwright-install-with-retry.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Wrap `npx playwright install --with-deps <browser>` in a retry loop with
+# linear backoff. Survives transient apt mirror failures (Ubuntu 521s,
+# Cloudflare blips) without forcing the whole CI run to be re-triggered.
+#
+# Usage:
+#   bash scripts/playwright-install-with-retry.sh chromium
+
+set -euo pipefail
+
+MAX_ATTEMPTS=${MAX_ATTEMPTS:-3}
+BROWSER=${1:-chromium}
+
+for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+    if npx playwright install --with-deps "$BROWSER"; then
+        exit 0
+    fi
+    if [[ "$attempt" -lt "$MAX_ATTEMPTS" ]]; then
+        delay=$((attempt * 15))
+        echo "[playwright-install] attempt $attempt/$MAX_ATTEMPTS failed; retrying in ${delay}s..." >&2
+        sleep "$delay"
+    fi
+done
+
+echo "[playwright-install] all $MAX_ATTEMPTS attempts failed" >&2
+exit 1


### PR DESCRIPTION
## Summary

- Adds `scripts/playwright-install-with-retry.sh` — wraps `npx playwright install --with-deps <browser>` in a 3-attempt loop with linear backoff (15s, 30s)
- Switches `engine-e2e`, `dashboard-e2e`, and `sysops-e2e` `install-browsers` tasks to use it

## Why

PR #126's CI failed once because Ubuntu's apt mirror returned 521 (Cloudflare upstream blip) during `playwright install --with-deps`. Whole 15-minute pipeline had to be re-run. Worst-case overhead with this fix is ~45s of retry sleep on a transient blip vs. a full re-run cycle.

## Test plan

- [ ] CI runs green
- [ ] If apt fails on first attempt, retry log line appears in `install-browsers` step output