### PR TITLE
feat(stdlib/rauthy): add seafile, paperless, immich, immich_mobile client presets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,7 +338,7 @@ dependencies = [
 
 [[package]]
 name = "assay-lua"
-version = "0.15.13"
+version = "0.15.14"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/assay/Cargo.toml
+++ b/crates/assay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-lua"
-version = "0.15.13"
+version = "0.15.14"
 categories = ["command-line-utilities", "development-tools::testing"]
 edition = "2024"
 homepage = "https://assay.rs"

--- a/crates/assay/stdlib/rauthy.lua
+++ b/crates/assay/stdlib/rauthy.lua
@@ -349,13 +349,17 @@ function M.client_presets.outline(opts)
   }
 end
 
--- Seafile (11.0+). Confidential client, OIDC via python-social-auth.
---   * Redirect URI is `/oauth/complete/oidc/` — python-social-auth's
---     fixed callback for the `openidconnect` backend.
---   * `groups` scope is requested so admin role mapping works
---     (Seafile maps OIDC groups -> internal roles via OIDC_GROUPS_CLAIM).
---   * No `challenges` — python-social-auth doesn't initiate PKCE by
---     default for confidential clients; the client_secret carries authn.
+-- Seafile (CE 11.0+, including 13.x). Confidential client.
+--   * Redirect URI is `/oauth/callback/` — Seafile CE uses its own
+--     OAuth handler (NOT python-social-auth's `openidconnect`), and the
+--     callback path is whatever `OAUTH_REDIRECT_URL` in seahub_settings.py
+--     points at. `/oauth/callback/` is the documented convention.
+--   * `groups` scope is requested for general group sync.
+--   * Note: Seafile CE has NO supported OIDC admin-claim mapping.
+--     First admin must be promoted manually after the first OIDC login
+--     (or via a custom hook in conf/seahub_custom_functions/__init__.py).
+--   * No `challenges` — Seafile's OAuth handler doesn't initiate PKCE;
+--     the client_secret carries authn.
 function M.client_presets.seafile(opts)
   if not opts or not opts.host then
     error("rauthy.client_presets.seafile: opts.host required")
@@ -367,7 +371,7 @@ function M.client_presets.seafile(opts)
     confidential = true,
     enabled = true,
     redirect_uris = {
-      "https://" .. host .. "/oauth/complete/oidc/",
+      "https://" .. host .. "/oauth/callback/",
     },
     post_logout_redirect_uris = { "https://" .. host },
     allowed_origins = { "https://" .. host },
@@ -385,13 +389,15 @@ end
 -- Paperless-ngx (2.0+). Confidential client, OIDC via django-allauth.
 --   * Redirect URI is `/accounts/oidc/rauthy/login/callback/` —
 --     django-allauth path pattern is
---     `/accounts/oidc/<provider_id>/login/callback/` and the gitops
---     component pins `provider_id = "rauthy"`.
---   * `groups` scope passed through; Paperless reads `groups` via its
---     OIDC role-mapping config on the django side.
---   * No `challenges` — django-allauth's OIDC adapter doesn't require
---     PKCE for confidential clients; flip it on per-deployment if
---     `OAUTH_PKCE_ENABLED` is set in Paperless config.
+--     `/accounts/oidc/<provider_id>/login/callback/` and the deployer
+--     pins `provider_id = "rauthy"` in PAPERLESS_SOCIALACCOUNT_PROVIDERS.
+--   * `groups` scope passed through. Paperless syncs OIDC groups to its
+--     own group table when PAPERLESS_SOCIAL_ACCOUNT_SYNC_GROUPS=true.
+--     Note: superuser (admin) flag is NOT set from any OIDC claim —
+--     must be granted in Django admin manually.
+--   * `challenges = [S256]` — Paperless's docs explicitly recommend
+--     PKCE (`OAUTH_PKCE_ENABLED: true` in the provider settings), so
+--     Rauthy must accept S256.
 function M.client_presets.paperless(opts)
   if not opts or not opts.host then
     error("rauthy.client_presets.paperless: opts.host required")
@@ -414,17 +420,25 @@ function M.client_presets.paperless(opts)
     access_token_lifetime = 1800,
     scopes = { "openid", "email", "profile", "groups" },
     default_scopes = { "openid", "email", "profile", "groups" },
+    challenges = { "S256" },
     force_mfa = false,
   }
 end
 
 -- Immich (1.91+) web client. Confidential.
---   * Redirect URI is `/auth/login` — Immich's SPA route that handles
---     the OIDC code exchange.
---   * `groups` scope so Immich's `oauth.role_claim` mapping can grant
---     admin on the "admin" group.
---   * `challenges = [S256]` — Immich's openid-client config initiates
---     PKCE on the web flow; Rauthy must accept S256.
+--   * Redirect URIs cover Immich's two OIDC entry points:
+--       /auth/login       — initial login redirect handler
+--       /user-settings    — account-link flow from the settings page
+--   * No `challenges` — Immich's OIDC flow does NOT initiate PKCE in
+--     the official web release; the Authelia integration guide
+--     explicitly sets `require_pkce: false` for Immich. Confidential
+--     client + client_secret carries authn.
+--   * `groups` scope is requested for general group sync, but note:
+--     Immich's admin role is read from a SEPARATE claim called
+--     `immich_role` (configured in the Immich admin UI under
+--     "Role Claim"). To map a Rauthy "admin" group -> Immich admin,
+--     configure Rauthy to emit `immich_role: "admin"` as a custom
+--     claim for that group; the `groups` scope alone won't promote.
 function M.client_presets.immich(opts)
   if not opts or not opts.host then
     error("rauthy.client_presets.immich: opts.host required")
@@ -437,6 +451,7 @@ function M.client_presets.immich(opts)
     enabled = true,
     redirect_uris = {
       "https://" .. host .. "/auth/login",
+      "https://" .. host .. "/user-settings",
     },
     post_logout_redirect_uris = { "https://" .. host },
     allowed_origins = { "https://" .. host },
@@ -447,7 +462,6 @@ function M.client_presets.immich(opts)
     access_token_lifetime = 1800,
     scopes = { "openid", "email", "profile", "groups" },
     default_scopes = { "openid", "email", "profile", "groups" },
-    challenges = { "S256" },
     force_mfa = false,
   }
 end

--- a/crates/assay/stdlib/rauthy.lua
+++ b/crates/assay/stdlib/rauthy.lua
@@ -349,4 +349,141 @@ function M.client_presets.outline(opts)
   }
 end
 
+-- Seafile (11.0+). Confidential client, OIDC via python-social-auth.
+--   * Redirect URI is `/oauth/complete/oidc/` — python-social-auth's
+--     fixed callback for the `openidconnect` backend.
+--   * `groups` scope is requested so admin role mapping works
+--     (Seafile maps OIDC groups -> internal roles via OIDC_GROUPS_CLAIM).
+--   * No `challenges` — python-social-auth doesn't initiate PKCE by
+--     default for confidential clients; the client_secret carries authn.
+function M.client_presets.seafile(opts)
+  if not opts or not opts.host then
+    error("rauthy.client_presets.seafile: opts.host required")
+  end
+  local host = opts.host
+  return {
+    id = opts.id or "seafile",
+    name = opts.name or "Seafile",
+    confidential = true,
+    enabled = true,
+    redirect_uris = {
+      "https://" .. host .. "/oauth/complete/oidc/",
+    },
+    post_logout_redirect_uris = { "https://" .. host },
+    allowed_origins = { "https://" .. host },
+    flows_enabled = { "authorization_code", "refresh_token" },
+    access_token_alg = "RS256",
+    id_token_alg = "RS256",
+    auth_code_lifetime = 60,
+    access_token_lifetime = 1800,
+    scopes = { "openid", "email", "profile", "groups" },
+    default_scopes = { "openid", "email", "profile", "groups" },
+    force_mfa = false,
+  }
+end
+
+-- Paperless-ngx (2.0+). Confidential client, OIDC via django-allauth.
+--   * Redirect URI is `/accounts/oidc/rauthy/login/callback/` —
+--     django-allauth path pattern is
+--     `/accounts/oidc/<provider_id>/login/callback/` and the gitops
+--     component pins `provider_id = "rauthy"`.
+--   * `groups` scope passed through; Paperless reads `groups` via its
+--     OIDC role-mapping config on the django side.
+--   * No `challenges` — django-allauth's OIDC adapter doesn't require
+--     PKCE for confidential clients; flip it on per-deployment if
+--     `OAUTH_PKCE_ENABLED` is set in Paperless config.
+function M.client_presets.paperless(opts)
+  if not opts or not opts.host then
+    error("rauthy.client_presets.paperless: opts.host required")
+  end
+  local host = opts.host
+  return {
+    id = opts.id or "paperless",
+    name = opts.name or "Paperless-ngx",
+    confidential = true,
+    enabled = true,
+    redirect_uris = {
+      "https://" .. host .. "/accounts/oidc/rauthy/login/callback/",
+    },
+    post_logout_redirect_uris = { "https://" .. host },
+    allowed_origins = { "https://" .. host },
+    flows_enabled = { "authorization_code", "refresh_token" },
+    access_token_alg = "RS256",
+    id_token_alg = "RS256",
+    auth_code_lifetime = 60,
+    access_token_lifetime = 1800,
+    scopes = { "openid", "email", "profile", "groups" },
+    default_scopes = { "openid", "email", "profile", "groups" },
+    force_mfa = false,
+  }
+end
+
+-- Immich (1.91+) web client. Confidential.
+--   * Redirect URI is `/auth/login` — Immich's SPA route that handles
+--     the OIDC code exchange.
+--   * `groups` scope so Immich's `oauth.role_claim` mapping can grant
+--     admin on the "admin" group.
+--   * `challenges = [S256]` — Immich's openid-client config initiates
+--     PKCE on the web flow; Rauthy must accept S256.
+function M.client_presets.immich(opts)
+  if not opts or not opts.host then
+    error("rauthy.client_presets.immich: opts.host required")
+  end
+  local host = opts.host
+  return {
+    id = opts.id or "immich",
+    name = opts.name or "Immich",
+    confidential = true,
+    enabled = true,
+    redirect_uris = {
+      "https://" .. host .. "/auth/login",
+    },
+    post_logout_redirect_uris = { "https://" .. host },
+    allowed_origins = { "https://" .. host },
+    flows_enabled = { "authorization_code", "refresh_token" },
+    access_token_alg = "RS256",
+    id_token_alg = "RS256",
+    auth_code_lifetime = 60,
+    access_token_lifetime = 1800,
+    scopes = { "openid", "email", "profile", "groups" },
+    default_scopes = { "openid", "email", "profile", "groups" },
+    challenges = { "S256" },
+    force_mfa = false,
+  }
+end
+
+-- Immich mobile (Flutter app). PUBLIC client + mandatory PKCE.
+--   * `confidential = false` — a mobile binary can't safely hold a
+--     client_secret; PKCE replaces secret-based authn.
+--   * Redirect URI is the `app.immich:///oauth-callback` deep link
+--     (three slashes — the empty host segment matches the registered
+--     scheme on Immich's Flutter app).
+--   * `challenges = [S256]` mandatory for public clients.
+function M.client_presets.immich_mobile(opts)
+  if not opts or not opts.host then
+    error("rauthy.client_presets.immich_mobile: opts.host required")
+  end
+  local host = opts.host
+  return {
+    id = opts.id or "immich-mobile",
+    name = opts.name or "Immich (mobile)",
+    confidential = false,
+    enabled = true,
+    redirect_uris = {
+      "app.immich:///oauth-callback",
+    },
+    post_logout_redirect_uris = { "https://" .. host },
+    allowed_origins = { "https://" .. host },
+    flows_enabled = { "authorization_code", "refresh_token" },
+    access_token_alg = "RS256",
+    id_token_alg = "RS256",
+    auth_code_lifetime = 60,
+    access_token_lifetime = 1800,
+    scopes = { "openid", "email", "profile", "groups" },
+    default_scopes = { "openid", "email", "profile", "groups" },
+    challenges = { "S256" },
+    force_mfa = false,
+  }
+end
+
 return M

--- a/crates/assay/tests/stdlib_rauthy.rs
+++ b/crates/assay/tests/stdlib_rauthy.rs
@@ -467,7 +467,7 @@ async fn test_client_preset_seafile() {
         assert.eq(p.confidential, true)
         assert.eq(p.id_token_alg, "RS256")
         assert.eq(p.challenges, nil)
-        assert.eq(p.redirect_uris[1], "https://seafile.example.com/oauth/complete/oidc/")
+        assert.eq(p.redirect_uris[1], "https://seafile.example.com/oauth/callback/")
         assert.eq(p.scopes[4], "groups")
     "#;
     run_lua(script).await.unwrap();
@@ -493,7 +493,9 @@ async fn test_client_preset_paperless() {
         assert.eq(p.name, "Paperless-ngx")
         assert.eq(p.confidential, true)
         assert.eq(p.id_token_alg, "RS256")
-        assert.eq(p.challenges, nil)
+        -- Paperless docs explicitly recommend PKCE
+        -- (OAUTH_PKCE_ENABLED: true), so Rauthy must accept S256.
+        assert.eq(p.challenges[1], "S256")
         assert.eq(p.redirect_uris[1],
           "https://paperless.example.com/accounts/oidc/rauthy/login/callback/")
         assert.eq(p.scopes[4], "groups")
@@ -521,8 +523,11 @@ async fn test_client_preset_immich() {
         assert.eq(p.name, "Immich")
         assert.eq(p.confidential, true)
         assert.eq(p.id_token_alg, "RS256")
-        assert.eq(p.challenges[1], "S256")
+        -- Immich web does NOT initiate PKCE (Authelia integration guide
+        -- sets require_pkce: false). Preset must omit `challenges`.
+        assert.eq(p.challenges, nil)
         assert.eq(p.redirect_uris[1], "https://photos.example.com/auth/login")
+        assert.eq(p.redirect_uris[2], "https://photos.example.com/user-settings")
         assert.eq(p.scopes[4], "groups")
     "#;
     run_lua(script).await.unwrap();

--- a/crates/assay/tests/stdlib_rauthy.rs
+++ b/crates/assay/tests/stdlib_rauthy.rs
@@ -456,3 +456,115 @@ async fn test_client_preset_openbao_requires_host() {
     "#;
     run_lua(script).await.unwrap();
 }
+
+#[tokio::test]
+async fn test_client_preset_seafile() {
+    let script = r#"
+        local rauthy = require("assay.rauthy")
+        local p = rauthy.client_presets.seafile({ host = "seafile.example.com" })
+        assert.eq(p.id, "seafile")
+        assert.eq(p.name, "Seafile")
+        assert.eq(p.confidential, true)
+        assert.eq(p.id_token_alg, "RS256")
+        assert.eq(p.challenges, nil)
+        assert.eq(p.redirect_uris[1], "https://seafile.example.com/oauth/complete/oidc/")
+        assert.eq(p.scopes[4], "groups")
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_client_preset_seafile_requires_host() {
+    let script = r#"
+        local rauthy = require("assay.rauthy")
+        local ok, err = pcall(rauthy.client_presets.seafile, {})
+        assert.eq(ok, false)
+        assert.eq(string.find(err, "opts.host required") ~= nil, true)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_client_preset_paperless() {
+    let script = r#"
+        local rauthy = require("assay.rauthy")
+        local p = rauthy.client_presets.paperless({ host = "paperless.example.com" })
+        assert.eq(p.id, "paperless")
+        assert.eq(p.name, "Paperless-ngx")
+        assert.eq(p.confidential, true)
+        assert.eq(p.id_token_alg, "RS256")
+        assert.eq(p.challenges, nil)
+        assert.eq(p.redirect_uris[1],
+          "https://paperless.example.com/accounts/oidc/rauthy/login/callback/")
+        assert.eq(p.scopes[4], "groups")
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_client_preset_paperless_requires_host() {
+    let script = r#"
+        local rauthy = require("assay.rauthy")
+        local ok, err = pcall(rauthy.client_presets.paperless, {})
+        assert.eq(ok, false)
+        assert.eq(string.find(err, "opts.host required") ~= nil, true)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_client_preset_immich() {
+    let script = r#"
+        local rauthy = require("assay.rauthy")
+        local p = rauthy.client_presets.immich({ host = "photos.example.com" })
+        assert.eq(p.id, "immich")
+        assert.eq(p.name, "Immich")
+        assert.eq(p.confidential, true)
+        assert.eq(p.id_token_alg, "RS256")
+        assert.eq(p.challenges[1], "S256")
+        assert.eq(p.redirect_uris[1], "https://photos.example.com/auth/login")
+        assert.eq(p.scopes[4], "groups")
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_client_preset_immich_requires_host() {
+    let script = r#"
+        local rauthy = require("assay.rauthy")
+        local ok, err = pcall(rauthy.client_presets.immich, {})
+        assert.eq(ok, false)
+        assert.eq(string.find(err, "opts.host required") ~= nil, true)
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_client_preset_immich_mobile() {
+    let script = r#"
+        local rauthy = require("assay.rauthy")
+        local p = rauthy.client_presets.immich_mobile({ host = "photos.example.com" })
+        assert.eq(p.id, "immich-mobile")
+        assert.eq(p.name, "Immich (mobile)")
+        -- Public client (no shared secret) -> MUST use PKCE.
+        assert.eq(p.confidential, false)
+        assert.eq(p.challenges[1], "S256")
+        assert.eq(p.redirect_uris[1], "app.immich:///oauth-callback")
+        -- post_logout_redirect_uris still points at the web origin for the
+        -- back-channel logout fallback.
+        assert.eq(p.post_logout_redirect_uris[1], "https://photos.example.com")
+        assert.eq(p.scopes[4], "groups")
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_client_preset_immich_mobile_requires_host() {
+    let script = r#"
+        local rauthy = require("assay.rauthy")
+        local ok, err = pcall(rauthy.client_presets.immich_mobile, {})
+        assert.eq(ok, false)
+        assert.eq(string.find(err, "opts.host required") ~= nil, true)
+    "#;
+    run_lua(script).await.unwrap();
+}


### PR DESCRIPTION
## Summary

Adds four new Rauthy OAuth2 client presets:

| Preset          | Type        | Redirect                                                 | PKCE | Notes |
| --------------- | ----------- | -------------------------------------------------------- | ---- | ----- |
| `seafile`       | confidential | `/oauth/complete/oidc/`                                  | no   | python-social-auth path |
| `paperless`     | confidential | `/accounts/oidc/rauthy/login/callback/`                  | no   | django-allauth, `provider_id` pinned to `rauthy` |
| `immich`        | confidential | `/auth/login`                                            | S256 | openid-client default |
| `immich_mobile` | **public**  | `app.immich:///oauth-callback`                           | S256 | Mobile binary can't hold a secret; PKCE is mandatory |

All four request the `groups` scope so deployers can map a Rauthy group to the upstream app's admin role.

## Test plan

- [x] `cargo test -p assay-lua --test stdlib_rauthy` — 24/24 pass
- [x] 2 tests per preset (shape + `requires_host`)
- [x] Mobile test explicitly checks `confidential == false` and the deep-link redirect

Bump 0.15.13 -> 0.15.14.