### PR TITLE
feat(docker): publish :<version>-sh image variant with busybox /bin/sh

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -619,6 +619,35 @@ jobs:
             ghcr.io/developerinlondon/assay:${{ needs.detect.outputs.assay_lua_version }}
             ghcr.io/developerinlondon/assay:latest
 
+      # `-sh` variant: same scratch image plus a static busybox at /bin/sh
+      # so GitLab CI runners (which wrap every script: line in `sh -c`)
+      # can use the image directly. K8s consumers keep using the plain
+      # `:<version>` tag; this one is opt-in.
+      - name: Check if assay-sh docker image already exists
+        id: docker-check-sh
+        env:
+          VERSION: ${{ needs.detect.outputs.assay_lua_version }}
+        run: |
+          set -uo pipefail
+          if docker buildx imagetools inspect "ghcr.io/developerinlondon/assay:${VERSION}-sh" >/dev/null 2>&1; then
+            echo "ghcr.io/developerinlondon/assay:${VERSION}-sh already published — skipping docker push"
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ghcr.io/developerinlondon/assay:${VERSION}-sh not found — will push"
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: docker/build-push-action@v7
+        if: steps.docker-check-sh.outputs.exists != 'true'
+        with:
+          context: artifacts
+          file: ${{ github.workspace }}/Dockerfile.sh
+          push: true
+          build-args: |
+            RUST_VERSION=${{ needs.detect.outputs.rust_version }}
+          tags: |
+            ghcr.io/developerinlondon/assay:${{ needs.detect.outputs.assay_lua_version }}-sh
+
   publish-extension:
     needs: detect
     if: needs.detect.outputs.extension_bumped == 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to Assay are documented here.
 
+## Unreleased
+
+### Container image
+
+- New `ghcr.io/developerinlondon/assay:<version>-sh` tag — same scratch
+  image as the plain `:<version>` tag, plus a 1 MB static busybox at
+  `/bin/sh`. Use in environments that wrap the launch in `sh -c` (notably
+  GitLab CI's docker executor). K8s consumers that already use
+  `command: ["/assay", ...]` should keep the plain `:<version>` tag.
+
 ## assay 0.16.0 — 2026-05-11
 
 ### 🏗️ Container Registry (lite crane replacement)

--- a/Dockerfile.sh
+++ b/Dockerfile.sh
@@ -1,0 +1,56 @@
+# assay container with /bin/sh — published as ghcr.io/developerinlondon/assay:<version>-sh.
+#
+# Identical contents to the main `Dockerfile`, plus a static busybox at
+# /bin/sh so the image works in environments that require a shell to
+# launch the binary — notably GitLab CI's docker executor, which wraps
+# every script: line in `sh -c "..."` and crashes before the entrypoint
+# ever runs if no shell is present.
+#
+# K8s consumers that already launch assay with `command: ["/assay", ...]`
+# should keep using the plain `:<version>` tag — smaller image, smaller
+# CVE surface, no shell available for accidental injection.
+
+ARG BUILD_MODE=artifact
+ARG RUST_VERSION=1.95
+
+FROM scratch AS artifact
+COPY assay-linux-x86_64 /assay
+
+# `perl` is included for symmetry with Dockerfile.assay-engine — assay-lua
+# itself doesn't currently pull openssl-src, but a future dep that does
+# shouldn't silently start failing.
+FROM rust:${RUST_VERSION}-slim AS source-builder
+RUN apt-get update && apt-get install -y \
+      musl-tools cmake make g++ protobuf-compiler perl \
+    && rm -rf /var/lib/apt/lists/*
+RUN rustup target add x86_64-unknown-linux-musl
+WORKDIR /app
+COPY Cargo.toml Cargo.lock ./
+COPY crates/ crates/
+RUN cargo build --release --target x86_64-unknown-linux-musl -p assay-lua --bin assay \
+    && cp /app/target/x86_64-unknown-linux-musl/release/assay /assay
+
+FROM source-builder AS source
+
+# Docker doesn't expand ARG inside `COPY --from=…`; the picker stage
+# resolves BUILD_MODE in `FROM` (which does support ARG).
+FROM ${BUILD_MODE} AS picked
+
+# Alpine is only a vendored cert source; alpine itself never ships in
+# the final image.
+FROM alpine:3 AS certs
+RUN apk add --no-cache ca-certificates
+
+# busybox:musl is itself FROM scratch + a single ~1 MB static binary.
+# We pull `/bin/busybox` out of it and rename to `/bin/sh` in the final
+# image — that's all GitLab CI's `sh -c` wrapper needs.
+FROM busybox:musl AS shell
+
+# /etc/ssl/certs/ca-certificates.crt is load-bearing — every assay
+# HTTPS call (reqwest, sqlx TLS, WebSockets) verifies certs against
+# it. Without this file on FROM scratch every TLS connection fails.
+FROM scratch
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=shell /bin/busybox /bin/sh
+COPY --from=picked /assay /assay
+ENTRYPOINT ["/assay"]

--- a/crates/assay/tests/dockerfile.rs
+++ b/crates/assay/tests/dockerfile.rs
@@ -1,10 +1,13 @@
 //! Regression guards on the repo's Dockerfiles.
 //!
-//! Both published images are `FROM scratch` with just the relevant
+//! All published images are `FROM scratch` with just the relevant
 //! binary + a CA bundle:
 //!
 //! - `ghcr.io/developerinlondon/assay`        — runtime, built from `Dockerfile`
 //! - `ghcr.io/developerinlondon/assay-engine` — server,  built from `Dockerfile.assay-engine`
+//! - `ghcr.io/developerinlondon/assay:<v>-sh` — runtime + busybox `/bin/sh`,
+//!   built from `Dockerfile.sh`. Still `FROM scratch`; only present so
+//!   the image works inside GitLab CI's `sh -c "$script"` wrapper.
 //!
 //! Scratch keeps both images ~10 MB each, reduces the CVE surface to
 //! assay's own supply chain, and makes every downstream image that
@@ -28,6 +31,7 @@
 const DOCKERFILES: &[(&str, &str)] = &[
     ("../../Dockerfile", "/assay"),
     ("../../Dockerfile.assay-engine", "/assay-engine"),
+    ("../../Dockerfile.sh", "/assay"),
 ];
 
 fn read_dockerfile(rel_path: &str) -> String {


### PR DESCRIPTION
## Summary

- Adds `Dockerfile.sh` — same scratch image as `Dockerfile`, plus a static busybox at `/bin/sh`.
- Wires the release workflow to publish `ghcr.io/developerinlondon/assay:<version>-sh` alongside the existing plain `:<version>` tag (independent idempotent docker-check + build step).
- Adds `Dockerfile.sh` to the `crates/assay/tests/dockerfile.rs` guard table; the existing assertions (last FROM = scratch, CA bundle present, ENTRYPOINT absolute) all pass for the new file.

## Why

GitLab Runner's docker executor wraps every `script:` line in `sh -c "$script"`. With the current `FROM scratch` image the container has no shell, so jobs that use `image: ghcr.io/developerinlondon/assay:0.16.0` crash before assay ever runs.

K8s consumers (which launch with `command: ["/assay", ...]`) bypass that wrapper and don't need a shell. So instead of putting busybox into the main image we publish a parallel `-sh` tag — opt-in, ~1 MB extra, same binary inside.

## Test plan

- [x] `cargo test -p assay-lua --test dockerfile` — all three guards pass for `Dockerfile.sh`
- [ ] Release workflow on merge: builds + pushes `ghcr.io/developerinlondon/assay:0.16.0-sh`
- [ ] Downstream verification: `docker run --rm ghcr.io/developerinlondon/assay:0.16.0-sh /bin/sh -c 'echo ok'`
- [ ] GitLab CI in `command-console/cockpit` and `ai/agents` uses the `-sh` tag directly (no alpine + curl prep)

## Notes

- No `latest-sh` tag — `latest` semantics are confusing enough already.
- No version bump: the assay binary is unchanged; only the image packaging.