### PR TITLE
chore: cargo fmt oci.rs + tarball.rs

### DIFF
--- a/crates/assay/src/lua/builtins/oci.rs
+++ b/crates/assay/src/lua/builtins/oci.rs
@@ -1,11 +1,11 @@
-use flate2::write::GzEncoder;
 use flate2::Compression;
+use flate2::write::GzEncoder;
 use futures_util::StreamExt;
 use mlua::{Lua, Table};
+use oci_distribution::Reference;
 use oci_distribution::client::{Client as OciClient, ClientConfig};
 use oci_distribution::manifest::{OciDescriptor, OciManifest};
 use oci_distribution::secrets::RegistryAuth;
-use oci_distribution::Reference;
 use sha2::{Digest, Sha256};
 use std::io::Write;
 
@@ -130,11 +130,7 @@ async fn copy_image(
     // Prime auth on the destination registry up-front so we get a fast,
     // clear failure if creds are wrong, before doing any heavy I/O.
     client
-        .auth(
-            dst,
-            dst_auth,
-            oci_distribution::RegistryOperation::Push,
-        )
+        .auth(dst, dst_auth, oci_distribution::RegistryOperation::Push)
         .await
         .map_err(|e| ext(format!("auth dst {dst}: {e}")))?;
 
@@ -191,11 +187,7 @@ async fn stream_copy_blob(
 /// Pull the manifest only (no layers), then push it under the new tag.
 /// This is the cheap, correct OCI retag: it does not re-upload blobs.
 /// For cross-registry retagging use `oci.copy`.
-async fn retag_image(
-    src: &Reference,
-    dst: &Reference,
-    auth: &RegistryAuth,
-) -> mlua::Result<()> {
+async fn retag_image(src: &Reference, dst: &Reference, auth: &RegistryAuth) -> mlua::Result<()> {
     if src.registry() != dst.registry() || src.repository() != dst.repository() {
         return Err(ext(format!(
             "oci.tag: src and dst must share registry+repository; got {src} and {dst}. Use oci.copy for cross-registry."
@@ -234,11 +226,7 @@ async fn mutate_image(
         .map_err(|e| ext(format!("pull manifest {src}: {e}")))?;
 
     client
-        .auth(
-            dst,
-            dst_auth,
-            oci_distribution::RegistryOperation::Push,
-        )
+        .auth(dst, dst_auth, oci_distribution::RegistryOperation::Push)
         .await
         .map_err(|e| ext(format!("auth dst {dst}: {e}")))?;
 
@@ -298,7 +286,9 @@ fn build_tar(files: &[(String, Vec<u8>)]) -> mlua::Result<Vec<u8>> {
             header.set_size(content.len() as u64);
             header.set_mode(0o644);
             header.set_cksum();
-            builder.append_data(&mut header, path, content.as_slice()).map_err(ext)?;
+            builder
+                .append_data(&mut header, path, content.as_slice())
+                .map_err(ext)?;
         }
         builder.finish().map_err(ext)?;
     }
@@ -324,8 +314,8 @@ fn hex_sha256(data: &[u8]) -> String {
 /// for an image config blob; only the manifest needs canonical encoding,
 /// and oci-distribution's `push_manifest` handles that.
 fn append_diff_id(config_str: &str, diff_id: &str) -> mlua::Result<Vec<u8>> {
-    let mut config: serde_json::Value = serde_json::from_str(config_str)
-        .map_err(|e| ext(format!("parse image config: {e}")))?;
+    let mut config: serde_json::Value =
+        serde_json::from_str(config_str).map_err(|e| ext(format!("parse image config: {e}")))?;
 
     let rootfs = config
         .get_mut("rootfs")

--- a/crates/assay/src/lua/builtins/tarball.rs
+++ b/crates/assay/src/lua/builtins/tarball.rs
@@ -1,32 +1,41 @@
+use flate2::Compression;
 use flate2::read::GzDecoder;
 use flate2::write::GzEncoder;
-use flate2::Compression;
 use mlua::{Lua, Table};
 use std::io::Write;
 
 pub fn register_tar(lua: &Lua) -> mlua::Result<()> {
     let tar_table = lua.create_table()?;
 
-    let create_fn = lua.create_function(move |_lua, (output, files, opts): (String, Table, Option<Table>)| {
-        let gzip = opts.as_ref()
-            .and_then(|t| t.get::<bool>("gzip").ok())
-            .unwrap_or(true);
+    let create_fn = lua.create_function(
+        move |_lua, (output, files, opts): (String, Table, Option<Table>)| {
+            let gzip = opts
+                .as_ref()
+                .and_then(|t| t.get::<bool>("gzip").ok())
+                .unwrap_or(true);
 
-        let output_data: Vec<u8> = if gzip {
-            let enc = GzEncoder::new(Vec::new(), Compression::default());
-            let mut tar_builder = tar::Builder::new(enc);
-            add_files(&mut tar_builder, &files)?;
-            let enc = tar_builder.into_inner().map_err(|e| mlua::Error::external(e.to_string()))?;
-            enc.finish().map_err(|e| mlua::Error::external(e.to_string()))?
-        } else {
-            let mut tar_builder = tar::Builder::new(Vec::new());
-            add_files(&mut tar_builder, &files)?;
-            tar_builder.into_inner().map_err(|e| mlua::Error::external(e.to_string()))?
-        };
+            let output_data: Vec<u8> = if gzip {
+                let enc = GzEncoder::new(Vec::new(), Compression::default());
+                let mut tar_builder = tar::Builder::new(enc);
+                add_files(&mut tar_builder, &files)?;
+                let enc = tar_builder
+                    .into_inner()
+                    .map_err(|e| mlua::Error::external(e.to_string()))?;
+                enc.finish()
+                    .map_err(|e| mlua::Error::external(e.to_string()))?
+            } else {
+                let mut tar_builder = tar::Builder::new(Vec::new());
+                add_files(&mut tar_builder, &files)?;
+                tar_builder
+                    .into_inner()
+                    .map_err(|e| mlua::Error::external(e.to_string()))?
+            };
 
-        std::fs::write(&output, &output_data).map_err(|e| mlua::Error::external(e.to_string()))?;
-        Ok(true)
-    })?;
+            std::fs::write(&output, &output_data)
+                .map_err(|e| mlua::Error::external(e.to_string()))?;
+            Ok(true)
+        },
+    )?;
     tar_table.set("create", create_fn)?;
 
     let extract_fn = lua.create_function(move |_lua, (archive, dest): (String, String)| {
@@ -35,10 +44,14 @@ pub fn register_tar(lua: &Lua) -> mlua::Result<()> {
         if archive.ends_with(".gz") || archive.ends_with(".tgz") {
             let decoder = GzDecoder::new(&file[..]);
             let mut archive = tar::Archive::new(decoder);
-            archive.unpack(&dest).map_err(|e| mlua::Error::external(e.to_string()))?;
+            archive
+                .unpack(&dest)
+                .map_err(|e| mlua::Error::external(e.to_string()))?;
         } else {
             let mut archive = tar::Archive::new(&file[..]);
-            archive.unpack(&dest).map_err(|e| mlua::Error::external(e.to_string()))?;
+            archive
+                .unpack(&dest)
+                .map_err(|e| mlua::Error::external(e.to_string()))?;
         }
 
         Ok(true)
@@ -52,16 +65,26 @@ pub fn register_tar(lua: &Lua) -> mlua::Result<()> {
         if archive.ends_with(".gz") || archive.ends_with(".tgz") {
             let decoder = GzDecoder::new(&file[..]);
             let mut archive = tar::Archive::new(decoder);
-            for entry in archive.entries().map_err(|e| mlua::Error::external(e.to_string()))? {
+            for entry in archive
+                .entries()
+                .map_err(|e| mlua::Error::external(e.to_string()))?
+            {
                 let entry = entry.map_err(|e| mlua::Error::external(e.to_string()))?;
-                let path = entry.path().map_err(|e| mlua::Error::external(e.to_string()))?;
+                let path = entry
+                    .path()
+                    .map_err(|e| mlua::Error::external(e.to_string()))?;
                 entries.push(path.to_string_lossy().to_string());
             }
         } else {
             let mut archive = tar::Archive::new(&file[..]);
-            for entry in archive.entries().map_err(|e| mlua::Error::external(e.to_string()))? {
+            for entry in archive
+                .entries()
+                .map_err(|e| mlua::Error::external(e.to_string()))?
+            {
                 let entry = entry.map_err(|e| mlua::Error::external(e.to_string()))?;
-                let path = entry.path().map_err(|e| mlua::Error::external(e.to_string()))?;
+                let path = entry
+                    .path()
+                    .map_err(|e| mlua::Error::external(e.to_string()))?;
                 entries.push(path.to_string_lossy().to_string());
             }
         }
@@ -82,7 +105,9 @@ fn add_files<W: Write>(builder: &mut tar::Builder<W>, files: &Table) -> mlua::Re
             _ => value.to_string()?,
         };
         let mut header = tar::Header::new_gnu();
-        header.set_path(&path).map_err(|e| mlua::Error::external(e.to_string()))?;
+        header
+            .set_path(&path)
+            .map_err(|e| mlua::Error::external(e.to_string()))?;
         header.set_size(content.len() as u64);
         header.set_mode(0o644);
         header.set_cksum();


### PR DESCRIPTION
## Summary
- Tree-wide \`cargo fmt --check\` was failing on \`oci.rs\` + \`tarball.rs\` after #143 merged
- Reformatted both files only; no behavior change
- Unblocks pre-commit hook on subsequent PRs

## Test plan
- [x] \`cargo fmt --all -- --check\` passes locally after this change