### PR TITLE
Fix vault console header layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,8 +39,9 @@ All notable changes to Assay are documented here.
 ### Fixed
 
 - Empty-array defaults in SDK payloads now serialise as `[]` (were `{}`, which upstreams reject as
-  type mismatch). Wrapped in `json.array()`: `ory.hydra` `consent:accept` `grant_access_token_audience`,
-  `tailscale` `mint_key` `tags`, `engine.auth` `passkey:start_auth` `passkeys`.
+  type mismatch). Wrapped in `json.array()`: `ory.hydra` `consent:accept`
+  `grant_access_token_audience`, `tailscale` `mint_key` `tags`, `engine.auth` `passkey:start_auth`
+  `passkeys`.
 
 ## assay 0.16.4 — 2026-05-19
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,7 +279,7 @@ dependencies = [
 
 [[package]]
 name = "assay-dashboard"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "assay-domain",
  "axum",

--- a/crates/assay-dashboard/Cargo.toml
+++ b/crates/assay-dashboard/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-dashboard"
-version = "0.4.1"
+version = "0.4.2"
 categories = ["web-programming::http-server"]
 edition = "2024"
 keywords = ["dashboard", "workflow", "auth", "assay"]

--- a/crates/assay-dashboard/assets/vault/app.js
+++ b/crates/assay-dashboard/assets/vault/app.js
@@ -85,6 +85,28 @@
     return '<div class="error-banner">' + escapeHtml(msg) + '</div>';
   }
 
+  // Header-bar identity strip — version, leader dot, instance id.
+  // Same public loader used by workflow/auth/engine consoles.
+  async function loadHeaderIdentity() {
+    try {
+      const r = await fetch('/api/v1/engine/core/info', { headers: { 'accept': 'application/json' } });
+      if (!r.ok) return;
+      const info = await r.json();
+      const v = document.getElementById('cross-nav-version');
+      if (v && info.version) v.textContent = 'v' + info.version;
+      const dot = document.getElementById('cross-nav-leader-dot');
+      const txt = document.getElementById('cross-nav-leader-text');
+      if (dot) dot.classList.toggle('leader', !!info.leader);
+      if (txt) txt.textContent = info.leader ? 'leader' : 'follower';
+      const inst = document.getElementById('cross-nav-instance');
+      if (inst && info.instance_id) {
+        const id = info.instance_id;
+        inst.textContent = 'instance:' + id.slice(0, 6) + '…' + id.slice(-4);
+        inst.title = 'instance ' + id;
+      }
+    } catch (_) { /* leave placeholders */ }
+  }
+
   function statusCard(title, value, pillClass) {
     const v = pillClass
       ? '<span class="pill ' + pillClass + '">' + escapeHtml(value) + '</span>'
@@ -614,6 +636,7 @@
   if (window.AssayCrossNav) {
     window.AssayCrossNav.render({ active: 'vault' });
   }
+  loadHeaderIdentity();
 
   // Theme toggle wiring — pre-paint script in <head> already set
   // data-theme; this just bridges the toggle button to localStorage.

--- a/crates/assay-dashboard/assets/vault/style.css
+++ b/crates/assay-dashboard/assets/vault/style.css
@@ -4,16 +4,15 @@
  */
 
 .layout {
-  display: grid;
-  grid-template-columns: 220px 1fr;
-  gap: var(--gap-md, 1rem);
-  padding: var(--gap-md, 1rem);
-  min-height: calc(100vh - 56px);
+  display: flex;
+  gap: 0;
+  min-height: 0;
+  padding: var(--cross-nav-h) 0 0;
 }
 
 .sidebar {
   border-right: 1px solid var(--border, #2a2a2a);
-  padding-right: 1rem;
+  padding-right: 0;
 }
 
 .sidebar h2 {
@@ -55,10 +54,10 @@
   width: 100%;
   padding: 0.4rem;
   margin-bottom: 0.4rem;
-  background: var(--bg-elev, #1a1a1a);
+  background: var(--bg, #fff);
   border: 1px solid var(--border, #2a2a2a);
   color: inherit;
-  border-radius: 4px;
+  border-radius: 6px;
   font-family: ui-monospace, monospace;
   font-size: 0.85rem;
 }
@@ -74,11 +73,11 @@
   font-weight: 500;
 }
 
-.content {
+.main-content {
   min-width: 0;
 }
 
-.content h1 {
+.main-content h1 {
   margin-top: 0;
 }
 
@@ -90,10 +89,10 @@
 }
 
 .pane-status .card {
-  background: var(--bg-elev, #1a1a1a);
+  background: var(--surface, #fff);
   border: 1px solid var(--border, #2a2a2a);
   padding: 1rem;
-  border-radius: 6px;
+  border-radius: 8px;
 }
 
 .pane-status .card h3 {
@@ -119,8 +118,8 @@
 }
 
 .pill-sealed { background: #872; color: #fff; }
-.pill-unsealed { background: #181; color: #fff; }
-.pill-error { background: #c33; color: #fff; }
+.pill-unsealed { background: var(--green, #1a7f37); color: #fff; }
+.pill-error { background: var(--red, #cf222e); color: #fff; }
 
 table.data {
   width: 100%;
@@ -146,16 +145,16 @@ table.data th {
   display: inline-block;
   padding: 0.4rem 0.9rem;
   margin-right: 0.4rem;
-  background: var(--bg-elev, #1a1a1a);
+  background: var(--surface, #fff);
   border: 1px solid var(--border, #2a2a2a);
   color: inherit;
-  border-radius: 4px;
+  border-radius: 6px;
   text-decoration: none;
   cursor: pointer;
   font-size: 0.9rem;
 }
 
-.btn:hover { background: var(--bg-hover, #222); }
+.btn:hover { background: var(--surface-hover, #eef1f4); }
 
 .btn-primary {
   background: var(--accent, #6cf);
@@ -164,8 +163,8 @@ table.data th {
 }
 
 .btn-danger {
-  background: #c33;
-  border-color: #c33;
+  background: var(--red, #cf222e);
+  border-color: var(--red, #cf222e);
   color: #fff;
 }
 
@@ -185,7 +184,7 @@ table.data th {
   flex: 1;
   min-width: 200px;
   padding: 0.4rem;
-  background: var(--bg-elev, #1a1a1a);
+  background: var(--surface, #fff);
   border: 1px solid var(--border, #2a2a2a);
   color: inherit;
   border-radius: 4px;
@@ -193,7 +192,7 @@ table.data th {
 }
 
 pre.json {
-  background: var(--bg-elev, #1a1a1a);
+  background: var(--surface, #fff);
   border: 1px solid var(--border, #2a2a2a);
   padding: 0.75rem;
   border-radius: 4px;
@@ -202,10 +201,10 @@ pre.json {
 }
 
 .error-banner {
-  background: #4a1818;
-  border: 1px solid #c33;
-  color: #fbb;
+  background: color-mix(in srgb, var(--red, #cf222e) 12%, transparent);
+  border: 1px solid var(--red, #cf222e);
+  color: var(--text);
   padding: 0.6rem 0.9rem;
-  border-radius: 4px;
+  border-radius: 6px;
   margin-bottom: 1rem;
 }

--- a/crates/assay-engine/tests-e2e/vault-console.spec.ts
+++ b/crates/assay-engine/tests-e2e/vault-console.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from '@playwright/test';
+import { waitForCrossNav } from './_setup';
+
+test.describe('Vault console', () => {
+  test('chrome sits below the fixed cross-console header', async ({ page }) => {
+    await page.goto('/workflow/');
+    await page.evaluate((token) => {
+      window.localStorage.setItem('assay-admin-token', token);
+      window.localStorage.setItem('assay-theme', 'light');
+    }, process.env.ASSAY_E2E_ADMIN_KEY || 'dev-admin-key-change-me');
+    await page.goto('/vault/console');
+    await waitForCrossNav(page);
+    await expect(page.locator('.console-tab[data-tab="vault"]')).toHaveClass(/active/);
+    await expect(page.locator('#cross-nav-version')).toHaveText(/v\d+\.\d+\.\d+/);
+    await expect(page.locator('#cross-nav-leader-dot')).toHaveClass(/leader/);
+    await expect(page.locator('#cross-nav-instance')).toContainText(/instance:/);
+    await expect(page.locator('#cross-nav-instance')).not.toHaveText('instance:—');
+
+    const layout = await page.evaluate(() => {
+      const header = document.querySelector('.cross-nav')?.getBoundingClientRect();
+      const sidebarHeader = document.querySelector('.sidebar-header')?.getBoundingClientRect();
+      const main = document.querySelector('.main-content')?.getBoundingClientRect();
+      if (!header || !sidebarHeader || !main) {
+        throw new Error('vault console chrome was not rendered');
+      }
+      return {
+        headerBottom: header.bottom,
+        sidebarHeaderTop: sidebarHeader.top,
+        mainTop: main.top,
+      };
+    });
+
+    expect(layout.sidebarHeaderTop).toBeGreaterThanOrEqual(layout.headerBottom);
+    expect(layout.mainTop).toBeGreaterThanOrEqual(layout.headerBottom);
+
+    const colors = await page.evaluate(() => {
+      const probe = document.createElement('div');
+      probe.style.backgroundColor = 'var(--surface)';
+      document.body.appendChild(probe);
+      const surface = getComputedStyle(probe).backgroundColor;
+      probe.remove();
+
+      const card = document.querySelector('.pane-status .card');
+      const button = document.querySelector('#btn-init');
+      if (!card || !button) {
+        throw new Error('vault sealing controls were not rendered');
+      }
+      return {
+        surface,
+        cardBackground: getComputedStyle(card).backgroundColor,
+        buttonBackground: getComputedStyle(button).backgroundColor,
+      };
+    });
+
+    expect(colors.cardBackground).toBe(colors.surface);
+    expect(colors.buttonBackground).toBe(colors.surface);
+  });
+});


### PR DESCRIPTION
Summary:
- Align vault console layout with the fixed shared cross-console header.
- Use shared light-theme surface tokens for vault cards, controls, and errors.
- Populate vault cross-nav version, leader, and instance identity.
- Bump assay-dashboard to 0.4.2 and add a Playwright regression.
- Includes a dprint-only CHANGELOG wrap required by the repo pre-commit hook.

Verification:
- CARGO_TARGET_DIR=/home/eda/code/assay/target cargo build --release -p assay-engine
- Restarted local gondor-engine.service
- ASSAY_E2E_BASE=https://gondor-engine.agenteda.com bunx playwright test vault-console.spec.ts --reporter=list
- dprint check
- git diff --check