### PR TITLE
fix: clean up postgres test databases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,6 +259,20 @@ jobs:
         env:
           MOON_LOG: "info"
 
+      - name: Cleanup self-hosted Postgres test databases
+        if: always() && steps.targets.outputs.run_checks == 'true' && needs.changes.outputs.assay_rust == 'true' && runner.os == 'Linux' && runner.environment == 'self-hosted'
+        run: |
+          psql "$TEST_DATABASE_URL" -v ON_ERROR_STOP=1 <<'SQL'
+          SELECT pg_terminate_backend(pid)
+          FROM pg_stat_activity
+          WHERE datname LIKE 'assay_test_%';
+
+          SELECT format('DROP DATABASE IF EXISTS %I WITH (FORCE);', datname)
+          FROM pg_database
+          WHERE datname LIKE 'assay_test_%'
+          \gexec
+          SQL
+
       # `assay site/build.lua` (the moon `site:build` task above)
       # rewrites the stdlib table in README.md in place from
       # docs/modules/*.md frontmatter. If that rewrite produced a diff,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,14 @@ Use the main checkout for active work. Do not create extra git worktrees for thi
 human operator explicitly asks for parallel checkouts; one workstream in the main worktree is
 enough.
 
+## Self-hosted CI runner
+
+The GitHub Actions runner named `assay-runner-eda` runs inside the `assay-runner` systemd-nspawn
+machine on the EDA server. Treat its services as persistent, not ephemeral. In particular, its
+Postgres service is a long-lived system service used by Linux CI via `TEST_DATABASE_URL`; tests must
+drop any `assay_test_*` databases they create, and CI should keep an `always()` cleanup guard for
+that prefix.
+
 ## Library hygiene: no application-domain leakage
 
 **Assay is a general-purpose library. It must have zero knowledge of any specific application that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,8 @@ All notable changes to Assay are documented here.
 
 ### Fixed
 
-- `assay.postgres.client` percent-encodes username + password in the DSN. Passwords with `?`/`/`/`#`/`@` used to break sqlx URL parsing.
+- `assay.postgres.client` percent-encodes username + password in the DSN. Passwords with
+  `?`/`/`/`#`/`@` used to break sqlx URL parsing.
 
 ## assay 0.16.5 — 2026-05-21
 

--- a/crates/assay-workflow/tests/common/harness.rs
+++ b/crates/assay-workflow/tests/common/harness.rs
@@ -24,13 +24,8 @@ pub use assay_domain::types::{SchedulePatch, WorkflowSchedule, WorkflowSnapshot,
 pub enum Harness {
     #[cfg(feature = "backend-postgres")]
     Postgres {
-        // Held only when this test owns a dedicated testcontainer (local dev
-        // path). In CI, `TEST_DATABASE_URL` points to a shared Postgres
-        // service and this is `None`; the per-test database that the harness
-        // creates leaks harmlessly inside the shared container for the
-        // remainder of the job.
-        _container:
-            Option<testcontainers::ContainerAsync<testcontainers_modules::postgres::Postgres>>,
+        // Owns the per-test database and drops it when the harness leaves scope.
+        database: TestPostgresDatabase,
         store: assay_workflow::PostgresStore,
     },
     #[cfg(feature = "backend-sqlite")]
@@ -433,52 +428,117 @@ pub fn make_event(workflow_id: &str, seq: i32) -> WorkflowEvent {
 
 #[cfg(feature = "backend-postgres")]
 async fn postgres_harness() -> anyhow::Result<Harness> {
-    use sqlx::postgres::{PgConnectOptions, PgPool};
-    use std::str::FromStr;
-
-    // Both CI and local dev share a single Postgres server and carve out a
-    // fresh database per test. On CI, the server is a `docker run` pre-step
-    // that exposes `TEST_DATABASE_URL`. Locally, a testcontainer is started
-    // on the first test that needs it and reused for the rest of the
-    // process — eliminating both per-test container spin-up and the Drop
-    // deadlock that used to turn a timeout-panic into a 60-min silent hang.
+    // CI points `TEST_DATABASE_URL` at a shared Postgres server and carves
+    // out a fresh database per test. Local dev can fall back to an owned
+    // testcontainer per Postgres case; the container is held by
+    // `TestPostgresDatabase` and removed when the test database guard drops.
     // `env::var` returns `Ok("")` when the variable is set but empty — treat
     // that the same as unset so callers can "clear" the URL with
     // `TEST_DATABASE_URL=` without falling through to a broken connect.
-    let admin_url = match std::env::var("TEST_DATABASE_URL") {
-        Ok(url) if !url.is_empty() => url,
-        _ => shared_local_pg_url().await?,
-    };
-
-    let admin_opts = PgConnectOptions::from_str(&admin_url)?;
-    let admin_pool = PgPool::connect_with(admin_opts.clone()).await?;
-
-    let db_name = unique_db_name();
-    sqlx::query(&format!(r#"CREATE DATABASE "{db_name}""#))
-        .execute(&admin_pool)
-        .await?;
-    admin_pool.close().await;
-
-    let test_pool = PgPool::connect_with(admin_opts.database(&db_name)).await?;
-    let store = assay_workflow::PostgresStore::from_pool(test_pool).await?;
-    Ok(Harness::Postgres {
-        _container: None,
-        store,
-    })
+    let server = TestPostgresServer::from_env_or_container().await?;
+    let database = TestPostgresDatabase::create(server).await?;
+    let store = assay_workflow::PostgresStore::from_pool(database.pool().clone()).await?;
+    Ok(Harness::Postgres { database, store })
 }
 
-/// Start (or return the already-started) testcontainer that backs local test
-/// runs when `TEST_DATABASE_URL` is not set. The container is intentionally
-/// leaked via `mem::forget` once its URL is known — its `Drop` impl
-/// synchronously calls `docker stop` through `Handle::block_on`, which is
-/// unsafe during process teardown after the test runtime has shut down.
-/// testcontainers' ryuk reaper cleans up abandoned containers after the test
-/// process exits, so nothing stays resident long-term.
 #[cfg(feature = "backend-postgres")]
-pub async fn shared_local_pg_url() -> anyhow::Result<String> {
-    use tokio::sync::OnceCell;
-    static URL: OnceCell<String> = OnceCell::const_new();
-    URL.get_or_try_init(|| async {
+pub struct TestPostgresDatabase {
+    db_name: String,
+    admin_opts: sqlx::postgres::PgConnectOptions,
+    pool: sqlx::PgPool,
+    server: TestPostgresServer,
+}
+
+#[cfg(feature = "backend-postgres")]
+impl TestPostgresDatabase {
+    pub async fn create(server: TestPostgresServer) -> anyhow::Result<Self> {
+        use sqlx::postgres::{PgConnectOptions, PgPool};
+        use std::str::FromStr;
+
+        let admin_opts = PgConnectOptions::from_str(server.admin_url())?;
+        let admin_pool = PgPool::connect_with(admin_opts.clone()).await?;
+
+        let db_name = unique_db_name();
+        sqlx::query(&format!(r#"CREATE DATABASE "{db_name}""#))
+            .execute(&admin_pool)
+            .await?;
+        admin_pool.close().await;
+
+        let pool = PgPool::connect_with(admin_opts.clone().database(&db_name)).await?;
+        Ok(Self {
+            db_name,
+            admin_opts,
+            pool,
+            server,
+        })
+    }
+
+    pub fn db_name(&self) -> &str {
+        &self.db_name
+    }
+
+    pub fn pool(&self) -> &sqlx::PgPool {
+        &self.pool
+    }
+}
+
+#[cfg(feature = "backend-postgres")]
+impl Drop for TestPostgresDatabase {
+    fn drop(&mut self) {
+        let db_name = self.db_name.clone();
+        let admin_opts = self.admin_opts.clone();
+        let pool = self.pool.clone();
+        let cleanup = std::thread::spawn(move || {
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()?;
+            runtime.block_on(drop_test_postgres_database(admin_opts, db_name, pool))
+        })
+        .join();
+
+        match cleanup {
+            Ok(Ok(())) => {}
+            Ok(Err(err)) => eprintln!("failed to drop test Postgres database: {err:#}"),
+            Err(_) => eprintln!("test Postgres database cleanup thread panicked"),
+        }
+    }
+}
+
+#[cfg(feature = "backend-postgres")]
+async fn drop_test_postgres_database(
+    admin_opts: sqlx::postgres::PgConnectOptions,
+    db_name: String,
+    pool: sqlx::PgPool,
+) -> anyhow::Result<()> {
+    pool.close().await;
+    let admin_pool = sqlx::PgPool::connect_with(admin_opts).await?;
+    sqlx::query(&format!(
+        r#"DROP DATABASE IF EXISTS "{db_name}" WITH (FORCE)"#
+    ))
+    .execute(&admin_pool)
+    .await?;
+    admin_pool.close().await;
+    Ok(())
+}
+
+#[cfg(feature = "backend-postgres")]
+pub struct TestPostgresServer {
+    admin_url: String,
+    container: Option<testcontainers::ContainerAsync<testcontainers_modules::postgres::Postgres>>,
+}
+
+#[cfg(feature = "backend-postgres")]
+impl TestPostgresServer {
+    pub async fn from_env_or_container() -> anyhow::Result<Self> {
+        if let Ok(url) = std::env::var("TEST_DATABASE_URL")
+            && !url.is_empty()
+        {
+            return Ok(Self {
+                admin_url: url,
+                container: None,
+            });
+        }
+
         use testcontainers::ImageExt;
         use testcontainers::runners::AsyncRunner;
         use testcontainers_modules::postgres::Postgres as PgImage;
@@ -486,12 +546,15 @@ pub async fn shared_local_pg_url() -> anyhow::Result<String> {
         let container = PgImage::default().with_tag("18-alpine").start().await?;
         let host = container.get_host().await?;
         let port = container.get_host_port_ipv4(5432).await?;
-        let url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
-        std::mem::forget(container);
-        Ok::<_, anyhow::Error>(url)
-    })
-    .await
-    .cloned()
+        Ok(Self {
+            admin_url: format!("postgres://postgres:postgres@{host}:{port}/postgres"),
+            container: Some(container),
+        })
+    }
+
+    fn admin_url(&self) -> &str {
+        &self.admin_url
+    }
 }
 
 /// Produce a database name unique across tests within this process. Nanos + a

--- a/crates/assay-workflow/tests/common/harness.rs
+++ b/crates/assay-workflow/tests/common/harness.rs
@@ -487,12 +487,11 @@ impl Drop for TestPostgresDatabase {
     fn drop(&mut self) {
         let db_name = self.db_name.clone();
         let admin_opts = self.admin_opts.clone();
-        let pool = self.pool.clone();
         let cleanup = std::thread::spawn(move || {
             let runtime = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()?;
-            runtime.block_on(drop_test_postgres_database(admin_opts, db_name, pool))
+            runtime.block_on(drop_test_postgres_database(admin_opts, db_name))
         })
         .join();
 
@@ -508,15 +507,15 @@ impl Drop for TestPostgresDatabase {
 async fn drop_test_postgres_database(
     admin_opts: sqlx::postgres::PgConnectOptions,
     db_name: String,
-    pool: sqlx::PgPool,
 ) -> anyhow::Result<()> {
-    pool.close().await;
     let admin_pool = sqlx::PgPool::connect_with(admin_opts).await?;
-    sqlx::query(&format!(
-        r#"DROP DATABASE IF EXISTS "{db_name}" WITH (FORCE)"#
-    ))
-    .execute(&admin_pool)
-    .await?;
+    sqlx::query("SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = $1")
+        .bind(&db_name)
+        .execute(&admin_pool)
+        .await?;
+    sqlx::query(&format!(r#"DROP DATABASE IF EXISTS "{db_name}""#))
+        .execute(&admin_pool)
+        .await?;
     admin_pool.close().await;
     Ok(())
 }

--- a/crates/assay-workflow/tests/common/harness.rs
+++ b/crates/assay-workflow/tests/common/harness.rs
@@ -24,9 +24,9 @@ pub use assay_domain::types::{SchedulePatch, WorkflowSchedule, WorkflowSnapshot,
 pub enum Harness {
     #[cfg(feature = "backend-postgres")]
     Postgres {
+        store: assay_workflow::PostgresStore,
         // Owns the per-test database and drops it when the harness leaves scope.
         database: TestPostgresDatabase,
-        store: assay_workflow::PostgresStore,
     },
     #[cfg(feature = "backend-sqlite")]
     Sqlite {
@@ -438,7 +438,7 @@ async fn postgres_harness() -> anyhow::Result<Harness> {
     let server = TestPostgresServer::from_env_or_container().await?;
     let database = TestPostgresDatabase::create(server).await?;
     let store = assay_workflow::PostgresStore::from_pool(database.pool().clone()).await?;
-    Ok(Harness::Postgres { database, store })
+    Ok(Harness::Postgres { store, database })
 }
 
 #[cfg(feature = "backend-postgres")]

--- a/crates/assay-workflow/tests/postgres_store.rs
+++ b/crates/assay-workflow/tests/postgres_store.rs
@@ -53,8 +53,8 @@ async fn database_exists(db_name: &str) -> anyhow::Result<bool> {
 }
 
 struct TestStore {
-    database: TestPostgresDatabase,
     store: PostgresStore,
+    database: TestPostgresDatabase,
 }
 
 impl TestStore {

--- a/crates/assay-workflow/tests/postgres_store.rs
+++ b/crates/assay-workflow/tests/postgres_store.rs
@@ -14,59 +14,61 @@ mod common;
 use assay_workflow::store::WorkflowStore;
 use assay_workflow::store::postgres::PostgresStore;
 use assay_workflow::types::*;
-
-fn docker_available() -> bool {
-    std::process::Command::new("docker")
-        .arg("info")
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false)
-}
+use common::harness::TestPostgresDatabase;
+use common::harness::TestPostgresServer;
+use std::ops::Deref;
 
 /// Returns a fresh `PostgresStore` for this test — its own database on the
 /// shared server. `None` signals skip when Docker is unavailable and no
 /// shared URL is configured.
-async fn create_store() -> Option<PostgresStore> {
-    let admin_url = match std::env::var("TEST_DATABASE_URL") {
-        Ok(url) if !url.is_empty() => url,
-        _ => {
-            if !docker_available() {
-                eprintln!("Skipping: Docker not available and TEST_DATABASE_URL unset");
-                return None;
-            }
-            common::harness::shared_local_pg_url().await.ok()?
+async fn create_store() -> Option<TestStore> {
+    let server = match TestPostgresServer::from_env_or_container().await {
+        Ok(server) => server,
+        Err(err) => {
+            eprintln!("Skipping: Postgres unavailable: {err:#}");
+            return None;
         }
     };
-
-    use sqlx::postgres::{PgConnectOptions, PgPool};
-    use std::str::FromStr;
-    let admin_opts = PgConnectOptions::from_str(&admin_url).unwrap();
-    let admin_pool = PgPool::connect_with(admin_opts.clone()).await.unwrap();
-    let db_name = unique_db_name();
-    sqlx::query(&format!(r#"CREATE DATABASE "{db_name}""#))
-        .execute(&admin_pool)
+    let database = TestPostgresDatabase::create(server).await.unwrap();
+    let store = PostgresStore::from_pool(database.pool().clone())
         .await
         .unwrap();
-    admin_pool.close().await;
-    let pool = PgPool::connect_with(admin_opts.database(&db_name))
-        .await
-        .unwrap();
-    let store = PostgresStore::from_pool(pool).await.unwrap();
-    Some(store)
+    Some(TestStore { database, store })
 }
 
-fn unique_db_name() -> String {
-    use std::sync::atomic::{AtomicU64, Ordering};
-    use std::time::{SystemTime, UNIX_EPOCH};
-    static SEQ: AtomicU64 = AtomicU64::new(0);
-    let t = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
-    let n = SEQ.fetch_add(1, Ordering::Relaxed);
-    format!("assay_test_{t}_{n}")
+async fn database_exists(db_name: &str) -> anyhow::Result<bool> {
+    use sqlx::postgres::{PgConnectOptions, PgPool};
+    use std::str::FromStr;
+    let admin_url = std::env::var("TEST_DATABASE_URL")?;
+    let admin_opts = PgConnectOptions::from_str(&admin_url).unwrap();
+    let admin_pool = PgPool::connect_with(admin_opts).await?;
+    let exists = sqlx::query_scalar::<_, bool>(
+        "SELECT EXISTS(SELECT 1 FROM pg_database WHERE datname = $1)",
+    )
+    .bind(db_name)
+    .fetch_one(&admin_pool)
+    .await?;
+    admin_pool.close().await;
+    Ok(exists)
+}
+
+struct TestStore {
+    database: TestPostgresDatabase,
+    store: PostgresStore,
+}
+
+impl TestStore {
+    fn db_name(&self) -> &str {
+        self.database.db_name()
+    }
+}
+
+impl Deref for TestStore {
+    type Target = PostgresStore;
+
+    fn deref(&self) -> &Self::Target {
+        &self.store
+    }
 }
 
 /// Macro to skip tests when no Postgres is available. The second argument
@@ -123,6 +125,31 @@ async fn pg_workflow_create_and_get() {
     assert_eq!(fetched.namespace, "main");
     assert_eq!(fetched.workflow_type, "IngestData");
     assert_eq!(fetched.status, "PENDING");
+}
+
+#[tokio::test]
+async fn pg_test_database_is_dropped_after_store_goes_out_of_scope() {
+    if std::env::var("TEST_DATABASE_URL")
+        .ok()
+        .filter(|url| !url.is_empty())
+        .is_none()
+    {
+        return;
+    }
+
+    let db_name = {
+        let Some(store) = create_store().await else {
+            return;
+        };
+        let db_name = store.db_name().to_string();
+        store.create_namespace("cleanup-probe").await.unwrap();
+        db_name
+    };
+
+    assert!(
+        !database_exists(&db_name).await.unwrap(),
+        "test database {db_name} should be dropped when its store is dropped"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- make Postgres test databases owned by a cleanup guard instead of leaking `assay_test_*` databases
- remove the mem-forgotten shared local Testcontainers fallback; local Docker fallback containers are now owned and removed
- add a self-hosted CI cleanup step for `assay_test_%` databases as a failure-path guard
- format CHANGELOG.md because the repo pre-commit hook runs whole-repo dprint and origin/main had one stale line

## Verification

- CARGO_TARGET_DIR=/var/build/assay-target cargo test -p assay-workflow --test postgres_store
- CARGO_TARGET_DIR=/var/build/assay-target cargo test -p assay-workflow --test smoke_backends
- TEST_DATABASE_URL=postgres://postgres:postgres@localhost:55432/postgres CARGO_TARGET_DIR=/var/build/assay-target cargo test -p assay-workflow --test postgres_store pg_test_database_is_dropped_after_store_goes_out_of_scope
- CARGO_TARGET_DIR=/var/build/assay-target cargo clippy -p assay-workflow --tests -- -D warnings
- Docker Testcontainers remaining: 0
- assay-runner `assay_test_%` database count: 0