### PR TITLE
chore(release): assay-engine 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to Assay are documented here.
 
+## assay-engine 0.5.1 — 2026-06-03
+
+### Added
+
+- Zanzibar `/check` resolves computed-userset arrows (`relation->permission`) plus `intersect` /
+  `exclude` operators via a recursive evaluator (MAX_DEPTH 50, cycle-safe). Previously stubbed.
+
+### Fixed
+
+- Biscuit authorizer `max_time` 1 ms → 10 s — token checks no longer abort with "Reached Datalog
+  execution limits" under load (a spurious `Forbidden`).
+
 ## assay 0.16.7 — 2026-05-26
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,7 +309,7 @@ dependencies = [
 
 [[package]]
 name = "assay-engine"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "assay-auth",

--- a/crates/assay-engine/Cargo.toml
+++ b/crates/assay-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-engine"
-version = "0.5.0"
+version = "0.5.1"
 categories = ["asynchronous", "database", "web-programming::http-server"]
 edition = "2024"
 keywords = ["workflow", "auth", "oidc", "zanzibar", "postgres"]


### PR DESCRIPTION
`#162` (computed-userset Zanzibar arrows + biscuit `max_time` fix) merged without a version bump, so the bump-gated `release.yml` (`check-bumped.sh` vs crates.io) shipped nothing. Bump `assay-engine` 0.5.0 → 0.5.1 to cut the release.

Engine-only: the arrow code lives in `assay-auth` but compiles into the engine binary, so the release artifact picks it up from source.