### PR TITLE
fix(rauthy): immich preset must allow PKCE S256

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,18 @@
 
 All notable changes to Assay are documented here.
 
-## Unreleased
+## assay 0.16.1 — 2026-05-11
+
+### Fixed
+
+- `rauthy.client_presets.immich`: register `challenges = ["S256"]`. Current Immich web sends PKCE on
+  every authorize; Rauthy was rejecting it as a spec mismatch.
 
 ### Container image
 
-- New `ghcr.io/developerinlondon/assay:<version>-sh` tag — same scratch
-  image as the plain `:<version>` tag, plus a 1 MB static busybox at
-  `/bin/sh`. Use in environments that wrap the launch in `sh -c` (notably
-  GitLab CI's docker executor). K8s consumers that already use
+- New `ghcr.io/developerinlondon/assay:<version>-sh` tag — same scratch image as the plain
+  `:<version>` tag, plus a 1 MB static busybox at `/bin/sh`. Use in environments that wrap the
+  launch in `sh -c` (notably GitLab CI's docker executor). K8s consumers that already use
   `command: ["/assay", ...]` should keep the plain `:<version>` tag.
 
 ## assay 0.16.0 — 2026-05-11

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,7 +338,7 @@ dependencies = [
 
 [[package]]
 name = "assay-lua"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/assay/Cargo.toml
+++ b/crates/assay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-lua"
-version = "0.16.0"
+version = "0.16.1"
 categories = ["command-line-utilities", "development-tools::testing"]
 edition = "2024"
 homepage = "https://assay.rs"

--- a/crates/assay/stdlib/rauthy.lua
+++ b/crates/assay/stdlib/rauthy.lua
@@ -429,10 +429,12 @@ end
 --   * Redirect URIs cover Immich's two OIDC entry points:
 --       /auth/login       — initial login redirect handler
 --       /user-settings    — account-link flow from the settings page
---   * No `challenges` — Immich's OIDC flow does NOT initiate PKCE in
---     the official web release; the Authelia integration guide
---     explicitly sets `require_pkce: false` for Immich. Confidential
---     client + client_secret carries authn.
+--   * `challenges = ["S256"]` — Immich's web frontend builds its
+--     authorize URL via `openid-client`, which generates a
+--     `code_challenge` (PKCE S256) unconditionally on every flow.
+--     The Rauthy client must allow it or the request is rejected as
+--     a spec mismatch. Older Authelia/Immich guides predate this and
+--     said PKCE was off; that's no longer true.
 --   * `groups` scope is requested for general group sync, but note:
 --     Immich's admin role is read from a SEPARATE claim called
 --     `immich_role` (configured in the Immich admin UI under
@@ -462,6 +464,7 @@ function M.client_presets.immich(opts)
     access_token_lifetime = 1800,
     scopes = { "openid", "email", "profile", "groups" },
     default_scopes = { "openid", "email", "profile", "groups" },
+    challenges = { "S256" },
     force_mfa = false,
   }
 end

--- a/crates/assay/tests/stdlib_rauthy.rs
+++ b/crates/assay/tests/stdlib_rauthy.rs
@@ -523,9 +523,9 @@ async fn test_client_preset_immich() {
         assert.eq(p.name, "Immich")
         assert.eq(p.confidential, true)
         assert.eq(p.id_token_alg, "RS256")
-        -- Immich web does NOT initiate PKCE (Authelia integration guide
-        -- sets require_pkce: false). Preset must omit `challenges`.
-        assert.eq(p.challenges, nil)
+        -- Immich's web frontend uses openid-client, which always sends a
+        -- PKCE code_challenge. The Rauthy client must allow S256.
+        assert.eq(p.challenges[1], "S256")
         assert.eq(p.redirect_uris[1], "https://photos.example.com/auth/login")
         assert.eq(p.redirect_uris[2], "https://photos.example.com/user-settings")
         assert.eq(p.scopes[4], "groups")

--- a/docs/modules/aws-ecr.md
+++ b/docs/modules/aws-ecr.md
@@ -4,24 +4,24 @@ category: Cloud & AWS
 
 ## assay.aws.ecr
 
-AWS Elastic Container Registry client. Get authorization tokens for `docker login` or pushing/pulling
-images. Uses `assay.aws.sigv4` internally for request signing.
+AWS Elastic Container Registry client. Get authorization tokens for `docker login` or
+pushing/pulling images. Uses `assay.aws.sigv4` internally for request signing.
 
 ### Client
 
 - `ecr.client(opts)` → client. `opts` is a table with the fields:
-  - `access_key` *(required)* — AWS access key ID
-  - `secret_key` *(required)* — AWS secret access key
-  - `region`     *(required)* — AWS region
-  - `session_token` *(optional)* — STS session token
-  - `endpoint`      *(optional)* — override the API endpoint (full URL or bare host).
-    Defaults to `https://api.ecr.<region>.amazonaws.com`. Useful for VPC endpoints
-    or for injecting a mock server in tests.
+  - `access_key` _(required)_ — AWS access key ID
+  - `secret_key` _(required)_ — AWS secret access key
+  - `region` _(required)_ — AWS region
+  - `session_token` _(optional)_ — STS session token
+  - `endpoint` _(optional)_ — override the API endpoint (full URL or bare host). Defaults to
+    `https://api.ecr.<region>.amazonaws.com`. Useful for VPC endpoints or for injecting a mock
+    server in tests.
 
 ### Authorization
 
-- `c:get_authorization_token()` → `{token, proxy_endpoint, expires_at}` — Get an ECR
-  authorization token. The `token` field is the password for `docker login -u AWS`.
+- `c:get_authorization_token()` → `{token, proxy_endpoint, expires_at}` — Get an ECR authorization
+  token. The `token` field is the password for `docker login -u AWS`.
 
 Example:
 

--- a/docs/modules/aws-sigv4.md
+++ b/docs/modules/aws-sigv4.md
@@ -13,19 +13,19 @@ Parameterized for any AWS service (ecr, ec2, sts, iam, etc.).
   `authorization`, `x-amz-date`, `x-amz-content-sha256`, and any custom headers passed in. The
   `opts` table:
 
-  | Key | Type | Required | Description |
-  |-----|------|----------|-------------|
-  | `access_key` | string | Yes | AWS access key ID |
-  | `secret_key` | string | Yes | AWS secret access key |
-  | `session_token` | string | No | AWS session token (for STS credentials) |
-  | `service` | string | Yes | AWS service name (e.g. `"ecr"`) |
-  | `region` | string | Yes | AWS region (e.g. `"us-east-1"`) |
-  | `method` | string | No | HTTP method (default `"GET"`) |
-  | `host` | string | Yes | API hostname |
-  | `path` | string | No | Request path (default `"/"`) |
-  | `query` | string | No | Query string |
-  | `payload` | string | No | Request body (default `""`) |
-  | `headers` | table | No | Additional headers to include and sign |
+  | Key             | Type   | Required | Description                             |
+  | --------------- | ------ | -------- | --------------------------------------- |
+  | `access_key`    | string | Yes      | AWS access key ID                       |
+  | `secret_key`    | string | Yes      | AWS secret access key                   |
+  | `session_token` | string | No       | AWS session token (for STS credentials) |
+  | `service`       | string | Yes      | AWS service name (e.g. `"ecr"`)         |
+  | `region`        | string | Yes      | AWS region (e.g. `"us-east-1"`)         |
+  | `method`        | string | No       | HTTP method (default `"GET"`)           |
+  | `host`          | string | Yes      | API hostname                            |
+  | `path`          | string | No       | Request path (default `"/"`)            |
+  | `query`         | string | No       | Query string                            |
+  | `payload`       | string | No       | Request body (default `""`)             |
+  | `headers`       | table  | No       | Additional headers to include and sign  |
 
 Example:
 
@@ -45,3 +45,4 @@ local headers = sigv4.sign({
   },
 })
 -- Use headers with http.post/get
+```

--- a/docs/modules/oci.md
+++ b/docs/modules/oci.md
@@ -9,14 +9,14 @@ OCI container registry operations. Pull, push, copy, tag, and mutate images acro
 
 ### Image operations
 
-- `oci.copy(src, dst, opts?)` → true — Copy an image between registries. Pulls each layer one at
-  a time from `src` and pushes to `dst`; peak memory is the size of the largest single layer.
-  `opts` accepts `{src_auth, dst_auth}` where each auth table is `{username, password}`.
+- `oci.copy(src, dst, opts?)` → true — Copy an image between registries. Pulls each layer one at a
+  time from `src` and pushes to `dst`; peak memory is the size of the largest single layer. `opts`
+  accepts `{src_auth, dst_auth}` where each auth table is `{username, password}`.
 
-- `oci.tag(src, new_tag, opts?)` → true — Re-tag an image **within the same registry+repository**
-  by pulling the manifest and pushing it under `new_tag`. No layer data is copied — the new tag
-  points at the existing blobs. `opts` accepts `{auth = {username, password}}`. For cross-registry
-  tagging, use `oci.copy`.
+- `oci.tag(src, new_tag, opts?)` → true — Re-tag an image **within the same registry+repository** by
+  pulling the manifest and pushing it under `new_tag`. No layer data is copied — the new tag points
+  at the existing blobs. `opts` accepts `{auth = {username, password}}`. For cross-registry tagging,
+  use `oci.copy`.
 
 - `oci.mutate(src, dst, files, opts?)` → true — Copy `src` to `dst` and append a new tar.gz layer
   containing `files` (a table of `{path = content}`). The image config is updated so

--- a/docs/modules/tar.md
+++ b/docs/modules/tar.md
@@ -10,11 +10,11 @@ Tar archive creation, extraction, and listing. Supports plain tar and gzip-compr
 ### Functions
 
 - `tar.create(output, files, opts?)` → true — Create a tar archive. `files` is a table of
-  `{path = content}`. `opts.gzip` (default `true`) controls gzip compression. Output path
-  determines format (`.tar.gz` enables gzip).
+  `{path = content}`. `opts.gzip` (default `true`) controls gzip compression. Output path determines
+  format (`.tar.gz` enables gzip).
 
-- `tar.extract(archive, dest)` → true — Extract a tar or tar.gz archive to `dest`. Auto-detects
-  gzip compression from the filename extension.
+- `tar.extract(archive, dest)` → true — Extract a tar or tar.gz archive to `dest`. Auto-detects gzip
+  compression from the filename extension.
 
 - `tar.list(archive)` → `[string]` — List all file paths in a tar or tar.gz archive.
 


### PR DESCRIPTION
## Summary
- Current Immich web sends a PKCE code_challenge on every authorize (via openid-client)
- Preset registered the client without challenges, so Rauthy rejected with "Invalid redirect uri"
- Adds challenges = { "S256" } to the immich preset + refreshes comment + test
- Bumps to 0.16.1; also includes dprint fmt cleanup on docs from #143 (pre-commit blocker)

## Test plan
- [x] cargo test -p assay-lua --test stdlib_rauthy test_client_preset_immich passes