### PR TITLE
release: assay-lua 0.16.5 — empty array defaults serialise as [] not {}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,14 @@ All notable changes to Assay are documented here.
   `authz_require_admin`, `authz_bootstrap_first_admin`, `zanzibar_check`. All nil-defaulted;
   backward-compatible.
 
+## assay 0.16.5 — 2026-05-21
+
+### Fixed
+
+- Empty-array defaults in SDK payloads now serialise as `[]` (were `{}`, which upstreams reject as
+  type mismatch). Wrapped in `json.array()`: `ory.hydra` `consent:accept` `grant_access_token_audience`,
+  `tailscale` `mint_key` `tags`, `engine.auth` `passkey:start_auth` `passkeys`.
+
 ## assay 0.16.4 — 2026-05-19
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,7 +338,7 @@ dependencies = [
 
 [[package]]
 name = "assay-lua"
-version = "0.16.4"
+version = "0.16.5"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/assay/Cargo.toml
+++ b/crates/assay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-lua"
-version = "0.16.4"
+version = "0.16.5"
 categories = ["command-line-utilities", "development-tools::testing"]
 edition = "2024"
 homepage = "https://assay.rs"

--- a/crates/assay/stdlib/engine/auth.lua
+++ b/crates/assay/stdlib/engine/auth.lua
@@ -167,7 +167,7 @@ function M.client(opts)
   function c.passkey:start_auth(user_id, passkeys)
     return post(AUTH .. "/passkey/auth/start", {
       user_id = user_id,
-      passkeys = passkeys or {},
+      passkeys = json.array(passkeys or {}),
     })
   end
 

--- a/crates/assay/stdlib/ory/hydra.lua
+++ b/crates/assay/stdlib/ory/hydra.lua
@@ -243,9 +243,13 @@ function M.client(opts)
   --         session={id_token=table, access_token=table} }
   function c.consent:accept(challenge, opts)
     opts = opts or {}
+    -- json.array() wrap forces [] over {} on empty input, so Hydra
+    -- doesn't reject the payload with `cannot unmarshal object into
+    -- Go struct field AcceptOAuth2ConsentRequest.grant_access_token_audience
+    -- of type sqlxx.StringSliceJSONFormat`.
     local payload = {
-      grant_scope = opts.grant_scope or { "openid", "profile", "email" },
-      grant_access_token_audience = opts.grant_access_token_audience or {},
+      grant_scope = json.array(opts.grant_scope or { "openid", "profile", "email" }),
+      grant_access_token_audience = json.array(opts.grant_access_token_audience or {}),
       remember = opts.remember,
       remember_for = opts.remember_for,
       session = opts.session,

--- a/crates/assay/stdlib/tailscale.lua
+++ b/crates/assay/stdlib/tailscale.lua
@@ -115,7 +115,7 @@ function M.client(opts)
           reusable = mint_opts.reusable and true or false,
           ephemeral = mint_opts.ephemeral and true or false,
           preauthorized = mint_opts.preauthorized and true or false,
-          tags = mint_opts.tags or {},
+          tags = json.array(mint_opts.tags or {}),
         },
       },
     }

--- a/crates/assay/tests/stdlib_ory_hydra.rs
+++ b/crates/assay/tests/stdlib_ory_hydra.rs
@@ -182,6 +182,41 @@ async fn test_hydra_consent_accept_with_claims() {
     run_lua(&script).await.unwrap();
 }
 
+// Regression: when the caller doesn't pass grant_access_token_audience,
+// the Lua default of `or {}` used to serialise as `{}` (JSON object),
+// which Hydra rejects with `cannot unmarshal object into Go struct field
+// AcceptOAuth2ConsentRequest.grant_access_token_audience of type
+// sqlxx.StringSliceJSONFormat`. Wrap default in json.array() so it
+// serialises as `[]`.
+#[tokio::test]
+async fn test_hydra_consent_accept_empty_audience_is_json_array() {
+    let admin = MockServer::start().await;
+    Mock::given(method("PUT"))
+        .and(path("/admin/oauth2/auth/requests/consent/accept"))
+        .and(query_param("consent_challenge", "xyz789"))
+        .and(body_string_contains("\"grant_access_token_audience\":[]"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "redirect_to": "https://app.example.com/auth/callback?code=..."
+        })))
+        .mount(&admin)
+        .await;
+
+    let script = format!(
+        r#"
+        local hydra = require("assay.ory.hydra")
+        local h = hydra.client({{ admin_url = "{}" }})
+        -- No grant_access_token_audience passed → must serialise as [].
+        local result = h.consent:accept("xyz789", {{
+          grant_scope = {{"openid"}},
+          session = {{ id_token = {{ sub = "user:alice" }} }},
+        }})
+        assert.contains(result.redirect_to, "app.example.com")
+        "#,
+        admin.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
 #[tokio::test]
 async fn test_hydra_logout_get() {
     let admin = MockServer::start().await;


### PR DESCRIPTION
## Why

The Lua/JSON encoder treats empty tables as objects (`{}`), so SDK wrappers that default optional array-typed fields to `or {}` send the wrong shape and upstreams reject the payload.

User-visible blow-up: `hydra-auth` consent flow returned `runtime error: hydra: PUT /admin/oauth2/auth/requests/consent/accept HTTP 400: cannot unmarshal object into Go struct field AcceptOAuth2ConsentRequest.grant_access_token_audience of type sqlxx.StringSliceJSONFormat`. Login broken for any consumer that didn't explicitly pass `grant_access_token_audience`.

## Sweep

Audited stdlib for `or {}` defaults that go into JSON payloads. Three array-typed ones need fixing; the rest are either response parsing or correctly-typed empty objects (Vault kv `custom_md`, openclaw `args`, etc., left alone).

- `assay.ory.hydra` `c.consent:accept` — `grant_access_token_audience`, `grant_scope`
- `assay.tailscale` `c:mint_key` — `tags`
- `assay.engine.auth` `c.passkey:start_auth` — `passkeys`

## Fix

Wrap defaults in `json.array(...)` — forces `[]` shape on empty tables and is a no-op for already-non-empty arrays.

## Test

New regression `test_hydra_consent_accept_empty_audience_is_json_array` asserts wire body contains `"grant_access_token_audience":[]` when caller omits the field. All 13 hydra tests pass; `cargo clippy --tests -- -D warnings` clean.

## Release

0.16.4 → 0.16.5 (patch).