### PR TITLE
feat(stdlib/rauthy): add outline client preset + bump 0.15.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,7 +338,7 @@ dependencies = [
 
 [[package]]
 name = "assay-lua"
-version = "0.15.11"
+version = "0.15.12"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/assay/Cargo.toml
+++ b/crates/assay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-lua"
-version = "0.15.11"
+version = "0.15.12"
 categories = ["command-line-utilities", "development-tools::testing"]
 edition = "2024"
 homepage = "https://assay.rs"

--- a/crates/assay/stdlib/rauthy.lua
+++ b/crates/assay/stdlib/rauthy.lua
@@ -15,6 +15,7 @@
 --- @quickref c.clients:reconcile(payload) -> {action, secret?, drift_on?, reason?} | Idempotent reconcile; only rebuilds on `challenges` drift or 404
 --- @quickref M.client_presets.openbao({host, id?, name?}) -> payload | OpenBao OAuth2 client payload (RS256 + S256 PKCE; required by Vault go-oidc)
 --- @quickref M.client_presets.argocd({host, id?, name?}) -> payload | ArgoCD OAuth2 client payload (PKCE-public, EdDSA, CLI device-login redirect)
+--- @quickref M.client_presets.outline({host, id?, name?}) -> payload | Outline wiki OAuth2 client payload (confidential, RS256, S256 PKCE)
 
 local M = {}
 
@@ -300,6 +301,39 @@ function M.client_presets.argocd(opts)
     access_token_lifetime = 1800,
     scopes = { "openid", "email", "profile", "groups" },
     default_scopes = { "openid", "email", "profile", "groups" },
+    challenges = { "S256" },
+    force_mfa = false,
+  }
+end
+
+-- Outline wiki. Confidential client (shared client_secret).
+--   * `id_token_alg = RS256` — Outline uses jose for JWT validation; RS256 is the
+--     widely-supported default. EdDSA is not in jose's default key-resolution path.
+--   * `challenges = [S256]` — Outline performs PKCE on browser flows by default
+--     and Rauthy requires the client to declare the challenge method.
+--   * Redirect URI is `/auth/oidc.callback` (Outline's hardcoded OIDC callback path).
+function M.client_presets.outline(opts)
+  if not opts or not opts.host then
+    error("rauthy.client_presets.outline: opts.host required")
+  end
+  local host = opts.host
+  return {
+    id = opts.id or "outline",
+    name = opts.name or "Outline",
+    confidential = true,
+    enabled = true,
+    redirect_uris = {
+      "https://" .. host .. "/auth/oidc.callback",
+    },
+    post_logout_redirect_uris = { "https://" .. host },
+    allowed_origins = { "https://" .. host },
+    flows_enabled = { "authorization_code", "refresh_token" },
+    access_token_alg = "RS256",
+    id_token_alg = "RS256",
+    auth_code_lifetime = 60,
+    access_token_lifetime = 1800,
+    scopes = { "openid", "email", "profile" },
+    default_scopes = { "openid", "email", "profile" },
     challenges = { "S256" },
     force_mfa = false,
   }

--- a/crates/assay/tests/stdlib_rauthy.rs
+++ b/crates/assay/tests/stdlib_rauthy.rs
@@ -374,6 +374,36 @@ async fn test_client_preset_argocd() {
 }
 
 #[tokio::test]
+async fn test_client_preset_outline() {
+    let script = r#"
+        local rauthy = require("assay.rauthy")
+        local p = rauthy.client_presets.outline({ host = "wiki.example.com" })
+        assert.eq(p.id, "outline")
+        assert.eq(p.name, "Outline")
+        assert.eq(p.confidential, true)
+        assert.eq(p.id_token_alg, "RS256")
+        assert.eq(p.access_token_alg, "RS256")
+        assert.eq(p.challenges[1], "S256")
+        assert.eq(p.redirect_uris[1], "https://wiki.example.com/auth/oidc.callback")
+        assert.eq(p.scopes[1], "openid")
+        assert.eq(p.scopes[2], "email")
+        assert.eq(p.scopes[3], "profile")
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_client_preset_outline_requires_host() {
+    let script = r#"
+        local rauthy = require("assay.rauthy")
+        local ok, err = pcall(rauthy.client_presets.outline, {})
+        assert.eq(ok, false)
+        assert.eq(string.find(err, "opts.host required") ~= nil, true)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
 async fn test_client_preset_openbao_requires_host() {
     let script = r#"
         local rauthy = require("assay.rauthy")


### PR DESCRIPTION
Adds an `outline` preset to `assay.rauthy.client_presets`, mirroring the openbao + argocd shape.

- `confidential = true` — Outline uses a shared client_secret.
- `id_token_alg = RS256` — Outline's jose validator expects RS256; EdDSA isn't in its default key path.
- `challenges = [S256]` — Outline does PKCE on browser flows; Rauthy requires the client declare it.
- `redirect_uri = /auth/oidc.callback` — Outline's hardcoded callback.
- `scopes = openid email profile` — Outline reads `name`/`email`; no groups needed.
- Two new tests in `stdlib_rauthy.rs` (success + missing-host pcall). All 15 rauthy tests pass.
- `assay-lua` 0.15.11 → 0.15.12.