### PR TITLE
chore(vault)!: bump 0.3.0 — unblock assay-engine 0.4.3 publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Assay are documented here.
 
+## [assay-vault 0.3.0] — 2026-05-11
+
+- Pin `assay-auth = "0.4"` (was `"0.3"`); republish to unblock `assay-engine` publish.
+- `assay-engine` `assay-vault` dep `"0.2"` → `"0.3"` to match.
+- Same pattern as `assay-vault 0.1.0 → 0.2.0` in #99.
+
 ## assay 0.15.11 — 2026-05-11
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,7 +392,7 @@ dependencies = [
 
 [[package]]
 name = "assay-vault"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",

--- a/crates/assay-engine/Cargo.toml
+++ b/crates/assay-engine/Cargo.toml
@@ -90,7 +90,7 @@ backend-sqlite = [
 assay-auth = { path = "../assay-auth", version = "0.4" }
 assay-dashboard = { path = "../assay-dashboard", version = "0.4" }
 assay-domain = { path = "../assay-domain", version = "0.2" }
-assay-vault = { path = "../assay-vault", version = "0.2", optional = true, default-features = false }
+assay-vault = { path = "../assay-vault", version = "0.3", optional = true, default-features = false }
 assay-workflow = { path = "../assay-workflow", version = "0.3" }
 
 axum = "0.8"

--- a/crates/assay-vault/Cargo.toml
+++ b/crates/assay-vault/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-vault"
-version = "0.2.0"
+version = "0.3.0"
 categories = ["cryptography", "asynchronous", "database"]
 edition = "2024"
 keywords = ["vault", "secrets", "kv", "transit", "biscuit"]


### PR DESCRIPTION
## Summary

- Bump `assay-vault` 0.2.0 → 0.3.0 so its published manifest pins `assay-auth = "0.4"` (the published `0.2.0` still says `^0.3`).
- Bump `assay-engine`'s `assay-vault` dep `"0.2"` → `"0.3"` to match.

## Why

Last release run [25653841370](https://github.com/developerinlondon/assay/actions/runs/25653841370/job/75298642306) failed at `cargo publish -p assay-engine` with five `E0277` "trait bound … is not satisfied" errors. The full message:

```
note: there are multiple different versions of crate `assay_auth` in the dependency graph
   --> ...assay-auth-0.3.0/src/zanzibar/store.rs:31:1
 31 | pub trait ZanzibarStore: Send + Sync + 'static {
    | ^^^ this is the expected trait
   ::: ...assay-auth-0.4.1/src/zanzibar/store.rs:31:1
 31 | pub trait ZanzibarStore: Send + Sync + 'static {
    | --- this is the found trait
```

Trace:

1. Commit 5801b0e (`chore(release): bump assay-auth 0.3.0 → 0.4.0`) bumped vault's path-dep on assay-auth from `"0.3"` to `"0.4"` but kept `vault` itself at `0.2.0`.
2. `assay-vault 0.2.0` is still on crates.io with the old `assay-auth ^0.3` baked into its manifest (verified via the crates.io deps API).
3. `cargo publish -p assay-engine 0.4.3` does a verify-build of the packaged tarball — engine's direct dep pulls `assay-auth 0.4.1`, but its `assay-vault = "0.2"` dep pulls vault `0.2.0` (with `assay-auth 0.3.0`) from crates.io.
4. Two crates.io versions of `assay-auth` in the same graph → trait impls don't cross → compile fail.

This is the exact same situation #99 fixed for the `0.1.0 → 0.2.0` transition. Pre-1.0 semver treats a change in a public dep version requirement as breaking, so this is a minor bump.

## Local verification

- `cargo check --workspace`: clean ✓
- `cargo build --release -p assay-engine`: clean ✓
- `cargo publish --dry-run -p assay-vault`: package + verify-build pass; tarball `Cargo.toml` shows `[dependencies.assay-auth] version = "0.4"` ✓
- `cargo package -p assay-engine` cannot fully verify until `assay-vault 0.3.0` is on crates.io — CI workflow sequences `libraries` (publishes vault, sleeps 30s for index propagation) before `release-assay-engine`, so this resolves in CI.

## Test plan

- [ ] Merge → release workflow's `detect` job picks up `assay_vault_bumped=true` + `assay_engine_bumped=true`
- [ ] `libraries` job publishes `assay-vault 0.3.0` to crates.io
- [ ] `release-assay-engine` job's `cargo publish -p assay-engine` verify-build now resolves a single `assay-auth 0.4.1` and the publish succeeds
- [ ] `assay-engine-v0.4.3` tag + GitHub release created
- [ ] `ghcr.io/developerinlondon/assay-engine:0.4.3` pushed