### PR TITLE
chore: bump assay-auth 0.4.1, assay-engine 0.4.3

### DIFF
--- a/crates/assay-auth/Cargo.toml
+++ b/crates/assay-auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-auth"
-version = "0.4.0"
+version = "0.4.1"
 categories = ["authentication", "cryptography", "asynchronous"]
 edition = "2024"
 keywords = ["oidc", "zanzibar", "passkey", "biscuit", "auth"]

--- a/crates/assay-engine/Cargo.toml
+++ b/crates/assay-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-engine"
-version = "0.4.2"
+version = "0.4.3"
 categories = ["asynchronous", "database", "web-programming::http-server"]
 edition = "2024"
 keywords = ["workflow", "auth", "oidc", "zanzibar", "postgres"]


### PR DESCRIPTION
Version bumps for changes already on main.

- **assay-auth 0.4.0 → 0.4.1**: OIDC provider-agnostic federation, auth_params, binding, issuer validation, V5 migration
- **assay-engine 0.4.2 → 0.4.3**: load upstreams into registry at boot + admin CRUD sync