### PR TITLE
fix(json): empty Lua table encodes as `{}` not `[]` (0.15.10)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,11 +54,26 @@ jobs:
             target: x86_64-unknown-linux-gnu
           - os: macos-14
             target: aarch64-apple-darwin
-    # On the linux row, route to the self-hosted runner when the actor
-    # is the maintainer; any other actor (Dependabot, future outside
-    # contributors) falls back to ubuntu-latest. The macOS row always
-    # uses GitHub-hosted — there is no local mac.
-    runs-on: ${{ matrix.os == 'ubuntu-latest' && github.actor == 'developerinlondon' && fromJSON('["self-hosted","linux","assay"]') || matrix.os }}
+    # Self-hosted runner routing.
+    #
+    # Linux row: routes to the maintainer's self-hosted runner whenever
+    # the actor is the maintainer; any other actor (Dependabot, outside
+    # contributors) falls back to `ubuntu-latest`.
+    #
+    # macOS row: opt-in via the repo variable `MAC_LOCAL_RUNNER` (set to
+    # `"true"` when a local mac runner is online; unset / any other value
+    # routes to GitHub-hosted `macos-14`). Still gated on actor so PRs
+    # from non-maintainers never depend on the local box being up. Toggle
+    # with `gh variable set MAC_LOCAL_RUNNER --body true` when starting
+    # the runner; unset (`gh variable delete MAC_LOCAL_RUNNER`) when
+    # stopping it. GitHub Actions has no native "fallback if offline"
+    # so the variable is the kill-switch.
+    runs-on: >-
+      ${{
+        (matrix.os == 'ubuntu-latest' && github.actor == 'developerinlondon' && fromJSON('["self-hosted","linux","assay"]'))
+        || (matrix.os == 'macos-14' && github.actor == 'developerinlondon' && vars.MAC_LOCAL_RUNNER == 'true' && fromJSON('["self-hosted","macos","assay"]'))
+        || matrix.os
+      }}
     timeout-minutes: 25
 
     steps:
@@ -260,7 +275,11 @@ jobs:
   sysops-e2e:
     name: sysops-e2e
     needs: changes
-    if: needs.changes.outputs.sysops == 'true' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.workflows == 'true'
+    # Heavy browser-test job. Triggered only when libs/ or workflow YAML
+    # change — rust-only PRs (e.g. crates/** edits) don't pay the
+    # ~10–15 min Playwright cycle. A rust regression that breaks sysops
+    # gets caught at the next libs/** PR or the release-libs build.
+    if: needs.changes.outputs.sysops == 'true' || needs.changes.outputs.workflows == 'true'
     runs-on: ${{ github.actor == 'developerinlondon' && fromJSON('["self-hosted","linux","assay"]') || 'ubuntu-latest' }}
     timeout-minutes: 20
     steps:
@@ -297,7 +316,8 @@ jobs:
   sysops-smoke:
     name: sysops-smoke
     needs: changes
-    if: needs.changes.outputs.sysops == 'true' || needs.changes.outputs.rust == 'true' || needs.changes.outputs.workflows == 'true'
+    # Same trigger narrowing as sysops-e2e: skip on rust-only PRs.
+    if: needs.changes.outputs.sysops == 'true' || needs.changes.outputs.workflows == 'true'
     runs-on: ${{ github.actor == 'developerinlondon' && fromJSON('["self-hosted","linux","assay"]') || 'ubuntu-latest' }}
     timeout-minutes: 15
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -240,7 +240,14 @@ jobs:
             target: aarch64-apple-darwin
             suffix: darwin-aarch64
             deps: ""
-    runs-on: ${{ matrix.os }}
+    # macOS row opt-in routes to the maintainer's local mac runner when
+    # `vars.MAC_LOCAL_RUNNER == 'true'`. See ci.yml `check` job for the
+    # full rationale and toggle commands.
+    runs-on: >-
+      ${{
+        (matrix.os == 'macos-14' && vars.MAC_LOCAL_RUNNER == 'true' && fromJSON('["self-hosted","macos","assay"]'))
+        || matrix.os
+      }}
     steps:
       - uses: actions/checkout@v6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to Assay are documented here.
 
+## 0.15.10 — 2026-05-05
+
+- Fix: `json.encode({})` now returns `"{}"` (was `"[]"`). Same fix applies to every empty
+  Lua table passed as a JSON body via the http builtin. Closes #129.
+- Add: `json.array(t?)` / `json.object(t?)` to pin a table's encoded shape.
+- Migration: callers that need `"[]"` for an empty table must use `json.array(t)`.
+
 ## hostops 0.1.3 — 2026-05-04
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -337,7 +337,7 @@ dependencies = [
 
 [[package]]
 name = "assay-lua"
-version = "0.15.9"
+version = "0.15.10"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/assay/Cargo.toml
+++ b/crates/assay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-lua"
-version = "0.15.9"
+version = "0.15.10"
 categories = ["command-line-utilities", "development-tools::testing"]
 edition = "2024"
 homepage = "https://assay.rs"

--- a/crates/assay/src/lua/builtins/json.rs
+++ b/crates/assay/src/lua/builtins/json.rs
@@ -17,11 +17,67 @@ pub fn register_json(lua: &Lua) -> mlua::Result<()> {
     })?;
     json_table.set("encode", encode_fn)?;
 
+    // json.array(t) / json.object(t) — escape hatches that pin the shape
+    // a table will encode to, regardless of its contents. They attach a
+    // `__jsontype` metatable marker that `lua_table_to_json` honours.
+    //
+    // Needed because Lua has one composite type (table) covering both
+    // arrays and objects, so the encoder has to guess intent. The empty
+    // case is genuinely ambiguous and the default (empty → object) is
+    // wrong for the rare caller that wants `[]`. Use `json.array({})` in
+    // that case. Symmetrically, `json.object` lets you force object
+    // shape on a sequential 1..N table — useful when an API expects a
+    // JSON object whose keys happen to be string-encoded integers.
+    let array_fn = lua.create_function(|lua, t: Option<mlua::Table>| {
+        let table = t.unwrap_or(lua.create_table()?);
+        attach_jsontype(lua, &table, "array")?;
+        Ok(table)
+    })?;
+    json_table.set("array", array_fn)?;
+
+    let object_fn = lua.create_function(|lua, t: Option<mlua::Table>| {
+        let table = t.unwrap_or(lua.create_table()?);
+        attach_jsontype(lua, &table, "object")?;
+        Ok(table)
+    })?;
+    json_table.set("object", object_fn)?;
+
     lua.globals().set("json", json_table)?;
     Ok(())
 }
 
+// Set or update the `__jsontype` field on a table's metatable. Preserves
+// any existing metatable so a caller that already has __index / __tostring
+// etc. doesn't lose them.
+fn attach_jsontype(lua: &Lua, table: &mlua::Table, kind: &str) -> mlua::Result<()> {
+    let mt = match table.metatable() {
+        Some(existing) => existing,
+        None => {
+            let new = lua.create_table()?;
+            table.set_metatable(Some(new.clone()))?;
+            new
+        }
+    };
+    mt.set("__jsontype", kind)?;
+    Ok(())
+}
+
+// Read the `__jsontype` marker from a table's metatable. Returns
+// "array" / "object" if explicitly set, None otherwise.
+fn jsontype_marker(table: &mlua::Table) -> Option<String> {
+    let mt = table.metatable()?;
+    match mt.get::<Value>("__jsontype").ok()? {
+        Value::String(s) => s.to_str().ok().map(|s| s.to_string()),
+        _ => None,
+    }
+}
+
 pub fn lua_table_to_json(table: &mlua::Table) -> mlua::Result<serde_json::Value> {
+    // Honour an explicit __jsontype marker before doing any heuristic.
+    // Lets callers force "object" on a 1..N table or "array" on an empty
+    // / sparse one, which the heuristic alone can't express.
+    let forced_kind = jsontype_marker(table);
+
     let mut is_array = true;
     let mut max_index: i64 = 0;
     let mut count: i64 = 0;
@@ -42,9 +98,27 @@ pub fn lua_table_to_json(table: &mlua::Table) -> mlua::Result<serde_json::Value>
         }
     }
 
-    if is_array && max_index == count {
-        let mut arr = Vec::with_capacity(max_index as usize);
-        for i in 1..=max_index {
+    // Decide the final shape. Order:
+    //   1. Explicit __jsontype marker wins.
+    //   2. Non-empty 1..N integer keys → array (existing behaviour).
+    //   3. Anything else → object. This includes the empty table, where
+    //      historically we emitted `[]` — which broke every assay caller
+    //      passing `{}` as a JSON request body, since "object" is what
+    //      they all wanted. See issue #129.
+    let encode_as_array = match forced_kind.as_deref() {
+        Some("array") => true,
+        Some("object") => false,
+        _ => is_array && count > 0 && max_index == count,
+    };
+
+    if encode_as_array {
+        let len = if is_array && count > 0 && max_index == count {
+            max_index
+        } else {
+            count
+        };
+        let mut arr = Vec::with_capacity(len.max(0) as usize);
+        for i in 1..=len {
             let val: Value = table.get(i)?;
             arr.push(lua_value_to_json(&val)?);
         }

--- a/crates/assay/tests/json.rs
+++ b/crates/assay/tests/json.rs
@@ -24,3 +24,96 @@ async fn test_json_array() {
     "#;
     run_lua(script).await.unwrap();
 }
+
+// Empty Lua tables encode to JSON objects (`{}`), not arrays (`[]`).
+// Regression test for issue #129 — every assay http builtin caller that
+// passed `{}` as a request body was silently shipping `[]`.
+#[tokio::test]
+async fn test_empty_table_encodes_as_object() {
+    let script = r#"
+        assert.eq(json.encode({}), "{}")
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+// json.array(t) escape hatch — pin a table to JSON array shape via the
+// __jsontype metatable marker, regardless of whether it's empty.
+#[tokio::test]
+async fn test_json_array_helper_pins_array_shape() {
+    let script = r#"
+        assert.eq(json.encode(json.array({})), "[]")
+        assert.eq(json.encode(json.array()), "[]")
+        assert.eq(json.encode(json.array({1, 2, 3})), "[1,2,3]")
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+// json.object(t) escape hatch — force object shape on a table whose keys
+// happen to be 1..N integers.
+#[tokio::test]
+async fn test_json_object_helper_pins_object_shape() {
+    let script = r#"
+        local t = json.object({ "a", "b", "c" })
+        local s = json.encode(t)
+        -- Object key order is not guaranteed by serde_json; check the
+        -- shape characters and content separately.
+        assert.eq(s:sub(1, 1), "{")
+        assert.eq(s:sub(-1), "}")
+        assert.contains(s, '"1":"a"')
+        assert.contains(s, '"2":"b"')
+        assert.contains(s, '"3":"c"')
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+// Sequential 1..N tables still encode as arrays (existing behaviour).
+#[tokio::test]
+async fn test_sequential_table_still_array() {
+    let script = r#"
+        assert.eq(json.encode({10, 20, 30}), "[10,20,30]")
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+// String-keyed tables encode as objects.
+#[tokio::test]
+async fn test_string_keyed_table_encodes_as_object() {
+    let script = r#"
+        local s = json.encode({ name = "assay" })
+        assert.eq(s, '{"name":"assay"}')
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+// Nested empties: an object with an empty-table field encodes the field
+// as `{}`, mirroring the top-level rule.
+#[tokio::test]
+async fn test_nested_empty_table_encodes_as_object() {
+    let script = r#"
+        assert.eq(json.encode({ inner = {} }), '{"inner":{}}')
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+// Mixed nesting: a top-level object with an explicit empty array field.
+#[tokio::test]
+async fn test_nested_explicit_empty_array() {
+    let script = r#"
+        assert.eq(json.encode({ items = json.array({}) }), '{"items":[]}')
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+// json.array preserves an existing metatable. A table with __index set
+// for inheritance keeps that hook after json.array tags it.
+#[tokio::test]
+async fn test_json_array_preserves_existing_metatable() {
+    let script = r#"
+        local parent = { greeting = "hi" }
+        local t = setmetatable({}, { __index = parent })
+        json.array(t)
+        assert.eq(t.greeting, "hi")              -- __index still works
+        assert.eq(json.encode(t), "[]")          -- __jsontype applied
+    "#;
+    run_lua(script).await.unwrap();
+}

--- a/docs/modules/serialization.md
+++ b/docs/modules/serialization.md
@@ -7,7 +7,29 @@ category: Builtins
 JSON serialization. No `require()` needed.
 
 - `json.parse(str)` → table — Parse JSON string to Lua table
-- `json.encode(table)` → string — Encode Lua table to JSON string
+- `json.encode(value)` → string — Encode Lua value to JSON string
+- `json.array(t?)` → table — Tag a table to encode as a JSON array (defaults to a fresh empty table when called with no argument)
+- `json.object(t?)` → table — Tag a table to encode as a JSON object (defaults to a fresh empty table when called with no argument)
+
+### Empty tables
+
+Lua has one composite type covering both arrays and objects, so the
+encoder has to pick a shape for `{}`. The default is **object** —
+`json.encode({})` returns `"{}"`. To express an empty JSON array,
+use `json.array({})` (or just `json.array()`) which tags the table
+via a `__jsontype = "array"` metatable marker that the encoder
+honours regardless of contents.
+
+```lua
+json.encode({})                 -- "{}"
+json.encode(json.array({}))     -- "[]"
+json.encode(json.array({1,2}))  -- "[1,2]"
+json.encode(json.object({"a"})) -- '{"1":"a"}'  (object with stringified key)
+```
+
+For non-empty tables the heuristic still applies: contiguous
+`1..N` integer keys encode as arrays, anything else as objects. The
+helpers only matter when you need to override that.
 
 ## yaml
 


### PR DESCRIPTION
Closes #129.

## Summary

- `json.encode({})` returns `"{}"` (object) instead of `"[]"` (array)
- Adds `json.array(t?)` / `json.object(t?)` to pin shape via a `__jsontype` metatable marker
- Bumps `assay-lua` to 0.15.10
- CI: opt-in `vars.MAC_LOCAL_RUNNER` routing macOS jobs to a local self-hosted runner when online
- CI: drops `rust` trigger from `sysops-e2e`/`sysops-smoke` so rust-only PRs don't pay the Playwright cycle

## Why (json fix)

Every assay stdlib site that passes `{}` as a JSON request body through the http builtin was silently shipping `[]` — strict APIs (e.g. Unleash admin) reject this with `BadDataError: /body must be object`. Affected callers: `unleash.features:toggle_on/off`, `ory.hydra` logout accept/reject, `engine.workflow:signal` (no payload), `engine.vault` key rotate, `harbor` artifact scan, `zitadel` set-primary-domain, `hashicorp.vault` revoke-self.

## Migration

Any caller that needs an empty JSON array now uses `json.array({})` (or `json.array()`). None known in tree.

## Mac runner usage

When a self-hosted runner is registered on a Mac with labels `self-hosted, macos, assay`:

```sh
gh variable set MAC_LOCAL_RUNNER --body true     # while runner is online
gh variable delete MAC_LOCAL_RUNNER              # when stopping it
```

GitHub Actions has no native "fallback if offline" so this variable is the kill-switch. Runner registration itself is a separate manual step (download tarball + `./config.sh --url ... --token ...` from the repo's Settings → Actions → Runners page).

## Test plan

- [x] `cargo test -p assay-lua --test json` — 10 cases covering empty table, helpers, nested empties, metatable preservation
- [x] `cargo test -p assay-lua --test stdlib_unleash` — 32 existing cases still pass (toggle_on/off included)
- [x] `cargo clippy -p assay-lua --tests -- -D warnings`
- [x] `ruby -r yaml` parse of changed workflow YAML
- [ ] CI green