### PR TITLE
ci: decouple crates.io publish from docker push in release-assay-lua

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -481,18 +481,18 @@ jobs:
           fi
           echo "OK — assay-engine ${actual} live in cluster"
 
-  release-assay-lua:
-    needs: [detect, libraries, binaries]
+  # Crates.io publish is isolated from the binary/docker side: it builds
+  # from source and ships to crates.io with a different secret. If the
+  # token is rotated/expired, only this job fails — the binaries are
+  # still attached to the GH release and the docker images still ship.
+  release-assay-lua-crate:
+    needs: [detect, libraries]
     if: |
       always() &&
-      (needs.libraries.result == 'success' || needs.libraries.result == 'skipped') &&
-      (needs.binaries.result == 'success' || needs.binaries.result == 'skipped')
+      (needs.libraries.result == 'success' || needs.libraries.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: dtolnay/rust-toolchain@master
         with:
@@ -511,6 +511,21 @@ jobs:
           else
             cargo publish --allow-dirty -p assay-lua
           fi
+
+  # Tag, GH release, and both docker images. Does not depend on the
+  # crate publish — runs in parallel with release-assay-lua-crate.
+  release-assay-lua:
+    needs: [detect, libraries, binaries]
+    if: |
+      always() &&
+      (needs.libraries.result == 'success' || needs.libraries.result == 'skipped') &&
+      (needs.binaries.result == 'success' || needs.binaries.result == 'skipped')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/download-artifact@v8
         if: needs.detect.outputs.assay_lua_release_exists != 'true'


### PR DESCRIPTION
## Summary

- Splits the monolithic \`release-assay-lua\` job in two:
  - \`release-assay-lua-crate\` — only crates.io publish
  - \`release-assay-lua\` — tag + GH release + docker push (\`:v\` and \`:v-sh\`)
- Docker no longer aborts when \`CARGO_REGISTRY_TOKEN\` rotates/expires.

## Why

The 0.16.2 release just hit \`403 Forbidden: authentication failed\` on crates.io and the whole job died at step 4 of 12, leaving \`:0.16.2-sh\` unpublished. The docker push has no dependency on crates.io — it reads cross-compiled binaries from the \`binaries\` job and authenticates to GHCR with \`GITHUB_TOKEN\`. Independent failure domains, no shared state.

## Behaviour after this PR

- \`CARGO_REGISTRY_TOKEN\` valid: both jobs succeed, parity with today.
- \`CARGO_REGISTRY_TOKEN\` invalid: crate job fails loudly, docker job ships the image + tag + GH release. Maintainer fixes the secret and re-triggers; idempotent crate publish picks up.

## Test plan

- [ ] Merge → push to main re-triggers the release workflow for 0.16.2
- [ ] \`release-assay-lua-crate\`: still 403 until token is rotated; visible as a failed job
- [ ] \`release-assay-lua\`: ships \`assay-lua-v0.16.2\` tag + GH release + \`:0.16.2\` + \`:0.16.2-sh\` docker images