### PR TITLE
ci: use dedicated self-hosted cargo target dir

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,11 +178,20 @@ jobs:
       # On self-hosted, ~/.cargo/bin contains rustup but isn't on the
       # default GH Actions step PATH. The hosted runners have it because
       # Swatinem/rust-cache@v2 implicitly installs rustup and prepends
-      # ~/.cargo/bin; we skip that action on self-hosted (target/ is
-      # already warm locally) so we have to add it ourselves.
+      # ~/.cargo/bin; we skip that action on self-hosted, so we have to
+      # add it ourselves.
       - name: Add ~/.cargo/bin to PATH (self-hosted)
         if: steps.targets.outputs.run_checks == 'true' && runner.environment == 'self-hosted'
         run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+
+      # Keep self-hosted Cargo output off the runner checkout volume. On
+      # assay-runner-eda, /var/cache/runner-work is mounted from the
+      # dedicated cargo-targets LV and is owned by the runner user.
+      - name: Use dedicated Cargo target dir (self-hosted)
+        if: steps.targets.outputs.run_checks == 'true' && runner.environment == 'self-hosted'
+        run: |
+          mkdir -p /var/cache/runner-work/assay-target
+          echo "CARGO_TARGET_DIR=/var/cache/runner-work/assay-target" >> "$GITHUB_ENV"
 
       # mise's rust plugin defaults to the `minimal` profile (no clippy).
       - name: Install clippy component
@@ -201,11 +210,11 @@ jobs:
       # build-script outputs round-trip rather than rebuild. Heavy
       # build crates dominate cold-restore time on this workspace.
       #
-      # Skipped on self-hosted: the assay-runner container has a
-      # locally-persistent target/ (warmer than any GH cache hit) and
-      # the post-step's ~250MB upload over the home internet wipes
-      # out half the speedup. Github-hosted (macOS, Dependabot) still
-      # needs the cache.
+      # Skipped on self-hosted: the assay-runner container writes
+      # CARGO_TARGET_DIR to a locally-persistent dedicated LV, and the
+      # post-step's ~250MB upload over the home internet wipes out half
+      # the speedup. Github-hosted (macOS, Dependabot) still needs the
+      # cache.
       - uses: Swatinem/rust-cache@v2
         if: steps.targets.outputs.run_checks == 'true' && runner.environment == 'github-hosted'
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,9 @@ The GitHub Actions runner named `assay-runner-eda` runs inside the `assay-runner
 machine on the EDA server. Treat its services as persistent, not ephemeral. In particular, its
 Postgres service is a long-lived system service used by Linux CI via `TEST_DATABASE_URL`; tests must
 drop any `assay_test_*` databases they create, and CI should keep an `always()` cleanup guard for
-that prefix.
+that prefix. Keep Cargo build output on the runner cache mount by setting `CARGO_TARGET_DIR` to
+`/var/cache/runner-work/assay-target` for self-hosted CI; do not put recurring build artifacts under
+`/home/runner/actions-runner/_work/.../target`.
 
 ## Library hygiene: no application-domain leakage
 


### PR DESCRIPTION
## Summary
- set `CARGO_TARGET_DIR` to `/var/cache/runner-work/assay-target` on self-hosted CI jobs
- keep self-hosted Cargo artifacts off the runner checkout volume on `/var`
- document the runner cache path in `AGENTS.md`

## Verification
- `dprint check AGENTS.md .github/workflows/ci.yml`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/ci.yml`