### PR TITLE
fix(docker): ship full busybox /bin in assay:<v>-sh + move assay to PATH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Assay are documented here.
 
+## assay 0.16.2 — 2026-05-12
+
+### Fixed
+
+- `:<version>-sh` image: ship the full busybox applet set, not just `/bin/sh`; move `assay` to `/usr/local/bin/assay` so it resolves on `$PATH`.
+
 ## assay 0.16.1 — 2026-05-11
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,7 +338,7 @@ dependencies = [
 
 [[package]]
 name = "assay-lua"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/Dockerfile.sh
+++ b/Dockerfile.sh
@@ -41,9 +41,12 @@ FROM ${BUILD_MODE} AS picked
 FROM alpine:3 AS certs
 RUN apk add --no-cache ca-certificates
 
-# busybox:musl is itself FROM scratch + a single ~1 MB static binary.
-# We pull `/bin/busybox` out of it and rename to `/bin/sh` in the final
-# image — that's all GitLab CI's `sh -c` wrapper needs.
+# busybox:musl is itself FROM scratch + a ~1 MB static binary plus a
+# directory of relative symlinks (sh → busybox, grep → busybox, etc.).
+# We copy the whole /bin so GitLab Runner's prelude script — which
+# invokes grep, mkdir, sed, tar and a handful of other coreutils — has
+# what it needs. The ~1 MB binary is the only real disk cost; the
+# symlinks share the same inode-equivalent on the image layer.
 FROM busybox:musl AS shell
 
 # /etc/ssl/certs/ca-certificates.crt is load-bearing — every assay
@@ -51,6 +54,9 @@ FROM busybox:musl AS shell
 # it. Without this file on FROM scratch every TLS connection fails.
 FROM scratch
 COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=shell /bin/busybox /bin/sh
-COPY --from=picked /assay /assay
-ENTRYPOINT ["/assay"]
+COPY --from=shell /bin /bin
+# assay goes under /usr/local/bin/ so the bare `assay` command resolves
+# via the default PATH (=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin).
+# Scripts like `assay foo.lua` work without an absolute path.
+COPY --from=picked /assay /usr/local/bin/assay
+ENTRYPOINT ["/usr/local/bin/assay"]

--- a/crates/assay/Cargo.toml
+++ b/crates/assay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-lua"
-version = "0.16.1"
+version = "0.16.2"
 categories = ["command-line-utilities", "development-tools::testing"]
 edition = "2024"
 homepage = "https://assay.rs"

--- a/crates/assay/tests/dockerfile.rs
+++ b/crates/assay/tests/dockerfile.rs
@@ -31,7 +31,9 @@
 const DOCKERFILES: &[(&str, &str)] = &[
     ("../../Dockerfile", "/assay"),
     ("../../Dockerfile.assay-engine", "/assay-engine"),
-    ("../../Dockerfile.sh", "/assay"),
+    // The -sh variant puts assay at /usr/local/bin/assay so GitLab CI's
+    // `script:` lines can call bare `assay` via the default $PATH.
+    ("../../Dockerfile.sh", "/usr/local/bin/assay"),
 ];
 
 fn read_dockerfile(rel_path: &str) -> String {


### PR DESCRIPTION
## Summary

- Copy the full `/bin` from `busybox:musl` into the `:<version>-sh` image so `grep`, `mkdir`, `sed`, `tar`, etc. all resolve (single ~1 MB binary, many symlinks).
- Move `assay` from `/assay` to `/usr/local/bin/assay` so bare `assay foo.lua` calls resolve via the default `$PATH`.
- Bump `assay-lua` 0.16.1 → 0.16.2 because the broken `:0.16.1-sh` is already on GHCR; the release workflow skips republish for existing tags.

## Why

`:0.16.1-sh` fails immediately in GitLab CI:

```
/bin/sh: grep: not found
/bin/sh: eval: line 68: mkdir: not found
```

Runner's prelude expects coreutils. busybox supplies them as applets behind a single binary, but we only copied `/bin/busybox` as `/bin/sh` — the other applet symlinks were missing. Same root cause applies to anything else that shells out to coreutils.

## Test plan

- [x] `cargo test -p assay-lua --test dockerfile` — guards still pass against `Dockerfile.sh`
- [ ] Release workflow publishes `:0.16.2` (plain) and `:0.16.2-sh`
- [ ] `cockpit` and `agents` `.gitlab-ci.yml` bump to `:0.16.2-sh`, post-merge `ecr-publish-*` jobs succeed against control-plane ECR