### PR TITLE
fix(assay): diamond-permission resolve + biscuit share-query timeout (engine 0.5.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to Assay are documented here.
 
+## assay-engine 0.5.2 — 2026-06-03
+
+### Fixed
+
+- Zanzibar permission resolution no longer mis-flags a "diamond" — a permission reaching the same
+  relation via two union branches (e.g. `view = up + down` where both include `account`) — as a
+  schema cycle. Such permissions previously resolved to `CycleDetected` and silently denied; they
+  now evaluate correctly. (Carries `assay-auth 0.5.1`.)
+
+## assay-auth 0.5.1 — 2026-06-03
+
+### Fixed
+
+- `zanzibar::resolve` tracks the current resolution _path_ for cycle detection instead of a
+  cumulative visited-set, so a relation reachable via two union branches is no longer a false
+  positive. Genuine self-referential schema cycles are still rejected.
+
 ## assay-engine 0.5.1 — 2026-06-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to Assay are documented here.
   relation via two union branches (e.g. `view = up + down` where both include `account`) — as a
   schema cycle. Such permissions previously resolved to `CycleDetected` and silently denied; they
   now evaluate correctly. (Carries `assay-auth 0.5.1`.)
+- Biscuit share-link verify no longer intermittently times out under load — the datalog `query` now
+  uses the same 10s `max_time` backstop as `authorize`. (Carries `assay-vault 0.4.1`.)
 
 ## assay-auth 0.5.1 — 2026-06-03
 
@@ -18,6 +20,13 @@ All notable changes to Assay are documented here.
 - `zanzibar::resolve` tracks the current resolution _path_ for cycle detection instead of a
   cumulative visited-set, so a relation reachable via two union branches is no longer a false
   positive. Genuine self-referential schema cycles are still rejected.
+
+## assay-vault 0.4.1 — 2026-06-03
+
+### Fixed
+
+- Share-link `verify` bounds the biscuit datalog `query` with a 10s `max_time` (was biscuit's 1ms
+  default), matching the `authorize` backstop — a loaded host no longer hits `RunLimit(Timeout)`.
 
 ## assay-engine 0.5.1 — 2026-06-03
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -239,7 +239,7 @@ dependencies = [
 
 [[package]]
 name = "assay-auth"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "argon2",
@@ -309,7 +309,7 @@ dependencies = [
 
 [[package]]
 name = "assay-engine"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "assay-auth",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,7 +393,7 @@ dependencies = [
 
 [[package]]
 name = "assay-vault"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",

--- a/crates/assay-auth/Cargo.toml
+++ b/crates/assay-auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-auth"
-version = "0.5.0"
+version = "0.5.1"
 categories = ["authentication", "cryptography", "asynchronous"]
 edition = "2024"
 keywords = ["oidc", "zanzibar", "passkey", "biscuit", "auth"]

--- a/crates/assay-auth/src/zanzibar/resolve.rs
+++ b/crates/assay-auth/src/zanzibar/resolve.rs
@@ -75,23 +75,32 @@ fn walk_name(
     out: &mut Resolved,
     seen: &mut BTreeSet<String>,
 ) -> bool {
+    // `seen` is the *current resolution path*, not every name ever visited.
+    // A name reachable via two union branches (a DAG diamond, e.g.
+    // `view = up + down` where both include `account`) is legitimate; only a
+    // name reached while still on its own stack is a self-referential schema
+    // cycle. So insert on entry and pop on exit.
     if !seen.insert(name.to_string()) {
         return false;
     }
-    let Some(def) = schema.definitions.get(name) else {
+    let ok = match schema.definitions.get(name) {
         // An undefined name — treat as a direct relation (matches
         // SpiceDB's lenient resolution; the tuple table just won't
         // have rows for it and the walk denies cleanly).
-        out.union_relations.insert(name.to_string());
-        return true;
-    };
-    match &def.kind {
-        RelationKind::Direct(_) => {
+        None => {
             out.union_relations.insert(name.to_string());
             true
         }
-        RelationKind::Permission(expr) => walk_expr(schema, expr, out, seen),
-    }
+        Some(def) => match &def.kind {
+            RelationKind::Direct(_) => {
+                out.union_relations.insert(name.to_string());
+                true
+            }
+            RelationKind::Permission(expr) => walk_expr(schema, expr, out, seen),
+        },
+    };
+    seen.remove(name);
+    ok
 }
 
 fn walk_expr(
@@ -226,5 +235,59 @@ mod tests {
         assert!(r.needs_post_filter);
         assert!(r.union_relations.contains("a"));
         assert!(r.union_relations.contains("b"));
+    }
+
+    #[test]
+    fn diamond_via_two_permissions_is_not_a_cycle() {
+        // `view = up + down`; both `up` and `down` include `account`, so
+        // resolving `view` reaches `account` along two distinct union
+        // branches (a DAG diamond, NOT a cycle). The path-based cycle guard
+        // must not mistake the second visit for a self-reference.
+        let mut s = NamespaceSchema::new("node");
+        s.definitions.insert(
+            "account".into(),
+            RelationDef::relation("account", vec![TypeRef::direct("user")]),
+        );
+        s.definitions.insert(
+            "parent".into(),
+            RelationDef::relation("parent", vec![TypeRef::direct("node")]),
+        );
+        s.definitions.insert(
+            "child".into(),
+            RelationDef::relation("child", vec![TypeRef::direct("node")]),
+        );
+        s.definitions.insert(
+            "up".into(),
+            RelationDef::permission(
+                "up",
+                PermissionExpr::union(
+                    PermissionExpr::direct("account"),
+                    PermissionExpr::arrow("parent", "up"),
+                ),
+            ),
+        );
+        s.definitions.insert(
+            "down".into(),
+            RelationDef::permission(
+                "down",
+                PermissionExpr::union(
+                    PermissionExpr::direct("account"),
+                    PermissionExpr::arrow("child", "down"),
+                ),
+            ),
+        );
+        s.definitions.insert(
+            "view".into(),
+            RelationDef::permission(
+                "view",
+                PermissionExpr::union(PermissionExpr::direct("up"), PermissionExpr::direct("down")),
+            ),
+        );
+
+        let r = resolve(&s, "view").expect("diamond must resolve, not register as a cycle");
+        assert!(r.union_relations.contains("account"));
+        assert!(r.union_relations.contains("parent"));
+        assert!(r.union_relations.contains("child"));
+        assert!(r.needs_post_filter, "arrows present → post-filter");
     }
 }

--- a/crates/assay-auth/tests/zanzibar.rs
+++ b/crates/assay-auth/tests/zanzibar.rs
@@ -252,6 +252,117 @@ mod sqlite_tests {
         );
     }
 
+    // A permission composed of OTHER permissions that share a relation — a
+    // diamond `view = up + down`, both including `account` — must resolve.
+    // Pre-fix the resolver's cumulative visited-set mistook the shared
+    // `account` for a schema cycle and `check` silently denied. Behavioural
+    // regression guard for that bug.
+    #[tokio::test]
+    async fn composed_permission_diamond_resolves() {
+        let store = setup_sqlite().await;
+        store
+            .define_namespace(&NamespaceSchema::new("user"))
+            .await
+            .expect("ns user");
+        store
+            .define_namespace(
+                &NamespaceSchema::new("node")
+                    .with_relation(
+                        "account",
+                        RelationDef::relation("account", vec![TypeRef::direct("user")]),
+                    )
+                    .with_relation(
+                        "parent",
+                        RelationDef::relation("parent", vec![TypeRef::direct("node")]),
+                    )
+                    .with_relation(
+                        "child",
+                        RelationDef::relation("child", vec![TypeRef::direct("node")]),
+                    )
+                    .with_relation(
+                        "up",
+                        RelationDef::permission(
+                            "up",
+                            PermissionExpr::union(
+                                PermissionExpr::direct("account"),
+                                PermissionExpr::arrow("parent", "up"),
+                            ),
+                        ),
+                    )
+                    .with_relation(
+                        "down",
+                        RelationDef::permission(
+                            "down",
+                            PermissionExpr::union(
+                                PermissionExpr::direct("account"),
+                                PermissionExpr::arrow("child", "down"),
+                            ),
+                        ),
+                    )
+                    .with_relation(
+                        "view",
+                        RelationDef::permission(
+                            "view",
+                            PermissionExpr::union(
+                                PermissionExpr::direct("up"),
+                                PermissionExpr::direct("down"),
+                            ),
+                        ),
+                    ),
+            )
+            .await
+            .expect("ns node");
+
+        // c.parent = b, b.parent = a; ua is the account on a (c's grandparent).
+        store
+            .write_tuples(&[
+                Tuple::direct(
+                    ObjectRef::new("node", "a"),
+                    "account",
+                    SubjectRef::direct("user", "ua"),
+                ),
+                Tuple::direct(
+                    ObjectRef::new("node", "b"),
+                    "parent",
+                    SubjectRef::direct("node", "a"),
+                ),
+                Tuple::direct(
+                    ObjectRef::new("node", "c"),
+                    "parent",
+                    SubjectRef::direct("node", "b"),
+                ),
+            ])
+            .await
+            .expect("seed");
+
+        // view(c, ua) resolves via `up` (c->b->a, account at a).
+        let r = store
+            .check(
+                &ObjectRef::new("node", "c"),
+                "view",
+                &SubjectRef::direct("user", "ua"),
+                Consistency::Minimum,
+            )
+            .await
+            .expect("check ua");
+        assert!(
+            matches!(r, CheckResult::Allowed { .. }),
+            "composed view must resolve via up: {r:?}"
+        );
+
+        // An unrelated user is denied.
+        let r = store
+            .check(
+                &ObjectRef::new("node", "c"),
+                "view",
+                &SubjectRef::direct("user", "nobody"),
+                Consistency::Minimum,
+            )
+            .await
+            .expect("check nobody");
+        assert_eq!(r, CheckResult::Denied);
+    }
+
     #[tokio::test]
     async fn indirect_via_userset() {
         let store = setup_sqlite().await;

--- a/crates/assay-engine/Cargo.toml
+++ b/crates/assay-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-engine"
-version = "0.5.1"
+version = "0.5.2"
 categories = ["asynchronous", "database", "web-programming::http-server"]
 edition = "2024"
 keywords = ["workflow", "auth", "oidc", "zanzibar", "postgres"]

--- a/crates/assay-vault/Cargo.toml
+++ b/crates/assay-vault/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-vault"
-version = "0.4.0"
+version = "0.4.1"
 categories = ["cryptography", "asynchronous", "database"]
 edition = "2024"
 keywords = ["vault", "secrets", "kv", "transit", "biscuit"]

--- a/crates/assay-vault/src/share.rs
+++ b/crates/assay-vault/src/share.rs
@@ -246,10 +246,18 @@ mod biscuit_impl {
                 .map_err(|_| VaultError::Forbidden)?;
 
             // Pull the target back out of the authority facts.
-            let facts: Vec<(String, String)> =
-                authorizer
-                    .query("data($k, $i) <- target($k, $i)")
-                    .map_err(|e| VaultError::Crypto(format!("biscuit query: {e:?}")))?;
+            // Same 1ms-default trap as authorize above: the query runs datalog
+            // too, so bound it with the same 10s wall-clock backstop or a loaded
+            // runner intermittently times out (RunLimit(Timeout)).
+            let facts: Vec<(String, String)> = authorizer
+                .query_with_limits(
+                    "data($k, $i) <- target($k, $i)",
+                    biscuit_auth::AuthorizerLimits {
+                        max_time: std::time::Duration::from_secs(10),
+                        ..Default::default()
+                    },
+                )
+                .map_err(|e| VaultError::Crypto(format!("biscuit query: {e:?}")))?;
             let (kind, id) = facts
                 .into_iter()
                 .next()


### PR DESCRIPTION
Two fixes shipping as the `assay-engine 0.5.2` patch:

1. **Zanzibar diamond resolve** (`assay-auth 0.5.1`): `resolve()` tracked a cumulative visited-set, so a permission reaching the same relation via two union branches (`view = up + down`, both including `account`) was mis-flagged as a schema cycle → `CycleDetected` → silent deny. Now tracks the DFS path; genuine cycles still rejected. + unit & behavioural tests.

2. **Biscuit share-link query timeout** (`assay-vault 0.4.1`): `share.verify()`'s datalog `query` kept biscuit's 1 ms default — #162 added the 10 s backstop to `authorize()` but missed `query()`, so a loaded runner intermittently hit `RunLimit(Timeout)` (caught by CI here). Mirrors the authorize fix.

Bumps `assay-auth` 0.5.1, `assay-vault` 0.4.1, `assay-engine` 0.5.2.