### PR TITLE
fix(rauthy): drift detection for removed fields + outline preset no-PKCE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,7 +338,7 @@ dependencies = [
 
 [[package]]
 name = "assay-lua"
-version = "0.15.12"
+version = "0.15.13"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/assay/Cargo.toml
+++ b/crates/assay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-lua"
-version = "0.15.12"
+version = "0.15.13"
 categories = ["command-line-utilities", "development-tools::testing"]
 edition = "2024"
 homepage = "https://assay.rs"

--- a/crates/assay/stdlib/rauthy.lua
+++ b/crates/assay/stdlib/rauthy.lua
@@ -45,6 +45,15 @@ local function drift_field(payload, got)
   for k, v in pairs(payload) do
     if not field_eq(v, got[k]) then return k end
   end
+  -- Reverse direction: a field present in `got` but absent from `payload`
+  -- means the caller wants it removed. Without this, a preset shipped today
+  -- with `challenges = {"S256"}` and later overridden to omit `challenges`
+  -- would silently noop because the forward loop never visits the missing
+  -- key. Rauthy's PUT is a full-replacement, so a follow-up put() correctly
+  -- clears the field.
+  for k, v in pairs(got) do
+    if payload[k] == nil and v ~= nil then return k end
+  end
   return nil
 end
 
@@ -309,8 +318,10 @@ end
 -- Outline wiki. Confidential client (shared client_secret).
 --   * `id_token_alg = RS256` — Outline uses jose for JWT validation; RS256 is the
 --     widely-supported default. EdDSA is not in jose's default key-resolution path.
---   * `challenges = [S256]` — Outline performs PKCE on browser flows by default
---     and Rauthy requires the client to declare the challenge method.
+--   * No `challenges` field — Outline 1.8.x sends authorize requests without
+--     `code_challenge`, and Rauthy 400's "code_challenge missing" on any client
+--     that declares challenges. Confidential client + client_secret carries the
+--     authn weight; PKCE is redundant here.
 --   * Redirect URI is `/auth/oidc.callback` (Outline's hardcoded OIDC callback path).
 function M.client_presets.outline(opts)
   if not opts or not opts.host then
@@ -334,7 +345,6 @@ function M.client_presets.outline(opts)
     access_token_lifetime = 1800,
     scopes = { "openid", "email", "profile" },
     default_scopes = { "openid", "email", "profile" },
-    challenges = { "S256" },
     force_mfa = false,
   }
 end

--- a/crates/assay/tests/stdlib_rauthy.rs
+++ b/crates/assay/tests/stdlib_rauthy.rs
@@ -196,6 +196,47 @@ async fn test_reconcile_noop_when_no_drift() {
 }
 
 #[tokio::test]
+async fn test_reconcile_put_when_payload_omits_field_present_on_server() {
+    // Server has `challenges: ["S256"]`; caller's payload omits it (meaning
+    // "remove that field"). Reconcile should detect drift on `challenges`
+    // and issue a PUT — not silently noop.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/clients/openbao"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "openbao",
+            "name": "OpenBao",
+            "confidential": true,
+            "challenges": ["S256"],
+            "redirect_uris": ["https://o.example.com/cb"]
+        })))
+        .mount(&server)
+        .await;
+    Mock::given(method("PUT"))
+        .and(path("/clients/openbao"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local rauthy = require("assay.rauthy")
+        local c = rauthy.client("{}", "{}")
+        local r = c.clients:reconcile({{
+          id = "openbao", name = "OpenBao",
+          confidential = true,
+          redirect_uris = {{ "https://o.example.com/cb" }},
+        }})
+        assert.eq(r.action, "put")
+        assert.eq(r.drift_on, "challenges")
+        "#,
+        server.uri(),
+        api_key_lua_literal()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
 async fn test_reconcile_create_on_404() {
     let server = MockServer::start().await;
     // GET → 404
@@ -383,7 +424,9 @@ async fn test_client_preset_outline() {
         assert.eq(p.confidential, true)
         assert.eq(p.id_token_alg, "RS256")
         assert.eq(p.access_token_alg, "RS256")
-        assert.eq(p.challenges[1], "S256")
+        -- Outline 1.8.x sends authorize without code_challenge; the preset
+        -- intentionally omits `challenges` so Rauthy doesn't enforce PKCE.
+        assert.eq(p.challenges, nil)
         assert.eq(p.redirect_uris[1], "https://wiki.example.com/auth/oidc.callback")
         assert.eq(p.scopes[1], "openid")
         assert.eq(p.scopes[2], "email")


### PR DESCRIPTION
## Summary

- `drift_field` now detects drift in the reverse direction too: when a field is present on the server but absent from the desired payload (caller wants it cleared). Without this, `reconcile()` silently noop'd on intentional field removals.
- The `outline` client preset no longer sets `challenges = {"S256"}`. Outline 1.8.x sends authorize requests without `code_challenge`; Rauthy 400's `code_challenge missing` on any client that declares challenges. Confidential client + client_secret already carries the authn weight here; PKCE is redundant.

## Test plan

- [x] `cargo test -p assay-lua --test stdlib_rauthy` — 16/16 pass
- [x] New `test_reconcile_put_when_payload_omits_field_present_on_server` exercises the reverse-drift path
- [x] `test_client_preset_outline` updated to assert `challenges == nil`

Bump 0.15.12 -> 0.15.13.