### PR TITLE
feat: add yaml parse_all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to Assay are documented here.
 
+## assay 0.16.7 — 2026-05-26
+
+### Added
+
+- `yaml.parse_all(str)` parses multi-document YAML streams into a Lua array, skipping empty
+  documents. This removes per-script YAML stream splitting for Helm/Kubernetes render checks.
+
 ## sysops 0.2.0 — 2026-05-20
 
 ### Added
@@ -38,7 +45,8 @@ All notable changes to Assay are documented here.
 
 ### Fixed
 
-- `assay.postgres.client` percent-encodes username + password in the DSN. Passwords with `?`/`/`/`#`/`@` used to break sqlx URL parsing.
+- `assay.postgres.client` percent-encodes username + password in the DSN. Passwords with
+  `?`/`/`/`#`/`@` used to break sqlx URL parsing.
 
 ## assay 0.16.5 — 2026-05-21
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,7 +338,7 @@ dependencies = [
 
 [[package]]
 name = "assay-lua"
-version = "0.16.6"
+version = "0.16.7"
 dependencies = [
  "anyhow",
  "axum",

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ All 17 Rust builtins are available globally in `.lua` scripts — no `require` n
 | Function                                    | Description |
 | ------------------------------------------- | ----------- |
 | `json.parse(str)` / `json.encode(tbl)`      | JSON        |
-| `yaml.parse(str)` / `yaml.encode(tbl)`      | YAML        |
+| `yaml.parse(str)` / `yaml.parse_all(str)` / `yaml.encode(tbl)` | YAML stream/documents |
 | `toml.parse(str)` / `toml.encode(tbl)`      | TOML        |
 | `base64.encode(str)` / `base64.decode(str)` | Base64      |
 

--- a/crates/assay/Cargo.toml
+++ b/crates/assay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-lua"
-version = "0.16.6"
+version = "0.16.7"
 categories = ["command-line-utilities", "development-tools::testing"]
 edition = "2024"
 homepage = "https://assay.rs"

--- a/crates/assay/src/context.rs
+++ b/crates/assay/src/context.rs
@@ -58,7 +58,9 @@ pub fn format_context(entries: &[ModuleContextEntry]) -> String {
     output.push_str("## Built-in Functions (always available, no require needed)\n");
     output.push_str("http.get(url, opts?) -> {status, body, headers}\n");
     output.push_str("json.parse(str) -> table | json.encode(tbl) -> str\n");
-    output.push_str("yaml.parse(str) -> table | yaml.encode(tbl) -> str\n");
+    output.push_str(
+        "yaml.parse(str) -> table | yaml.parse_all(str) -> [table] | yaml.encode(tbl) -> str\n",
+    );
     output.push_str("toml.parse(str) -> table | toml.encode(tbl) -> str\n");
     output.push_str("base64.encode(str) -> str | base64.decode(str) -> str\n");
     output.push_str("crypto.jwt_sign(claims, key, alg) -> token\n");

--- a/crates/assay/src/lua/builtins/serialization.rs
+++ b/crates/assay/src/lua/builtins/serialization.rs
@@ -1,5 +1,6 @@
 use super::json::{json_value_to_lua, lua_value_to_json};
 use mlua::{Lua, Value};
+use serde::Deserialize;
 
 pub fn register_yaml(lua: &Lua) -> mlua::Result<()> {
     let yaml_table = lua.create_table()?;
@@ -10,6 +11,21 @@ pub fn register_yaml(lua: &Lua) -> mlua::Result<()> {
         json_value_to_lua(lua, &json_val)
     })?;
     yaml_table.set("parse", parse_fn)?;
+
+    let parse_all_fn = lua.create_function(|lua, s: String| {
+        let docs = lua.create_table()?;
+        let mut index = 1;
+        for doc in serde_yml::Deserializer::from_str(&s) {
+            let json_val = serde_json::Value::deserialize(doc)
+                .map_err(|e| mlua::Error::runtime(format!("yaml.parse_all: {e}")))?;
+            if !json_val.is_null() {
+                docs.set(index, json_value_to_lua(lua, &json_val)?)?;
+                index += 1;
+            }
+        }
+        Ok(Value::Table(docs))
+    })?;
+    yaml_table.set("parse_all", parse_all_fn)?;
 
     let encode_fn = lua.create_function(|_, val: Value| {
         let json_val = lua_value_to_json(&val)?;

--- a/crates/assay/tests/yaml.rs
+++ b/crates/assay/tests/yaml.rs
@@ -24,6 +24,30 @@ async fn test_yaml_parse_array() {
 }
 
 #[tokio::test]
+async fn test_yaml_parse_all_documents() {
+    let script = r#"
+        local docs = yaml.parse_all("kind: Service\nmetadata:\n  name: api\n---\nkind: Deployment\nmetadata:\n  name: worker\n")
+        assert.eq(#docs, 2)
+        assert.eq(docs[1].kind, "Service")
+        assert.eq(docs[1].metadata.name, "api")
+        assert.eq(docs[2].kind, "Deployment")
+        assert.eq(docs[2].metadata.name, "worker")
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_yaml_parse_all_skips_empty_documents() {
+    let script = r#"
+        local docs = yaml.parse_all("---\nkind: ConfigMap\n---\n---\nkind: Secret\n")
+        assert.eq(#docs, 2)
+        assert.eq(docs[1].kind, "ConfigMap")
+        assert.eq(docs[2].kind, "Secret")
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
 async fn test_yaml_parse_nested() {
     let script = r#"
         local data = yaml.parse("server:\n  host: localhost\n  port: 8080\n")

--- a/docs/modules/serialization.md
+++ b/docs/modules/serialization.md
@@ -35,6 +35,7 @@ anything else as objects. The helpers only matter when you need to override that
 YAML serialization. No `require()` needed.
 
 - `yaml.parse(str)` → table — Parse YAML string to Lua table
+- `yaml.parse_all(str)` → table[] — Parse a YAML stream into a Lua array, skipping empty documents
 - `yaml.encode(table)` → string — Encode Lua table to YAML string
 
 ## toml

--- a/llms.txt
+++ b/llms.txt
@@ -17,7 +17,7 @@
 
 ## Builtins (no require needed)
 - [http](https://assay.rs/modules/http.html): HTTP client, server, SSE streaming — http.get/post/put/patch/delete/serve
-- [json, yaml, toml](https://assay.rs/modules/serialization.html): JSON/YAML/TOML parse and encode
+- [json, yaml, toml](https://assay.rs/modules/serialization.html): JSON/YAML/TOML parse, parse-all, and encode
 - [fs](https://assay.rs/modules/fs.html): Filesystem — fs.read/write, fs.lines (streaming line iterator), fs.sub_in_file (sed -i equivalent using Lua patterns)
 - [crypto, base64](https://assay.rs/modules/crypto.html): JWT signing/verification/decoding (PEM or JWKS), HMAC, hashing, random, base64
 - [regex](https://assay.rs/modules/regex.html): Regex match, find, replace

--- a/site/static/llms.txt
+++ b/site/static/llms.txt
@@ -15,7 +15,7 @@
 
 ## Builtins (no require needed)
 - [http](https://assay.rs/modules/http.html): HTTP client, server, SSE streaming — http.get/post/put/patch/delete/serve
-- [json, yaml, toml](https://assay.rs/modules/serialization.html): JSON/YAML/TOML parse and encode
+- [json, yaml, toml](https://assay.rs/modules/serialization.html): JSON/YAML/TOML parse, parse-all, and encode
 - [fs](https://assay.rs/modules/fs.html): Filesystem — fs.read/write
 - [crypto, base64](https://assay.rs/modules/crypto.html): JWT signing/decoding, HMAC, hashing, random, base64
 - [regex](https://assay.rs/modules/regex.html): Regex match, find, replace


### PR DESCRIPTION
## Summary\n- add yaml.parse_all(str) for multi-document YAML streams\n- skip empty YAML documents in the returned Lua array\n- document and version the assay-lua 0.16.7 runtime surface\n\n## Verification\n- cargo test -p assay-lua --test yaml\n- cargo build -p assay-lua --bin assay --release\n- dprint check CHANGELOG.md README.md docs/modules/serialization.md llms.txt site/static/llms.txt crates/assay/Cargo.toml