### PR TITLE
feat(keto): add tuples:upsert for idempotent ensure-exactly-one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to Assay are documented here.
 
+## assay 0.16.3 — 2026-05-19
+
+### Added
+
+- `c.tuples:upsert(tuple)` — idempotent ensure-exactly-one. Returns `"noop"` / `"created"` / `"repaired", N`. Use for seed scripts; `tuples:create` is non-idempotent.
+
+### Changed
+
+- `c.tuples:create` docstring flags non-idempotency, points at `upsert`.
+
 ## sysops 0.1.6 — 2026-05-18
 
 ### Added

--- a/crates/assay/Cargo.toml
+++ b/crates/assay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-lua"
-version = "0.16.2"
+version = "0.16.3"
 categories = ["command-line-utilities", "development-tools::testing"]
 edition = "2024"
 homepage = "https://assay.rs"

--- a/crates/assay/stdlib/ory/keto.lua
+++ b/crates/assay/stdlib/ory/keto.lua
@@ -3,7 +3,8 @@
 --- @keywords keto, ory, authorization, authz, rbac, rebac, permissions, roles, relation-tuples, zanzibar, access-control, members, groups, opl, permits
 --- @quickref keto.client(read_url, opts?) -> client | Create a Keto client (read endpoint)
 --- @quickref c.tuples:list(opts) -> {relation_tuples, next_page_token} | List relation tuples matching filters
---- @quickref c.tuples:create(tuple) -> nil | Create a relation tuple (requires write_url)
+--- @quickref c.tuples:create(tuple) -> nil | Create a relation tuple (requires write_url; non-idempotent — see tuples:upsert)
+--- @quickref c.tuples:upsert(tuple) -> "noop" | "created" | "repaired", dups_removed | Ensure exactly one tuple exists for the (namespace, object, relation, subject) identity (requires write_url)
 --- @quickref c.tuples:delete(tuple) -> nil | Delete a relation tuple (requires write_url)
 --- @quickref c.tuples:delete_all(filters) -> nil | Delete all matching relation tuples (requires write_url)
 --- @quickref c.permissions:check(ns, obj, rel, subject) -> bool | Check if a subject has a relation (or OPL permit) on an object
@@ -108,12 +109,67 @@ function M.client(read_url, opts)
 
   -- Create a relation tuple (requires write_url).
   -- tuple: { namespace, object, relation, subject_id } or with subject_set
+  --
+  -- NOT idempotent. Keto's PUT /admin/relation-tuples endpoint is a
+  -- strict CREATE — calling this method twice with the same body stores
+  -- the tuple twice. For "ensure this tuple exists exactly once"
+  -- semantics, use c.tuples:upsert instead. This method is kept as the
+  -- 1:1 wrapper around the underlying HTTP verb for callers that need
+  -- the raw behaviour.
   function c.tuples:create(tuple)
     require_write()
     local resp = http.put(write .. "/admin/relation-tuples", tuple)
     if resp.status ~= 201 and resp.status ~= 200 then
       error("keto: create tuple HTTP " .. resp.status .. ": " .. resp.body)
     end
+  end
+
+  -- Ensure exactly one tuple exists for the given (namespace, object,
+  -- relation, subject) identity. Idempotent + self-repairing:
+  --
+  --   list count == 1   →  no-op, returns ("noop", 0)
+  --   list count == 0   →  create, returns ("created", 0)
+  --   list count >  1   →  delete-all-matching + create-one,
+  --                        returns ("repaired", N) where N is the
+  --                        number of duplicates that were removed
+  --                        (the kept tuple is excluded from the count)
+  --
+  -- This is the method seed/bootstrap scripts should call when they
+  -- want to assert membership. tuples:create is a footgun for that
+  -- intent because Keto's PUT verb is non-idempotent.
+  function c.tuples:upsert(tuple)
+    require_write()
+    local filters = {
+      namespace = tuple.namespace,
+      object = tuple.object,
+      relation = tuple.relation,
+    }
+    if tuple.subject_id then
+      filters.subject_id = tuple.subject_id
+    elseif tuple.subject_set then
+      filters.subject_set_namespace = tuple.subject_set.namespace
+      filters.subject_set_object = tuple.subject_set.object
+      filters.subject_set_relation = tuple.subject_set.relation
+    end
+    local existing = self:list(filters)
+    local count = existing and #(existing.relation_tuples or {}) or 0
+    if count == 1 then
+      return "noop", 0
+    end
+    if count > 1 then
+      -- DELETE /admin/relation-tuples is filter-based — removes every
+      -- matching tuple in one call, regardless of how many duplicates
+      -- accumulated.
+      self:delete(tuple)
+    end
+    local resp = http.put(write .. "/admin/relation-tuples", tuple)
+    if resp.status ~= 201 and resp.status ~= 200 then
+      error("keto: upsert tuple HTTP " .. resp.status .. ": " .. resp.body)
+    end
+    if count == 0 then
+      return "created", 0
+    end
+    return "repaired", count - 1
   end
 
   -- Delete a specific relation tuple (requires write_url).

--- a/crates/assay/tests/stdlib_ory_keto.rs
+++ b/crates/assay/tests/stdlib_ory_keto.rs
@@ -240,3 +240,155 @@ async fn test_keto_write_requires_write_url() {
     );
     run_lua(&script).await.unwrap();
 }
+
+#[tokio::test]
+async fn test_keto_tuples_upsert_created_when_absent() {
+    // Empty list response -> upsert creates exactly one tuple.
+    let read_server = MockServer::start().await;
+    let write_server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/relation-tuples"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "relation_tuples": [],
+            "next_page_token": ""
+        })))
+        .mount(&read_server)
+        .await;
+    Mock::given(method("PUT"))
+        .and(path("/admin/relation-tuples"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({})))
+        .mount(&write_server)
+        .await;
+
+    let script = format!(
+        r#"
+        local keto = require("assay.ory.keto")
+        local k = keto.client("{}", {{ write_url = "{}" }})
+        local action, dups = k.tuples:upsert({{
+          namespace = "Role",
+          object = "namespace1:role-a",
+          relation = "members",
+          subject_id = "user:alice",
+        }})
+        assert.eq(action, "created")
+        assert.eq(dups, 0)
+        "#,
+        read_server.uri(),
+        write_server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_keto_tuples_upsert_noop_when_one_exists() {
+    // List returns exactly one matching tuple -> upsert is a no-op
+    // (no PUT, no DELETE issued).
+    let read_server = MockServer::start().await;
+    let write_server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/relation-tuples"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "relation_tuples": [
+                {
+                    "namespace": "Role",
+                    "object": "namespace1:role-a",
+                    "relation": "members",
+                    "subject_id": "user:alice"
+                }
+            ],
+            "next_page_token": ""
+        })))
+        .mount(&read_server)
+        .await;
+    // No write mocks mounted — if upsert tries to call PUT or DELETE,
+    // wiremock returns 404 and the upsert errors. That's the assertion
+    // shape we want: "noop" really means no write side-effect.
+
+    let script = format!(
+        r#"
+        local keto = require("assay.ory.keto")
+        local k = keto.client("{}", {{ write_url = "{}" }})
+        local action, dups = k.tuples:upsert({{
+          namespace = "Role",
+          object = "namespace1:role-a",
+          relation = "members",
+          subject_id = "user:alice",
+        }})
+        assert.eq(action, "noop")
+        assert.eq(dups, 0)
+        "#,
+        read_server.uri(),
+        write_server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_keto_tuples_upsert_repairs_duplicates() {
+    // List returns 4 identical tuples -> upsert deletes them all and
+    // creates exactly one. Returns ("repaired", 3) — the 3 surplus
+    // tuples that were removed (the kept tuple is excluded from the
+    // count).
+    let read_server = MockServer::start().await;
+    let write_server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/relation-tuples"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "relation_tuples": [
+                {"namespace": "Role", "object": "x", "relation": "members", "subject_id": "user:dup"},
+                {"namespace": "Role", "object": "x", "relation": "members", "subject_id": "user:dup"},
+                {"namespace": "Role", "object": "x", "relation": "members", "subject_id": "user:dup"},
+                {"namespace": "Role", "object": "x", "relation": "members", "subject_id": "user:dup"}
+            ],
+            "next_page_token": ""
+        })))
+        .mount(&read_server)
+        .await;
+    Mock::given(method("DELETE"))
+        .and(path("/admin/relation-tuples"))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(&write_server)
+        .await;
+    Mock::given(method("PUT"))
+        .and(path("/admin/relation-tuples"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({})))
+        .mount(&write_server)
+        .await;
+
+    let script = format!(
+        r#"
+        local keto = require("assay.ory.keto")
+        local k = keto.client("{}", {{ write_url = "{}" }})
+        local action, dups = k.tuples:upsert({{
+          namespace = "Role",
+          object = "x",
+          relation = "members",
+          subject_id = "user:dup",
+        }})
+        assert.eq(action, "repaired")
+        assert.eq(dups, 3)
+        "#,
+        read_server.uri(),
+        write_server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_keto_tuples_upsert_requires_write_url() {
+    let read_server = MockServer::start().await;
+
+    let script = format!(
+        r#"
+        local keto = require("assay.ory.keto")
+        local k = keto.client("{}")
+        local ok, err = pcall(function()
+          k.tuples:upsert({{ namespace = "Role", object = "x", relation = "members", subject_id = "user:y" }})
+        end)
+        assert.eq(ok, false)
+        assert.contains(tostring(err), "write_url not configured")
+        "#,
+        read_server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}


### PR DESCRIPTION
## Summary

- `c.tuples:create` is non-idempotent — Keto's `PUT /admin/relation-tuples` is documented as a strict CREATE. Naive use accumulates duplicates on every re-run, which is exactly what every seed/bootstrap script wants to avoid.
- This PR adds `c.tuples:upsert(tuple)` as the missing idempotent primitive. Existing API unchanged.

## API

```lua
local action, dups = k.tuples:upsert(tuple)
-- action: "noop"     when exactly one matching tuple already exists
--         "created"  when none existed
--         "repaired" when 2+ duplicates existed (deleted all, created one)
-- dups:   number of surplus tuples removed (0 unless "repaired")
```

Identity for the upsert is `(namespace, object, relation, subject_id|subject_set)`.

## Why now

A consumer's seed Job (writes a few dozen tuples on every ArgoCD sync) accumulated 4+ duplicates per identity over several months. Investigation showed the bug was systemic: every caller of `tuples:create` for "ensure exists" intent had the same problem. The clean fix is an idempotent primitive in the stdlib so consumer code stops carrying defensive wrappers.

## Behaviour

- `count == 1`: no HTTP write happens — pure list call. The most common case in steady state.
- `count == 0`: one PUT, same as `tuples:create`.
- `count > 1`: one DELETE (filter-based, removes all matching in one call) + one PUT. Self-repairing for existing dup accumulations.

## Tests

4 new tests covering the three branches + the write-url precondition:

- `test_keto_tuples_upsert_created_when_absent`
- `test_keto_tuples_upsert_noop_when_one_exists`
- `test_keto_tuples_upsert_repairs_duplicates`
- `test_keto_tuples_upsert_requires_write_url`

All 13 stdlib_ory_keto tests pass locally. `cargo clippy -p assay-lua --tests -- -D warnings` clean.

## Version

assay-lua `0.16.2 → 0.16.3` (patch — additive, no breaking change).