### PR TITLE
release: assay-lua 0.16.6 — URL-encode credentials in postgres DSN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,12 @@ All notable changes to Assay are documented here.
   `authz_require_admin`, `authz_bootstrap_first_admin`, `zanzibar_check`. All nil-defaulted;
   backward-compatible.
 
+## assay 0.16.6 — 2026-05-22
+
+### Fixed
+
+- `assay.postgres.client` percent-encodes username + password in the DSN. Passwords with `?`/`/`/`#`/`@` used to break sqlx URL parsing.
+
 ## assay 0.16.5 — 2026-05-21
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,7 +338,7 @@ dependencies = [
 
 [[package]]
 name = "assay-lua"
-version = "0.16.5"
+version = "0.16.6"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/assay/Cargo.toml
+++ b/crates/assay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-lua"
-version = "0.16.5"
+version = "0.16.6"
 categories = ["command-line-utilities", "development-tools::testing"]
 edition = "2024"
 homepage = "https://assay.rs"

--- a/crates/assay/stdlib/postgres.lua
+++ b/crates/assay/stdlib/postgres.lua
@@ -13,9 +13,24 @@
 
 local M = {}
 
+-- Percent-encode every character outside the URI userinfo unreserved set
+-- (RFC 3986 §3.2.1). Without this, passwords containing "?", "/", "#",
+-- "@" — common in generated AWS RDS masteradmin secrets — break sqlx's
+-- URL parser (most visibly with "invalid port number" because the "?"
+-- gets read as the start of a query string).
+local function urlencode(s)
+  return (tostring(s):gsub("([^%w%-%.%_%~])", function(c)
+    return string.format("%%%02X", string.byte(c))
+  end))
+end
+
+function M._build_dsn(host, port, username, password, database)
+  return "postgres://" .. urlencode(username) .. ":" .. urlencode(password)
+    .. "@" .. host .. ":" .. tostring(port) .. "/" .. (database or "postgres")
+end
+
 function M.client(host, port, username, password, database)
-  local dsn = "postgres://" .. username .. ":" .. password .. "@" .. host .. ":" .. tostring(port) .. "/" .. (database or "postgres")
-  local pool = db.connect(dsn)
+  local pool = db.connect(M._build_dsn(host, port, username, password, database))
 
   -- ===== Client =====
 

--- a/crates/assay/tests/stdlib_postgres.rs
+++ b/crates/assay/tests/stdlib_postgres.rs
@@ -11,8 +11,74 @@ async fn test_require_postgres() {
         assert.not_nil(pg.client_from_vault, "postgres.client_from_vault should exist")
         assert.not_nil(pg._quote_ident, "postgres._quote_ident should exist")
         assert.not_nil(pg._quote_literal, "postgres._quote_literal should exist")
+        assert.not_nil(pg._build_dsn, "postgres._build_dsn should exist")
     "#;
     run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_postgres_build_dsn_plain() {
+    let result: String = eval_lua(
+        r#"
+        local pg = require("assay.postgres")
+        return pg._build_dsn("localhost", 5432, "alice", "s3cret", "mydb")
+    "#,
+    )
+    .await;
+    assert_eq!(result, "postgres://alice:s3cret@localhost:5432/mydb");
+}
+
+// Regression: AWS RDS generated passwords routinely contain "?", "/",
+// "#", "@" — the URI sub-delim/gen-delim set. Concatenating raw used
+// to break sqlx's URL parser ("invalid port number" because "?" was
+// read as the query-string boundary).
+#[tokio::test]
+async fn test_postgres_build_dsn_password_with_url_specials() {
+    let result: String = eval_lua(
+        r#"
+        local pg = require("assay.postgres")
+        return pg._build_dsn("host", 5432, "user", "di_)XJp0NTl[P|?)a7b@k9", "postgres")
+    "#,
+    )
+    .await;
+    assert!(
+        !result.contains("|?"),
+        "raw '?' must not appear in the DSN authority — got {result}"
+    );
+    assert!(
+        result.contains("%3F"),
+        "'?' must be percent-encoded to %3F — got {result}"
+    );
+    // Confirms the URL parses as expected: port 5432 visible in the right slot.
+    assert!(
+        result.contains("@host:5432/postgres"),
+        "host/port must be after the encoded password — got {result}"
+    );
+}
+
+#[tokio::test]
+async fn test_postgres_build_dsn_password_with_at_sign() {
+    let result: String = eval_lua(
+        r#"
+        local pg = require("assay.postgres")
+        return pg._build_dsn("host", 5432, "user", "a@b", "postgres")
+    "#,
+    )
+    .await;
+    assert!(result.contains("a%40b"));
+    assert!(result.ends_with("@host:5432/postgres"));
+}
+
+#[tokio::test]
+async fn test_postgres_build_dsn_username_encoded() {
+    let result: String = eval_lua(
+        r#"
+        local pg = require("assay.postgres")
+        return pg._build_dsn("host", 5432, "us er", "pw", "db")
+    "#,
+    )
+    .await;
+    assert!(result.contains("us%20er:pw"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Why

\`postgres.client(host, port, username, password)\` built the DSN by raw string concat. Passwords containing URI sub/gen-delim characters (\`?\`, \`/\`, \`#\`, \`@\`) — routine in AWS RDS generated masteradmin secrets — broke sqlx's URL parser with \`error with configuration: invalid port number\` (the \`?\` was being read as the query-string boundary).

Found while bringing up cc/agents in QA where the RDS password contained \`?\`.

## Fix

Percent-encode username + password before constructing the DSN.

## Audit

Swept stdlib for other credential-in-URL constructions. Only \`postgres.lua\` was affected. Other connection-string-ish constructions are HTTP Basic-auth headers (\`grafana\`, \`argocd\`, \`harbor\`) which base64-encode and aren't URL parsers — unaffected.

## Test

Added 4 regression tests against \`_build_dsn\` covering \`?\`, \`@\`, space in user/password, plus the plain case.

## Release

0.16.5 → 0.16.6 (patch).