### PR TITLE
fix(keto): subject_set filter keys + don't skip empty string params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Assay are documented here.
 
+## assay 0.16.4 — 2026-05-19
+
+### Fixed
+
+- `assay.ory.keto` filter keys for `subject_set` now use dotted notation (`subject_set.namespace`, …) to match Keto's API. The previous underscored keys (`subject_set_namespace`, …) were silently ignored on GET and rejected with HTTP 400 on DELETE, breaking `tuples:upsert` for any subject_set tuples (e.g. parent edges in HRBAC seeds).
+
 ## assay 0.16.3 — 2026-05-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,7 +338,7 @@ dependencies = [
 
 [[package]]
 name = "assay-lua"
-version = "0.16.2"
+version = "0.16.4"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/assay/Cargo.toml
+++ b/crates/assay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-lua"
-version = "0.16.3"
+version = "0.16.4"
 categories = ["command-line-utilities", "development-tools::testing"]
 edition = "2024"
 homepage = "https://assay.rs"

--- a/crates/assay/stdlib/ory/keto.lua
+++ b/crates/assay/stdlib/ory/keto.lua
@@ -35,7 +35,7 @@ function M.client(read_url, opts)
   local function build_query(params)
     local parts = {}
     for k, v in pairs(params) do
-      if v ~= nil and v ~= "" then
+      if v ~= nil then
         parts[#parts + 1] = urlencode(k) .. "=" .. urlencode(v)
       end
     end
@@ -71,9 +71,9 @@ function M.client(read_url, opts)
       if type(subj) == "string" then
         params.subject_id = subj
       elseif type(subj) == "table" then
-        params.subject_set_namespace = subj.namespace
-        params.subject_set_object = subj.object
-        params.subject_set_relation = subj.relation
+        params["subject_set.namespace"] = subj.namespace
+        params["subject_set.object"] = subj.object
+        params["subject_set.relation"] = subj.relation
       end
     else
       params = {
@@ -84,9 +84,9 @@ function M.client(read_url, opts)
       if type(subject) == "string" then
         params.subject_id = subject
       elseif type(subject) == "table" then
-        params.subject_set_namespace = subject.namespace
-        params.subject_set_object = subject.object
-        params.subject_set_relation = subject.relation
+        params["subject_set.namespace"] = subject.namespace
+        params["subject_set.object"] = subject.object
+        params["subject_set.relation"] = subject.relation
       end
     end
     return params
@@ -101,8 +101,9 @@ function M.client(read_url, opts)
   c.tuples = {}
 
   -- List relation tuples.
-  -- Filters: namespace, object, relation, subject_id, subject_set_namespace,
-  -- subject_set_object, subject_set_relation, page_size, page_token
+  -- Filters: namespace, object, relation, subject_id, ["subject_set.namespace"],
+  -- ["subject_set.object"], ["subject_set.relation"], page_size, page_token.
+  -- Filter keys with a dot must be quoted as string literals.
   function c.tuples:list(filters)
     return read_get("/relation-tuples" .. build_query(filters or {}))
   end
@@ -147,9 +148,9 @@ function M.client(read_url, opts)
     if tuple.subject_id then
       filters.subject_id = tuple.subject_id
     elseif tuple.subject_set then
-      filters.subject_set_namespace = tuple.subject_set.namespace
-      filters.subject_set_object = tuple.subject_set.object
-      filters.subject_set_relation = tuple.subject_set.relation
+      filters["subject_set.namespace"] = tuple.subject_set.namespace
+      filters["subject_set.object"] = tuple.subject_set.object
+      filters["subject_set.relation"] = tuple.subject_set.relation
     end
     local existing = self:list(filters)
     local count = existing and #(existing.relation_tuples or {}) or 0
@@ -184,9 +185,9 @@ function M.client(read_url, opts)
     if tuple.subject_id then
       params.subject_id = tuple.subject_id
     elseif tuple.subject_set then
-      params.subject_set_namespace = tuple.subject_set.namespace
-      params.subject_set_object = tuple.subject_set.object
-      params.subject_set_relation = tuple.subject_set.relation
+      params["subject_set.namespace"] = tuple.subject_set.namespace
+      params["subject_set.object"] = tuple.subject_set.object
+      params["subject_set.relation"] = tuple.subject_set.relation
     end
     local resp = http.delete(write .. "/admin/relation-tuples" .. build_query(params))
     if resp.status ~= 204 and resp.status ~= 200 then

--- a/crates/assay/tests/stdlib_ory_keto.rs
+++ b/crates/assay/tests/stdlib_ory_keto.rs
@@ -375,6 +375,67 @@ async fn test_keto_tuples_upsert_repairs_duplicates() {
 }
 
 #[tokio::test]
+async fn test_keto_tuples_upsert_with_subject_set() {
+    // Keto's relation-tuple filters use dotted notation
+    // (subject_set.namespace), not underscored. This test asserts the
+    // client emits the correct query-param keys for subject_set tuples
+    // — Keto's DELETE endpoint rejects unknown keys with HTTP 400 and
+    // would break upsert's repair path on dup'd subject_set tuples
+    // (e.g. parent edges in HRBAC seeds).
+    let read_server = MockServer::start().await;
+    let write_server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/relation-tuples"))
+        .and(query_param("namespace", "managementplane"))
+        .and(query_param("object", "na"))
+        .and(query_param("relation", "parent"))
+        .and(query_param("subject_set.namespace", "organization"))
+        .and(query_param("subject_set.object", "simons"))
+        .and(query_param("subject_set.relation", ""))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "relation_tuples": [
+                {"namespace": "managementplane", "object": "na", "relation": "parent",
+                 "subject_set": {"namespace": "organization", "object": "simons", "relation": ""}},
+                {"namespace": "managementplane", "object": "na", "relation": "parent",
+                 "subject_set": {"namespace": "organization", "object": "simons", "relation": ""}}
+            ],
+            "next_page_token": ""
+        })))
+        .mount(&read_server)
+        .await;
+    Mock::given(method("DELETE"))
+        .and(path("/admin/relation-tuples"))
+        .and(query_param("subject_set.namespace", "organization"))
+        .and(query_param("subject_set.object", "simons"))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(&write_server)
+        .await;
+    Mock::given(method("PUT"))
+        .and(path("/admin/relation-tuples"))
+        .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({})))
+        .mount(&write_server)
+        .await;
+
+    let script = format!(
+        r#"
+        local keto = require("assay.ory.keto")
+        local k = keto.client("{}", {{ write_url = "{}" }})
+        local action, dups = k.tuples:upsert({{
+          namespace = "managementplane",
+          object = "na",
+          relation = "parent",
+          subject_set = {{ namespace = "organization", object = "simons", relation = "" }},
+        }})
+        assert.eq(action, "repaired")
+        assert.eq(dups, 1)
+        "#,
+        read_server.uri(),
+        write_server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
 async fn test_keto_tuples_upsert_requires_write_url() {
     let read_server = MockServer::start().await;
 


### PR DESCRIPTION
## Summary

Two related bugs in `assay.ory.keto` that surfaced when `tuples:upsert` (added in #151) tried to repair duplicate tuples whose subject is a `subject_set` (parent edges in HRBAC seeds).

## Bug 1 — wrong filter key format

The client built filter query params as `subject_set_namespace`, `subject_set_object`, `subject_set_relation` (underscored), but Keto's API expects dotted notation: `subject_set.namespace`, etc.

- **GET `/relation-tuples`** silently ignored the unknown keys (returned unfiltered results — looked fine in practice but didn't actually filter).
- **DELETE `/admin/relation-tuples`** rejected with HTTP 400: `"query parameter key 'subject_set_namespace' unknown"`.
- This broke `tuples:upsert` on any subject_set tuple, since upsert's repair path goes through DELETE.

## Bug 2 — `build_query` skipped empty strings

`subject_set.relation = ""` is the common form for parent edges (`organization:simons → managementplane:na parent`). `build_query` was filtering out values where `v == ""`, so the relation never made it into the URL. With only `subject_set.namespace` and `subject_set.object` sent, Keto's filter semantics get ambiguous (some endpoints require all three).

Fix: skip only `nil`. Empty string was written deliberately by the caller.

## Touched

- `c.tuples:list` filter docs
- `c.tuples:delete` — subject_set params now dotted
- `c.tuples:upsert` — subject_set filter now dotted
- `build_check_params` (for `permissions:check` table form) — same fix
- `build_query` — drop the `v ~= ""` guard

## Tests

New: `test_keto_tuples_upsert_with_subject_set` — asserts the client emits `subject_set.namespace`, `subject_set.object`, `subject_set.relation=""` in the GET filter and that upsert's repair path completes against a wiremock returning 2 dups.

14 stdlib_ory_keto tests pass. `cargo clippy -p assay-lua --tests -- -D warnings` clean.

## Version

assay-lua `0.16.3 → 0.16.4` (patch — fixes only).