### PR TITLE
fix(db): use native postgres decoding for numeric values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to Assay are documented here.
 
+## assay 0.16.8 — 2026-06-03
+
+### Added
+
+- `assay.postgres.client_url(url)` creates a stdlib Postgres client from a full connection URL.
+
+### Fixed
+
+- `db.query()` now decodes Postgres `numeric`/`decimal` values as exact Lua strings instead of
+  failing through sqlx's `Any` driver.
+
 ## assay 0.16.7 — 2026-05-26
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,7 +338,7 @@ dependencies = [
 
 [[package]]
 name = "assay-lua"
-version = "0.16.7"
+version = "0.16.8"
 dependencies = [
  "anyhow",
  "axum",
@@ -1131,6 +1131,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bigdecimal"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d6867f1565b3aad85681f1015055b087fcfd840d6aeee6eee7f2da317603695"
+dependencies = [
+ "autocfg",
+ "libm",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -5443,6 +5456,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
 dependencies = [
  "base64 0.22.1",
+ "bigdecimal",
  "bytes",
  "crc",
  "crossbeam-queue",
@@ -5519,6 +5533,7 @@ checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
  "base64 0.22.1",
+ "bigdecimal",
  "bitflags",
  "byteorder",
  "bytes",
@@ -5562,6 +5577,7 @@ checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64 0.22.1",
+ "bigdecimal",
  "bitflags",
  "byteorder",
  "crc",
@@ -5578,6 +5594,7 @@ dependencies = [
  "log",
  "md-5 0.10.6",
  "memchr",
+ "num-bigint",
  "once_cell",
  "rand 0.8.5",
  "serde",

--- a/crates/assay/Cargo.toml
+++ b/crates/assay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-lua"
-version = "0.16.7"
+version = "0.16.8"
 categories = ["command-line-utilities", "development-tools::testing"]
 edition = "2024"
 homepage = "https://assay.rs"
@@ -95,7 +95,7 @@ tar = "0.4.45"
 toml = "0.9.12"
 
 # SQL database (optional — Postgres, MySQL, SQLite)
-sqlx = { version = "0.8.6", features = ["runtime-tokio-rustls", "postgres", "mysql", "sqlite", "any"], optional = true }
+sqlx = { version = "0.8.6", features = ["runtime-tokio-rustls", "postgres", "mysql", "sqlite", "any", "bigdecimal"], optional = true }
 
 # WebSocket client
 futures-util = "0.3"

--- a/crates/assay/src/lua/builtins/db.rs
+++ b/crates/assay/src/lua/builtins/db.rs
@@ -1,9 +1,17 @@
+use super::json::json_value_to_lua;
 use mlua::{Lua, Table, UserData, Value};
 use sqlx::any::AnyRow;
-use sqlx::{AnyPool, Column, Row, ValueRef};
+use sqlx::postgres::{PgArguments, PgPoolOptions, PgRow};
+use sqlx::types::BigDecimal;
+use sqlx::{AnyPool, Column, PgPool, Row, ValueRef};
 use std::sync::Arc;
 
-struct DbPool(Arc<AnyPool>);
+#[derive(Clone)]
+enum DbPool {
+    Any(Arc<AnyPool>),
+    Postgres(Arc<PgPool>),
+}
+
 impl UserData for DbPool {}
 
 pub fn register_db(lua: &Lua) -> mlua::Result<()> {
@@ -12,12 +20,21 @@ pub fn register_db(lua: &Lua) -> mlua::Result<()> {
     let db_table = lua.create_table()?;
 
     let connect_fn = lua.create_async_function(|lua, url: String| async move {
+        if is_postgres_url(&url) {
+            let pool = PgPoolOptions::new()
+                .max_connections(5)
+                .connect(&url)
+                .await
+                .map_err(|e| mlua::Error::runtime(format!("db.connect: {e}")))?;
+            return lua.create_any_userdata(DbPool::Postgres(Arc::new(pool)));
+        }
+
         let pool = sqlx::any::AnyPoolOptions::new()
             .max_connections(if url.starts_with("sqlite:") { 1 } else { 5 })
             .connect(&url)
             .await
             .map_err(|e| mlua::Error::runtime(format!("db.connect: {e}")))?;
-        lua.create_any_userdata(DbPool(Arc::new(pool)))
+        lua.create_any_userdata(DbPool::Any(Arc::new(pool)))
     })?;
     db_table.set("connect", connect_fn)?;
 
@@ -28,22 +45,10 @@ pub fn register_db(lua: &Lua) -> mlua::Result<()> {
         let sql = extract_sql_string(&args_iter.next(), "db.query")?;
         let params = extract_params(&args_iter.next())?;
 
-        let mut query = sqlx::query(&sql);
-        for p in &params {
-            query = bind_param(query, p);
+        match pool {
+            DbPool::Any(pool) => any_query(&lua, &pool, &sql, &params).await,
+            DbPool::Postgres(pool) => postgres_query(&lua, &pool, &sql, &params).await,
         }
-
-        let rows: Vec<AnyRow> = query
-            .fetch_all(&*pool)
-            .await
-            .map_err(|e| mlua::Error::runtime(format!("db.query: {e}")))?;
-
-        let result = lua.create_table()?;
-        for (i, row) in rows.iter().enumerate() {
-            let row_table = any_row_to_lua_table(&lua, row)?;
-            result.set(i + 1, row_table)?;
-        }
-        Ok(Value::Table(result))
     })?;
     db_table.set("query", query_fn)?;
 
@@ -54,26 +59,23 @@ pub fn register_db(lua: &Lua) -> mlua::Result<()> {
         let sql = extract_sql_string(&args_iter.next(), "db.execute")?;
         let params = extract_params(&args_iter.next())?;
 
-        let mut query = sqlx::query(&sql);
-        for p in &params {
-            query = bind_param(query, p);
-        }
-
-        let result = query
-            .execute(&*pool)
-            .await
-            .map_err(|e| mlua::Error::runtime(format!("db.execute: {e}")))?;
+        let rows_affected = match pool {
+            DbPool::Any(pool) => any_execute(&pool, &sql, &params).await?,
+            DbPool::Postgres(pool) => postgres_execute(&pool, &sql, &params).await?,
+        };
 
         let tbl = lua.create_table()?;
-        tbl.set("rows_affected", result.rows_affected() as i64)?;
+        tbl.set("rows_affected", rows_affected as i64)?;
         Ok(Value::Table(tbl))
     })?;
     db_table.set("execute", execute_fn)?;
 
     let close_fn = lua.create_async_function(|_, args: mlua::MultiValue| async move {
         let mut args_iter = args.into_iter();
-        let pool = extract_db_pool(&args_iter.next(), "db.close")?;
-        pool.close().await;
+        match extract_db_pool(&args_iter.next(), "db.close")? {
+            DbPool::Any(pool) => pool.close().await,
+            DbPool::Postgres(pool) => pool.close().await,
+        }
         Ok(())
     })?;
     db_table.set("close", close_fn)?;
@@ -82,13 +84,17 @@ pub fn register_db(lua: &Lua) -> mlua::Result<()> {
     Ok(())
 }
 
-fn extract_db_pool(val: &Option<Value>, fn_name: &str) -> mlua::Result<Arc<AnyPool>> {
+fn is_postgres_url(url: &str) -> bool {
+    url.starts_with("postgres://") || url.starts_with("postgresql://")
+}
+
+fn extract_db_pool(val: &Option<Value>, fn_name: &str) -> mlua::Result<DbPool> {
     match val {
         Some(Value::UserData(ud)) => {
             let db = ud.borrow::<DbPool>().map_err(|_| {
                 mlua::Error::runtime(format!("{fn_name}: first argument must be a db connection"))
             })?;
-            Ok(db.0.clone())
+            Ok(db.clone())
         }
         _ => Err(mlua::Error::runtime(format!(
             "{fn_name}: first argument must be a db connection"
@@ -145,10 +151,97 @@ fn extract_params(val: &Option<Value>) -> mlua::Result<Vec<DbParam>> {
     }
 }
 
-fn bind_param<'q>(
+async fn any_query(
+    lua: &Lua,
+    pool: &AnyPool,
+    sql: &str,
+    params: &[DbParam],
+) -> mlua::Result<Value> {
+    let mut query = sqlx::query(sql);
+    for p in params {
+        query = bind_any_param(query, p);
+    }
+
+    let rows: Vec<AnyRow> = query
+        .fetch_all(pool)
+        .await
+        .map_err(|e| mlua::Error::runtime(format!("db.query: {e}")))?;
+
+    let result = lua.create_table()?;
+    for (i, row) in rows.iter().enumerate() {
+        let row_table = any_row_to_lua_table(lua, row)?;
+        result.set(i + 1, row_table)?;
+    }
+    Ok(Value::Table(result))
+}
+
+async fn postgres_query(
+    lua: &Lua,
+    pool: &PgPool,
+    sql: &str,
+    params: &[DbParam],
+) -> mlua::Result<Value> {
+    let mut query = sqlx::query(sql);
+    for p in params {
+        query = bind_postgres_param(query, p);
+    }
+
+    let rows: Vec<PgRow> = query
+        .fetch_all(pool)
+        .await
+        .map_err(|e| mlua::Error::runtime(format!("db.query: {e}")))?;
+
+    let result = lua.create_table()?;
+    for (i, row) in rows.iter().enumerate() {
+        let row_table = postgres_row_to_lua_table(lua, row)?;
+        result.set(i + 1, row_table)?;
+    }
+    Ok(Value::Table(result))
+}
+
+async fn any_execute(pool: &AnyPool, sql: &str, params: &[DbParam]) -> mlua::Result<u64> {
+    let mut query = sqlx::query(sql);
+    for p in params {
+        query = bind_any_param(query, p);
+    }
+
+    let result = query
+        .execute(pool)
+        .await
+        .map_err(|e| mlua::Error::runtime(format!("db.execute: {e}")))?;
+    Ok(result.rows_affected())
+}
+
+async fn postgres_execute(pool: &PgPool, sql: &str, params: &[DbParam]) -> mlua::Result<u64> {
+    let mut query = sqlx::query(sql);
+    for p in params {
+        query = bind_postgres_param(query, p);
+    }
+
+    let result = query
+        .execute(pool)
+        .await
+        .map_err(|e| mlua::Error::runtime(format!("db.execute: {e}")))?;
+    Ok(result.rows_affected())
+}
+
+fn bind_any_param<'q>(
     query: sqlx::query::Query<'q, sqlx::Any, sqlx::any::AnyArguments<'q>>,
     param: &'q DbParam,
 ) -> sqlx::query::Query<'q, sqlx::Any, sqlx::any::AnyArguments<'q>> {
+    match param {
+        DbParam::Null => query.bind(None::<String>),
+        DbParam::Bool(b) => query.bind(*b),
+        DbParam::Int(n) => query.bind(*n),
+        DbParam::Float(f) => query.bind(*f),
+        DbParam::Text(s) => query.bind(s.as_str()),
+    }
+}
+
+fn bind_postgres_param<'q>(
+    query: sqlx::query::Query<'q, sqlx::Postgres, PgArguments>,
+    param: &'q DbParam,
+) -> sqlx::query::Query<'q, sqlx::Postgres, PgArguments> {
     match param {
         DbParam::Null => query.bind(None::<String>),
         DbParam::Bool(b) => query.bind(*b),
@@ -208,4 +301,76 @@ fn any_column_to_lua_value<C: Column>(lua: &Lua, row: &AnyRow, col: &C) -> mlua:
             Ok(Value::String(lua.create_string(&v)?))
         }
     }
+}
+
+fn postgres_row_to_lua_table(lua: &Lua, row: &PgRow) -> mlua::Result<Table> {
+    let table = lua.create_table()?;
+    for col in row.columns() {
+        let name = col.name();
+        let val: Value = postgres_column_to_lua_value(lua, row, col)?;
+        table.set(name.to_string(), val)?;
+    }
+    Ok(table)
+}
+
+fn postgres_column_to_lua_value<C: Column>(lua: &Lua, row: &PgRow, col: &C) -> mlua::Result<Value> {
+    let ordinal = col.ordinal();
+    let type_info = col.type_info();
+    let type_name = type_info.to_string();
+    let type_name = type_name.to_uppercase();
+
+    if row
+        .try_get_raw(ordinal)
+        .map(|v| v.is_null())
+        .unwrap_or(true)
+    {
+        return Ok(Value::Nil);
+    }
+
+    match type_name.as_str() {
+        "BOOL" | "BOOLEAN" => {
+            let v: bool = read_column(row, ordinal)?;
+            Ok(Value::Boolean(v))
+        }
+        "INT2" | "SMALLINT" => {
+            let v: i16 = read_column(row, ordinal)?;
+            Ok(Value::Integer(i64::from(v)))
+        }
+        "INT4" | "INTEGER" | "INT" => {
+            let v: i32 = read_column(row, ordinal)?;
+            Ok(Value::Integer(i64::from(v)))
+        }
+        "INT8" | "BIGINT" => {
+            let v: i64 = read_column(row, ordinal)?;
+            Ok(Value::Integer(v))
+        }
+        "FLOAT4" | "REAL" => {
+            let v: f32 = read_column(row, ordinal)?;
+            Ok(Value::Number(f64::from(v)))
+        }
+        "FLOAT8" | "DOUBLE" | "DOUBLE PRECISION" => {
+            let v: f64 = read_column(row, ordinal)?;
+            Ok(Value::Number(v))
+        }
+        "NUMERIC" | "DECIMAL" => {
+            let v: BigDecimal = read_column(row, ordinal)?;
+            Ok(Value::String(lua.create_string(v.to_string())?))
+        }
+        "JSON" | "JSONB" => {
+            let v: sqlx::types::Json<serde_json::Value> = read_column(row, ordinal)?;
+            json_value_to_lua(lua, &v.0)
+        }
+        _ => {
+            let v: String = read_column(row, ordinal)?;
+            Ok(Value::String(lua.create_string(&v)?))
+        }
+    }
+}
+
+fn read_column<'r, T>(row: &'r PgRow, ordinal: usize) -> mlua::Result<T>
+where
+    T: sqlx::Decode<'r, sqlx::Postgres> + sqlx::Type<sqlx::Postgres>,
+{
+    row.try_get(ordinal)
+        .map_err(|e| mlua::Error::runtime(format!("db: column read error: {e}")))
 }

--- a/crates/assay/stdlib/postgres.lua
+++ b/crates/assay/stdlib/postgres.lua
@@ -4,6 +4,7 @@
 --- @quickref c.queries:query(sql, params?) -> [row] | Execute SQL query, return rows
 --- @quickref c.queries:execute(sql, params?) -> number | Execute SQL statement, return affected count
 --- @quickref c:close() -> nil | Close database connection
+--- @quickref M.client_url(url) -> client | Create from a full PostgreSQL connection URL
 --- @quickref c.users:exists(username) -> bool | Check if PostgreSQL user exists
 --- @quickref c.users:ensure(username, password, opts?) -> bool | Create user if not exists
 --- @quickref c.databases:exists(dbname) -> bool | Check if database exists
@@ -29,9 +30,7 @@ function M._build_dsn(host, port, username, password, database)
     .. "@" .. host .. ":" .. tostring(port) .. "/" .. (database or "postgres")
 end
 
-function M.client(host, port, username, password, database)
-  local pool = db.connect(M._build_dsn(host, port, username, password, database))
-
+local function client_from_pool(pool)
   -- ===== Client =====
 
   local c = {}
@@ -114,6 +113,14 @@ function M.client(host, port, username, password, database)
   end
 
   return c
+end
+
+function M.client_url(url)
+  return client_from_pool(db.connect(url))
+end
+
+function M.client(host, port, username, password, database)
+  return M.client_url(M._build_dsn(host, port, username, password, database))
 end
 
 function M.client_from_vault(vault_client, vault_path, host, port)

--- a/crates/assay/tests/db.rs
+++ b/crates/assay/tests/db.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use common::run_lua_local;
+use common::{create_vm, run_lua_local};
 
 #[tokio::test]
 async fn test_db_sqlite_create_and_insert() {
@@ -187,4 +187,28 @@ async fn test_db_sqlite_close() {
     )
     .await
     .unwrap();
+}
+
+#[tokio::test]
+async fn test_db_postgres_numeric_decodes_as_string() {
+    let Ok(url) = std::env::var("ASSAY_TEST_POSTGRES_URL") else {
+        return;
+    };
+    let vm = create_vm();
+    vm.globals().set("postgres_url", url).unwrap();
+    let script = assay::lua::async_bridge::strip_shebang(
+        r#"
+        local conn = db.connect(postgres_url)
+        local rows = db.query(conn, "SELECT 12345.6789::numeric AS amount")
+        assert.eq(#rows, 1)
+        assert.eq(type(rows[1].amount), "string")
+        assert.eq(rows[1].amount, "12345.6789")
+        db.close(conn)
+    "#,
+    );
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async { vm.load(script).exec_async().await })
+        .await
+        .unwrap();
 }

--- a/crates/assay/tests/stdlib_postgres.rs
+++ b/crates/assay/tests/stdlib_postgres.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use common::{eval_lua, run_lua, run_lua_local};
+use common::{create_vm, eval_lua, run_lua, run_lua_local};
 
 #[tokio::test]
 async fn test_require_postgres() {
@@ -8,6 +8,7 @@ async fn test_require_postgres() {
         local pg = require("assay.postgres")
         assert.not_nil(pg, "postgres module should load")
         assert.not_nil(pg.client, "postgres.client should exist")
+        assert.not_nil(pg.client_url, "postgres.client_url should exist")
         assert.not_nil(pg.client_from_vault, "postgres.client_from_vault should exist")
         assert.not_nil(pg._quote_ident, "postgres._quote_ident should exist")
         assert.not_nil(pg._quote_literal, "postgres._quote_literal should exist")
@@ -160,4 +161,29 @@ async fn test_postgres_client_from_vault_missing_secret() {
     );
 
     run_lua_local(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_postgres_client_url_numeric_decodes_as_string() {
+    let Ok(url) = std::env::var("ASSAY_TEST_POSTGRES_URL") else {
+        return;
+    };
+    let vm = create_vm();
+    vm.globals().set("postgres_url", url).unwrap();
+    let script = assay::lua::async_bridge::strip_shebang(
+        r#"
+        local pg = require("assay.postgres")
+        local c = pg.client_url(postgres_url)
+        local rows = c.queries:query("SELECT 12345.6789::numeric AS amount")
+        assert.eq(#rows, 1)
+        assert.eq(type(rows[1].amount), "string")
+        assert.eq(rows[1].amount, "12345.6789")
+        c:close()
+    "#,
+    );
+    let local = tokio::task::LocalSet::new();
+    local
+        .run_until(async { vm.load(script).exec_async().await })
+        .await
+        .unwrap();
 }


### PR DESCRIPTION
## Summary

- route `postgres://` / `postgresql://` `db.connect()` calls through native `PgPool` instead of sqlx `AnyPool`
- decode Postgres `numeric`/`decimal` values as exact Lua strings
- add `assay.postgres.client_url(url)` so callers with a full DSN can use the Postgres stdlib wrapper
- bump `assay-lua` to `0.16.8`

## Tests

- `cargo clippy -p assay-lua -- -D warnings`
- `ASSAY_TEST_POSTGRES_URL=... cargo test -p assay-lua --test db -- --nocapture`
- `ASSAY_TEST_POSTGRES_URL=... cargo test -p assay-lua --test stdlib_postgres -- --nocapture`
- `ASSAY_TEST_POSTGRES_URL=... cargo test -p assay-lua`
