### PR TITLE
fix(auth): passkey login — server-side credential lookup, sign-counter enforcement, session minting

### DIFF
--- a/crates/assay-auth/src/passkey.rs
+++ b/crates/assay-auth/src/passkey.rs
@@ -206,46 +206,25 @@ impl PasskeyManager {
     }
 
     /// Step 2 of authentication. Verifies the browser's
-    /// [`PublicKeyCredential`] and returns the
-    /// [`AuthenticatedPasskey`] result the caller persists (sign-count
-    /// bump, backup-state changes, etc.) via the user store.
+    /// [`PublicKeyCredential`] against the in-progress state and returns
+    /// the library's [`AuthenticationResult`].
+    ///
+    /// The library enforces the sign-counter here: because
+    /// [`PasskeyManager::start_authentication_with`] is fed the stored
+    /// [`Passkey`] carrying its persisted counter, a regression (clone /
+    /// replay) surfaces as a `CredentialPossibleCompromise` error from
+    /// the library and this call fails closed. On success the caller
+    /// persists the bumped counter — see [`apply_auth_update`] +
+    /// [`crate::store::UserStore::update_passkey_counter`].
     pub fn finish_authentication(
         &self,
         state: &PasskeyAuthentication,
         response: &PublicKeyCredential,
-    ) -> Result<AuthenticatedPasskey> {
-        let result = self
-            .webauthn
+    ) -> Result<webauthn_rs::prelude::AuthenticationResult> {
+        self.webauthn
             .finish_passkey_authentication(response, state)
-            .map_err(|e| Error::Passkey(format!("finish_passkey_authentication: {e}")))?;
-        Ok(AuthenticatedPasskey {
-            credential_id: result.cred_id().as_ref().to_vec(),
-            sign_count: result.counter(),
-            user_verified: result.user_verified(),
-            needs_update: result.needs_update(),
-        })
+            .map_err(|e| Error::Passkey(format!("finish_passkey_authentication: {e}")))
     }
-}
-
-/// Successful authentication result — carries the credential id the
-/// caller looks up in `auth.passkeys`, plus the new sign-count the
-/// caller persists (cheap UPDATE keyed on credential_id).
-#[derive(Clone, Debug)]
-pub struct AuthenticatedPasskey {
-    /// Raw bytes of the verified credential id. Matches the
-    /// `auth.passkeys.credential_id` primary key.
-    pub credential_id: Vec<u8>,
-    /// New sign-count from the authenticator. Spec requires the server
-    /// to assert this is greater than the stored value — when it isn't,
-    /// the caller MAY treat the credential as cloned and revoke it.
-    pub sign_count: u32,
-    /// Whether the user verified themselves on this authentication
-    /// (PIN, biometric, …). Useful for step-up flows.
-    pub user_verified: bool,
-    /// `webauthn-rs` thinks the stored Passkey blob is out-of-date with
-    /// respect to the new `AuthenticationResult` (counter or backup
-    /// state changed). Re-persist via the user store when true.
-    pub needs_update: bool,
 }
 
 /// Project a [`webauthn_rs::prelude::Passkey`] into a
@@ -266,7 +245,46 @@ pub fn passkey_to_cred(passkey: &Passkey, created_at: f64) -> crate::store::Pass
         sign_count: 0,
         transports: Vec::new(),
         created_at,
+        // Authoritative re-verification material: the full serialised
+        // Passkey. The authentication ceremony deserialises this so
+        // webauthn-rs sees the persisted sign-count and can enforce
+        // counter / clone detection.
+        passkey_json: serde_json::to_string(passkey).ok(),
     }
+}
+
+/// Reconstruct a [`webauthn_rs::prelude::Passkey`] from a stored
+/// [`crate::store::PasskeyCred`]. Returns [`Error::Passkey`] when the row
+/// predates the `passkey_json` column (legacy credential that can no
+/// longer drive a login and must be re-registered) or the blob fails to
+/// deserialise.
+pub fn cred_to_passkey(cred: &crate::store::PasskeyCred) -> Result<Passkey> {
+    let blob = cred.passkey_json.as_deref().ok_or_else(|| {
+        Error::Passkey(
+            "stored credential has no serialised Passkey blob (legacy row); re-register the passkey"
+                .to_string(),
+        )
+    })?;
+    serde_json::from_str(blob)
+        .map_err(|e| Error::Passkey(format!("decode stored Passkey blob: {e}")))
+}
+
+/// Apply a successful [`AuthenticationResult`] back onto the stored
+/// [`webauthn_rs::prelude::Passkey`] (bumping its sign-count + backup
+/// state) and return the re-serialised blob the caller persists via
+/// [`UserStore::update_passkey_counter`]. Errors if the credential id
+/// doesn't match the result.
+pub fn apply_auth_update(
+    passkey: &mut Passkey,
+    result: &webauthn_rs::prelude::AuthenticationResult,
+) -> Result<String> {
+    if passkey.update_credential(result).is_none() {
+        return Err(Error::Passkey(
+            "authentication result credential id does not match stored passkey".to_string(),
+        ));
+    }
+    serde_json::to_string(passkey)
+        .map_err(|e| Error::Passkey(format!("re-serialise updated Passkey: {e}")))
 }
 
 #[cfg(test)]
@@ -321,6 +339,34 @@ mod tests {
         }
         async fn remove_passkey(&self, _credential_id: &[u8]) -> anyhow::Result<bool> {
             Ok(true)
+        }
+        async fn get_passkey(
+            &self,
+            credential_id: &[u8],
+        ) -> anyhow::Result<Option<(String, PasskeyCred)>> {
+            let guard = self.0.lock().unwrap();
+            for (uid, creds) in guard.iter() {
+                if let Some(c) = creds.iter().find(|c| c.credential_id == credential_id) {
+                    return Ok(Some((uid.clone(), c.clone())));
+                }
+            }
+            Ok(None)
+        }
+        async fn update_passkey_counter(
+            &self,
+            credential_id: &[u8],
+            sign_count: u32,
+            passkey_json: &str,
+        ) -> anyhow::Result<bool> {
+            let mut guard = self.0.lock().unwrap();
+            for creds in guard.values_mut() {
+                if let Some(c) = creds.iter_mut().find(|c| c.credential_id == credential_id) {
+                    c.sign_count = sign_count;
+                    c.passkey_json = Some(passkey_json.to_string());
+                    return Ok(true);
+                }
+            }
+            Ok(false)
         }
         async fn link_upstream(
             &self,

--- a/crates/assay-auth/src/passkey.rs
+++ b/crates/assay-auth/src/passkey.rs
@@ -234,8 +234,19 @@ impl PasskeyManager {
 /// lossy — re-authentication needs a future column to round-trip the
 /// blob. Tests and admin tooling that just want to enumerate stored
 /// credentials are fine with the projection.
-pub fn passkey_to_cred(passkey: &Passkey, created_at: f64) -> crate::store::PasskeyCred {
-    crate::store::PasskeyCred {
+/// Project a freshly-registered [`Passkey`] into a
+/// [`crate::store::PasskeyCred`] for persistence in `auth.passkeys`.
+///
+/// Returns [`Error::Passkey`] if the Passkey cannot be serialised —
+/// this must fail loudly at registration time rather than persisting a
+/// credential that can never drive a login (a `NULL` `passkey_json`
+/// blob means `cred_to_passkey` fails closed at authentication).
+pub fn passkey_to_cred(passkey: &Passkey, created_at: f64) -> Result<crate::store::PasskeyCred> {
+    // Serialise the full Passkey blob first — if this fails we must
+    // not return a partially-built cred.
+    let passkey_json = serde_json::to_string(passkey)
+        .map_err(|e| Error::Passkey(format!("serialise Passkey for storage: {e}")))?;
+    Ok(crate::store::PasskeyCred {
         credential_id: passkey.cred_id().as_ref().to_vec(),
         // Public key bytes aren't directly exposed by webauthn-rs'
         // public surface; we fall back to a JSON serialisation of the
@@ -245,12 +256,8 @@ pub fn passkey_to_cred(passkey: &Passkey, created_at: f64) -> crate::store::Pass
         sign_count: 0,
         transports: Vec::new(),
         created_at,
-        // Authoritative re-verification material: the full serialised
-        // Passkey. The authentication ceremony deserialises this so
-        // webauthn-rs sees the persisted sign-count and can enforce
-        // counter / clone detection.
-        passkey_json: serde_json::to_string(passkey).ok(),
-    }
+        passkey_json: Some(passkey_json),
+    })
 }
 
 /// Reconstruct a [`webauthn_rs::prelude::Passkey`] from a stored

--- a/crates/assay-auth/src/schema.rs
+++ b/crates/assay-auth/src/schema.rs
@@ -100,7 +100,12 @@ CREATE TABLE IF NOT EXISTS auth.passkeys (
     public_key      BYTEA NOT NULL,
     sign_count      INTEGER NOT NULL DEFAULT 0,
     transports      TEXT NOT NULL,
-    created_at      DOUBLE PRECISION NOT NULL
+    created_at      DOUBLE PRECISION NOT NULL,
+    -- Full serialised webauthn-rs Passkey blob. Authoritative
+    -- re-verification material carrying the persisted sign-count so the
+    -- authentication ceremony can enforce counter / clone detection.
+    -- Nullable for forward-compat with rows written before this column.
+    passkey_json    TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_auth_passkeys_user
     ON auth.passkeys (user_id);
@@ -368,7 +373,8 @@ pub const SQLITE_DDL_V1: &[(&str, &str)] = &[
             public_key      BLOB NOT NULL,
             sign_count      INTEGER NOT NULL DEFAULT 0,
             transports      TEXT NOT NULL,
-            created_at      REAL NOT NULL
+            created_at      REAL NOT NULL,
+            passkey_json    TEXT
         )",
     ),
     (

--- a/crates/assay-auth/src/schema.rs
+++ b/crates/assay-auth/src/schema.rs
@@ -59,7 +59,16 @@ pub const MODULE_NAME: &str = "auth";
 ///               and `auth.oidc_upstream_states` with `binding_hash`
 ///               (cookie-bound CSRF binding token hash) — the
 ///               provider-agnostic federation hardening pack.
-pub const MIGRATION_VERSION: i32 = 5;
+/// V6: adds `auth.passkeys.passkey_json TEXT` — the full serialised
+///               `webauthn_rs::prelude::Passkey` blob. Without it the
+///               authentication ceremony cannot enforce sign-counter /
+///               clone detection because webauthn-rs needs the stored
+///               counter inside the `Passkey` struct, not just an
+///               integer column. PG uses `ADD COLUMN IF NOT EXISTS`;
+///               SQLite uses `ADD COLUMN` with duplicate-column
+///               tolerance (same pattern as V5). Already present in the
+///               V1 `CREATE TABLE` for fresh deployments.
+pub const MIGRATION_VERSION: i32 = 6;
 
 /// Postgres DDL for the auth schema, version 1.
 ///
@@ -598,6 +607,19 @@ pub const SQLITE_DDL_V4: &[(&str, &str)] = &[
     ),
 ];
 
+/// Postgres DDL for the auth schema, version 6 — passkey blob column.
+///
+/// Adds `passkey_json TEXT` to `auth.passkeys` so the authentication
+/// ceremony can feed the stored `webauthn_rs::prelude::Passkey` (with
+/// its persisted sign-count) back to the library, enabling sign-counter
+/// / clone-detection enforcement. `ADD COLUMN IF NOT EXISTS` makes this
+/// idempotent on PG. Already present in the V1 `CREATE TABLE IF NOT
+/// EXISTS` for fresh deployments; this pack upgrades existing tables.
+pub const PG_DDL_V6: &str = r#"
+ALTER TABLE auth.passkeys
+    ADD COLUMN IF NOT EXISTS passkey_json TEXT;
+"#;
+
 /// SQLite DDL for the auth schema, version 5 — provider-agnostic
 /// upstream federation columns.
 ///
@@ -623,17 +645,29 @@ pub const SQLITE_DDL_V5: &[(&str, &str)] = &[
     ),
 ];
 
+/// SQLite DDL for the auth schema, version 6 — passkey blob column.
+///
+/// Mirrors [`PG_DDL_V6`]: adds `passkey_json TEXT` to `auth.passkeys`
+/// for sign-counter enforcement. SQLite has no `ADD COLUMN IF NOT
+/// EXISTS`; the runner tolerates the "duplicate column name" error
+/// exactly as it does for V5. Already in the V1 `CREATE TABLE` for
+/// fresh deployments.
+pub const SQLITE_DDL_V6: &[(&str, &str)] = &[(
+    "passkeys.passkey_json",
+    "ALTER TABLE auth.passkeys ADD COLUMN passkey_json TEXT",
+)];
+
 /// Postgres migration runner.
 ///
-/// Applies every DDL pack up to and including the current
-/// [`MIGRATION_VERSION`] (V1 then V2 today). Splits each pack into
+/// Applies every DDL pack V1–V6 in order. Splits each pack into
 /// individual statements (sqlx requires one statement per `query`),
 /// executes each, then records `(MODULE_NAME, MIGRATION_VERSION)` into
-/// `engine.migrations`. Idempotent — every CREATE uses `IF NOT EXISTS`.
+/// `engine.migrations`. Idempotent: every CREATE uses `IF NOT EXISTS`
+/// and every ALTER uses `ADD COLUMN IF NOT EXISTS`.
 #[cfg(feature = "backend-postgres")]
 pub async fn migrate_postgres(pool: &sqlx::PgPool) -> anyhow::Result<()> {
     use anyhow::Context;
-    for ddl in [PG_DDL_V1, PG_DDL_V2, PG_DDL_V3, PG_DDL_V4, PG_DDL_V5] {
+    for ddl in [PG_DDL_V1, PG_DDL_V2, PG_DDL_V3, PG_DDL_V4, PG_DDL_V5, PG_DDL_V6] {
         for stmt in split_pg_statements(ddl) {
             sqlx::query(&stmt)
                 .execute(pool)
@@ -656,10 +690,12 @@ pub async fn migrate_postgres(pool: &sqlx::PgPool) -> anyhow::Result<()> {
 /// SQLite migration runner.
 ///
 /// Caller must have ATTACHed the auth database as `auth` before
-/// calling. Applies every DDL pack up to and including
-/// [`MIGRATION_VERSION`] (V1 then V2 today). Each DDL chunk is
+/// calling. Applies every DDL pack V1–V6 in order. Each DDL chunk is
 /// executed as its own statement; the per-table failure context names
-/// the table that broke so engine boot logs are actionable.
+/// the table that broke so engine boot logs are actionable. Idempotent:
+/// CREATEs use `IF NOT EXISTS`; `ALTER TABLE … ADD COLUMN` statements
+/// (V5, V6) tolerate the "duplicate column name" error SQLite emits on
+/// re-run — equivalent to `IF NOT EXISTS` for column additions.
 #[cfg(feature = "backend-sqlite")]
 pub async fn migrate_sqlite(pool: &sqlx::SqlitePool) -> anyhow::Result<()> {
     use anyhow::Context;
@@ -671,11 +707,11 @@ pub async fn migrate_sqlite(pool: &sqlx::SqlitePool) -> anyhow::Result<()> {
                 .with_context(|| format!("auth sqlite migrate: {label}"))?;
         }
     }
-    for (label, stmt) in SQLITE_DDL_V5 {
+    // V5 and V6 use ALTER TABLE ADD COLUMN which SQLite does not support
+    // with IF NOT EXISTS — tolerate duplicate-column errors so re-running
+    // on an already-migrated DB is a no-op.
+    for (label, stmt) in SQLITE_DDL_V5.iter().chain(SQLITE_DDL_V6) {
         if let Err(e) = sqlx::query(stmt).execute(pool).await {
-            // SQLite's `ALTER TABLE … ADD COLUMN` is not idempotent;
-            // tolerate the duplicate-column error so re-running the
-            // migration on an already-V5 DB is a no-op.
             let msg = format!("{e}");
             if msg.contains("duplicate column name") {
                 continue;
@@ -750,5 +786,196 @@ mod tests {
         assert!(stmts.iter().any(|s| s.contains("auth.users")));
         assert!(stmts.iter().any(|s| s.contains("auth.sessions")));
         assert!(stmts.iter().any(|s| s.contains("auth.jwks_keys")));
+    }
+
+    /// V6 upgrade test: simulate a pre-V6 deployment (auth.passkeys table
+    /// exists but lacks `passkey_json`), run `migrate_sqlite`, then verify
+    /// that `add_passkey` (INSERT) and `get_passkey` (SELECT) work — i.e.
+    /// the column is present and readable after the migration. This is the
+    /// scenario real existing deployments face on the first boot after V6.
+    #[cfg(feature = "backend-sqlite")]
+    #[tokio::test]
+    async fn sqlite_v6_upgrade_adds_passkey_json_to_existing_table() {
+        use sqlx::sqlite::{SqliteConnectOptions, SqlitePool, SqlitePoolOptions};
+        use sqlx::Executor;
+        use std::str::FromStr;
+
+        // Each test gets its own named in-memory DB so parallel runs
+        // never collide (mirrors the oidc_provider.rs harness pattern).
+        let suffix = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .subsec_nanos();
+        let engine_uri = format!("file:assay_v6_eng_{suffix}?mode=memory&cache=shared");
+        let auth_uri = format!("file:assay_v6_auth_{suffix}?mode=memory&cache=shared");
+
+        let opts = SqliteConnectOptions::from_str("sqlite::memory:").unwrap();
+        let pool: SqlitePool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .after_connect(move |conn, _| {
+                let engine_uri = engine_uri.clone();
+                let auth_uri = auth_uri.clone();
+                Box::pin(async move {
+                    conn.execute(
+                        format!("ATTACH DATABASE '{engine_uri}' AS engine").as_str(),
+                    )
+                    .await?;
+                    conn.execute(
+                        format!("ATTACH DATABASE '{auth_uri}' AS auth").as_str(),
+                    )
+                    .await?;
+                    Ok(())
+                })
+            })
+            .connect_with(opts)
+            .await
+            .expect("connect sqlite");
+
+        // Ensure the engine.migrations table exists (migrate_sqlite writes to it).
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS engine.migrations (
+                module TEXT NOT NULL,
+                version INTEGER NOT NULL,
+                PRIMARY KEY (module, version)
+            )",
+        )
+        .execute(&pool)
+        .await
+        .expect("create engine.migrations");
+
+        // Pre-condition: create auth.passkeys WITHOUT passkey_json,
+        // simulating a database that was last migrated at V1–V5.
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS auth.users (
+                id TEXT PRIMARY KEY,
+                email TEXT,
+                email_verified INTEGER NOT NULL DEFAULT 0,
+                display_name TEXT,
+                password_hash TEXT,
+                created_at REAL NOT NULL
+            )",
+        )
+        .execute(&pool)
+        .await
+        .expect("create auth.users");
+
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS auth.passkeys (
+                credential_id BLOB PRIMARY KEY,
+                user_id TEXT NOT NULL,
+                public_key BLOB NOT NULL,
+                sign_count INTEGER NOT NULL DEFAULT 0,
+                transports TEXT NOT NULL,
+                created_at REAL NOT NULL
+                -- passkey_json column intentionally absent: pre-V6 state
+            )",
+        )
+        .execute(&pool)
+        .await
+        .expect("create pre-V6 auth.passkeys");
+
+        // Insert a user row so FK constraints don't block add_passkey.
+        sqlx::query(
+            "INSERT INTO auth.users (id, created_at) VALUES ('user_upgrade', 0.0)",
+        )
+        .execute(&pool)
+        .await
+        .expect("insert test user");
+
+        // Run the migration — V6 ALTER TABLE ADD COLUMN must succeed.
+        crate::schema::migrate_sqlite(&pool)
+            .await
+            .expect("migrate_sqlite V6");
+
+        // Verify the column is present and usable via the store layer.
+        use crate::store::UserStore as _;
+        let store =
+            crate::store::sqlite::SqliteUserStore::new(pool.clone());
+
+        let cred = crate::store::PasskeyCred {
+            credential_id: vec![0xAB, 0xCD],
+            public_key: vec![1, 2, 3],
+            sign_count: 0,
+            transports: vec![],
+            created_at: 0.0,
+            passkey_json: Some("{\"upgraded\":true}".to_string()),
+        };
+        store
+            .add_passkey("user_upgrade", &cred)
+            .await
+            .expect("add_passkey after V6 upgrade");
+
+        let (owner, fetched) = store
+            .get_passkey(&[0xAB, 0xCD])
+            .await
+            .expect("get_passkey after V6 upgrade")
+            .expect("row must exist");
+        assert_eq!(owner, "user_upgrade");
+        assert_eq!(
+            fetched.passkey_json.as_deref(),
+            Some("{\"upgraded\":true}"),
+            "passkey_json must round-trip through the upgraded column"
+        );
+    }
+
+    /// Running migrate_sqlite a second time on an already-V6 DB must be
+    /// a no-op (duplicate column name is tolerated, not an error).
+    #[cfg(feature = "backend-sqlite")]
+    #[tokio::test]
+    async fn sqlite_v6_migration_is_idempotent() {
+        use sqlx::sqlite::{SqliteConnectOptions, SqlitePool, SqlitePoolOptions};
+        use sqlx::Executor;
+        use std::str::FromStr;
+
+        let suffix = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .subsec_nanos()
+            .wrapping_add(1); // distinct from the upgrade test
+        let engine_uri = format!("file:assay_v6_idem_eng_{suffix}?mode=memory&cache=shared");
+        let auth_uri = format!("file:assay_v6_idem_{suffix}?mode=memory&cache=shared");
+
+        let opts = SqliteConnectOptions::from_str("sqlite::memory:").unwrap();
+        let pool: SqlitePool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .after_connect(move |conn, _| {
+                let engine_uri = engine_uri.clone();
+                let auth_uri = auth_uri.clone();
+                Box::pin(async move {
+                    conn.execute(
+                        format!("ATTACH DATABASE '{engine_uri}' AS engine").as_str(),
+                    )
+                    .await?;
+                    conn.execute(
+                        format!("ATTACH DATABASE '{auth_uri}' AS auth").as_str(),
+                    )
+                    .await?;
+                    Ok(())
+                })
+            })
+            .connect_with(opts)
+            .await
+            .expect("connect sqlite");
+
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS engine.migrations (
+                module TEXT NOT NULL,
+                version INTEGER NOT NULL,
+                PRIMARY KEY (module, version)
+            )",
+        )
+        .execute(&pool)
+        .await
+        .expect("create engine.migrations");
+
+        // First run — full fresh migration.
+        crate::schema::migrate_sqlite(&pool)
+            .await
+            .expect("first migrate_sqlite");
+
+        // Second run — must not error (idempotency).
+        crate::schema::migrate_sqlite(&pool)
+            .await
+            .expect("second migrate_sqlite must be idempotent");
     }
 }

--- a/crates/assay-auth/src/session.rs
+++ b/crates/assay-auth/src/session.rs
@@ -265,8 +265,20 @@ async fn login_post(State(ctx): State<AuthCtx>, Json(body): Json<LoginBody>) -> 
     if !ok {
         return unauthorized("invalid credentials");
     }
+    mint_session_response(&ctx, &user.id, user.email.clone()).await
+}
+
+/// Mint an authenticated session for `user_id`, set the session + CSRF
+/// cookies, and return the `200 OK` body. Shared by every successful
+/// authentication path (password + passkey) so they log the user in
+/// identically — same store, same cookies, same attributes.
+async fn mint_session_response(
+    ctx: &AuthCtx,
+    user_id: &str,
+    email: Option<String>,
+) -> Response {
     let mgr = SessionManager::with_default_duration(ctx.sessions.clone());
-    let session = match mgr.create(&user.id).await {
+    let session = match mgr.create(user_id).await {
         Ok(s) => s,
         Err(e) => return server_error(&format!("create session: {e}")),
     };
@@ -280,8 +292,8 @@ async fn login_post(State(ctx): State<AuthCtx>, Json(body): Json<LoginBody>) -> 
     let mut response = (
         StatusCode::OK,
         Json(json!({
-            "user_id": user.id,
-            "email": user.email,
+            "user_id": user_id,
+            "email": email,
             "csrf_token": session.csrf_token,
         })),
     )
@@ -415,12 +427,13 @@ async fn passkey_register_finish(
 
 #[derive(Deserialize)]
 struct PasskeyAuthStartBody {
+    /// The user the client claims to be authenticating. We use it ONLY
+    /// to look the user's registered credentials up in the server's
+    /// store — the credential list itself is NEVER taken from the
+    /// client. (A future discoverable-credential / userless flow can
+    /// drop this field once `webauthn-rs` resident-key support is wired;
+    /// until then the allowed-credentials list is server-resolved.)
     user_id: String,
-    /// Optional pre-decoded passkeys (for tests + advanced clients).
-    /// In production we'd load these out of `auth.passkeys`;
-    /// has no `passkey_json` column so we accept them as a body field.
-    #[serde(default)]
-    passkeys: Vec<serde_json::Value>,
 }
 
 async fn passkey_auth_start(
@@ -430,16 +443,25 @@ async fn passkey_auth_start(
     let Some(mgr) = ctx.passkeys.as_ref() else {
         return svc_unavailable("passkey manager not configured");
     };
-    let _ = body.user_id;
-    let mut creds: Vec<webauthn_rs::prelude::Passkey> = Vec::with_capacity(body.passkeys.len());
-    for v in body.passkeys {
-        match serde_json::from_value(v) {
-            Ok(p) => creds.push(p),
-            Err(e) => return bad_request(&format!("decode passkey: {e}")),
-        }
+    // Resolve the user's allowed credentials SERVER-SIDE from the store.
+    // We never trust a client-supplied credential / passkey list — doing
+    // so would let an attacker present a credential they control and
+    // impersonate any account.
+    let stored = match ctx.users.list_passkeys(&body.user_id).await {
+        Ok(v) => v,
+        Err(e) => return server_error(&format!("list passkeys: {e}")),
+    };
+    if stored.is_empty() {
+        // Mirror the unauthorized shape so the endpoint doesn't leak
+        // whether the user exists vs. simply has no passkeys.
+        return unauthorized("no passkeys registered");
     }
-    if creds.is_empty() {
-        return bad_request("passkeys list is empty");
+    let mut creds: Vec<webauthn_rs::prelude::Passkey> = Vec::with_capacity(stored.len());
+    for cred in &stored {
+        match crate::passkey::cred_to_passkey(cred) {
+            Ok(p) => creds.push(p),
+            Err(e) => return server_error(&format!("rebuild stored passkey: {e}")),
+        }
     }
     match mgr.start_authentication_with(&creds) {
         Ok((challenge, state)) => (
@@ -477,18 +499,53 @@ async fn passkey_auth_finish(
             Ok(r) => r,
             Err(e) => return bad_request(&format!("decode response: {e}")),
         };
-    match mgr.finish_authentication(&state, &response) {
-        Ok(result) => (
-            StatusCode::OK,
-            Json(json!({
-                "credential_id": data_encoding::BASE64URL_NOPAD.encode(&result.credential_id),
-                "sign_count": result.sign_count,
-                "user_verified": result.user_verified,
-            })),
-        )
-            .into_response(),
-        Err(e) => unauthorized(&format!("finish_authentication: {e}")),
+    // Verify the assertion. The library enforces the sign-counter here:
+    // the in-progress `state` was built from the server-resolved stored
+    // `Passkey` carrying its persisted counter, so a regression (clone /
+    // replay) surfaces as an error and this fails closed.
+    let result = match mgr.finish_authentication(&state, &response) {
+        Ok(r) => r,
+        Err(e) => return unauthorized(&format!("finish_authentication: {e}")),
+    };
+
+    // Resolve the owning user from the credential the authenticator
+    // asserted — server-side, never from the client.
+    let cred_id = result.cred_id().as_ref().to_vec();
+    let (user_id, stored_cred) = match ctx.users.get_passkey(&cred_id).await {
+        Ok(Some(pair)) => pair,
+        Ok(None) => return unauthorized("unknown credential"),
+        Err(e) => return server_error(&format!("get passkey: {e}")),
+    };
+
+    // Persist the sign-counter bump (+ backup-state) so the NEXT
+    // authentication enforces against the new value. `update_credential`
+    // returns the re-serialised blob; only write when it actually moved.
+    let mut passkey = match crate::passkey::cred_to_passkey(&stored_cred) {
+        Ok(p) => p,
+        Err(e) => return server_error(&format!("rebuild stored passkey: {e}")),
+    };
+    if result.needs_update() {
+        match crate::passkey::apply_auth_update(&mut passkey, &result) {
+            Ok(blob) => {
+                if let Err(e) = ctx
+                    .users
+                    .update_passkey_counter(&cred_id, result.counter(), &blob)
+                    .await
+                {
+                    return server_error(&format!("persist sign counter: {e}"));
+                }
+            }
+            Err(e) => return server_error(&format!("apply auth update: {e}")),
+        }
     }
+
+    // Mint a real authenticated session — identical to the password
+    // login path. This is what actually logs the user in.
+    let email = match ctx.users.get_user_by_id(&user_id).await {
+        Ok(Some(u)) => u.email,
+        _ => None,
+    };
+    mint_session_response(&ctx, &user_id, email).await
 }
 
 fn parse_cookie(headers: &HeaderMap, name: &str) -> Option<String> {
@@ -740,5 +797,318 @@ mod tests {
         let cookie = cookie_for(&session, &url);
         // Local-dev HTTP must not set Secure or the browser drops the cookie.
         assert_eq!(cookie.secure(), Some(false));
+    }
+
+    // ---- Passkey login security regressions (audit: session.rs) -------
+    //
+    // The three defects these cover:
+    //   (a) trusted a client-supplied credential list
+    //   (b) never enforced / persisted the sign counter
+    //   (c) never minted a session on success
+    //
+    // A full browser ceremony needs an authenticator simulator; these
+    // target the layers we own (request shape, store round-trip, session
+    // minting + the server-side credential resolution path).
+
+    use crate::ctx::AuthCtx;
+    use crate::passkey::{PasskeyConfig, PasskeyManager};
+    use crate::store::types::{PasskeyCred, User};
+    use crate::store::UserStore;
+
+    /// Minimal in-memory user store for the handler tests. Keyed by
+    /// user_id; carries passkeys + a tiny user table.
+    #[derive(Default)]
+    struct MemUserStore {
+        users: Mutex<HashMap<String, User>>,
+        passkeys: Mutex<HashMap<String, Vec<PasskeyCred>>>,
+    }
+
+    #[async_trait::async_trait]
+    impl UserStore for MemUserStore {
+        async fn create_user(&self, user: &User) -> anyhow::Result<()> {
+            self.users
+                .lock()
+                .unwrap()
+                .insert(user.id.clone(), user.clone());
+            Ok(())
+        }
+        async fn get_user_by_id(&self, id: &str) -> anyhow::Result<Option<User>> {
+            Ok(self.users.lock().unwrap().get(id).cloned())
+        }
+        async fn get_user_by_email(&self, email: &str) -> anyhow::Result<Option<User>> {
+            Ok(self
+                .users
+                .lock()
+                .unwrap()
+                .values()
+                .find(|u| u.email.as_deref() == Some(email))
+                .cloned())
+        }
+        async fn update_user(&self, _user: &User) -> anyhow::Result<()> {
+            Ok(())
+        }
+        async fn list_users(
+            &self,
+            _limit: i64,
+            _offset: i64,
+            _search: Option<&str>,
+        ) -> anyhow::Result<Vec<User>> {
+            Ok(vec![])
+        }
+        async fn count_users(&self, _search: Option<&str>) -> anyhow::Result<i64> {
+            Ok(0)
+        }
+        async fn delete_user(&self, _id: &str) -> anyhow::Result<bool> {
+            Ok(false)
+        }
+        async fn set_password_hash(&self, _user_id: &str, _hash: &str) -> anyhow::Result<()> {
+            Ok(())
+        }
+        async fn get_password_hash(&self, _user_id: &str) -> anyhow::Result<Option<String>> {
+            Ok(None)
+        }
+        async fn list_passkeys(&self, user_id: &str) -> anyhow::Result<Vec<PasskeyCred>> {
+            Ok(self
+                .passkeys
+                .lock()
+                .unwrap()
+                .get(user_id)
+                .cloned()
+                .unwrap_or_default())
+        }
+        async fn add_passkey(&self, user_id: &str, cred: &PasskeyCred) -> anyhow::Result<()> {
+            self.passkeys
+                .lock()
+                .unwrap()
+                .entry(user_id.to_string())
+                .or_default()
+                .push(cred.clone());
+            Ok(())
+        }
+        async fn remove_passkey(&self, _credential_id: &[u8]) -> anyhow::Result<bool> {
+            Ok(true)
+        }
+        async fn get_passkey(
+            &self,
+            credential_id: &[u8],
+        ) -> anyhow::Result<Option<(String, PasskeyCred)>> {
+            let guard = self.passkeys.lock().unwrap();
+            for (uid, creds) in guard.iter() {
+                if let Some(c) = creds.iter().find(|c| c.credential_id == credential_id) {
+                    return Ok(Some((uid.clone(), c.clone())));
+                }
+            }
+            Ok(None)
+        }
+        async fn update_passkey_counter(
+            &self,
+            credential_id: &[u8],
+            sign_count: u32,
+            passkey_json: &str,
+        ) -> anyhow::Result<bool> {
+            let mut guard = self.passkeys.lock().unwrap();
+            for creds in guard.values_mut() {
+                if let Some(c) = creds.iter_mut().find(|c| c.credential_id == credential_id) {
+                    c.sign_count = sign_count;
+                    c.passkey_json = Some(passkey_json.to_string());
+                    return Ok(true);
+                }
+            }
+            Ok(false)
+        }
+        async fn link_upstream(
+            &self,
+            _user_id: &str,
+            _provider: &str,
+            _subject: &str,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+        async fn get_user_by_upstream(
+            &self,
+            _provider: &str,
+            _subject: &str,
+        ) -> anyhow::Result<Option<User>> {
+            Ok(None)
+        }
+        async fn list_upstream_for_user(
+            &self,
+            _user_id: &str,
+        ) -> anyhow::Result<Vec<(String, String)>> {
+            Ok(vec![])
+        }
+    }
+
+    fn test_passkey_manager(users: Arc<dyn UserStore>) -> PasskeyManager {
+        let cfg = PasskeyConfig {
+            rp_id: "localhost".to_string(),
+            rp_name: "Assay Test".to_string(),
+            origin: Url::parse("http://localhost:3000").unwrap(),
+        };
+        PasskeyManager::new(cfg, users).unwrap()
+    }
+
+    async fn body_json(resp: Response) -> serde_json::Value {
+        let bytes = axum::body::to_bytes(resp.into_body(), 1 << 20)
+            .await
+            .unwrap();
+        serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null)
+    }
+
+    fn set_cookie_values(resp: &Response) -> Vec<String> {
+        resp.headers()
+            .get_all(header::SET_COOKIE)
+            .iter()
+            .filter_map(|v| v.to_str().ok().map(|s| s.to_string()))
+            .collect()
+    }
+
+    /// Defect (a): the request shape no longer carries a client-supplied
+    /// credential list — a stray `passkeys` array is silently ignored, so
+    /// a client can never inject the credential set the server matches
+    /// against. (The allowed list is resolved server-side from the store.)
+    #[test]
+    fn auth_start_body_ignores_client_supplied_credential_list() {
+        // Old attack shape: client tries to smuggle its own credentials.
+        let raw = serde_json::json!({
+            "user_id": "user_victim",
+            "passkeys": [{"attacker": "controlled-credential"}]
+        });
+        let body: PasskeyAuthStartBody =
+            serde_json::from_value(raw).expect("user_id-only body deserialises");
+        assert_eq!(body.user_id, "user_victim");
+        // The struct has exactly one field — there is nowhere for a
+        // client credential list to land. This is enforced at the type
+        // level: if someone re-adds a `passkeys` field this test's
+        // companion (the handler test below) still proves the store is
+        // the only credential source.
+    }
+
+    /// Defect (a), behavioural: `passkey_auth_start` resolves allowed
+    /// credentials SERVER-SIDE. A user with no stored passkeys gets an
+    /// unauthorized response — there is no client-supplied list that
+    /// could substitute for the empty server store.
+    #[tokio::test]
+    async fn auth_start_uses_server_store_not_client_input() {
+        let users: Arc<dyn UserStore> = Arc::new(MemUserStore::default());
+        let sessions: Arc<dyn SessionStore> = Arc::new(MemSessionStore::new());
+        let ctx = AuthCtx::new(users.clone(), sessions)
+            .with_passkeys(test_passkey_manager(users));
+
+        let resp = passkey_auth_start(
+            State(ctx),
+            Json(PasskeyAuthStartBody {
+                user_id: "user_with_no_keys".to_string(),
+            }),
+        )
+        .await;
+        // No server-side credentials → fail closed, regardless of what a
+        // client might have wanted to present.
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    /// Defect (b): the sign counter round-trips through the store. The
+    /// stored `PasskeyCred` carries both the persisted `sign_count` and
+    /// the serialised `Passkey` blob; `update_passkey_counter` bumps both
+    /// and a re-read observes the new value. This is the persistence half
+    /// of clone detection — without it the library could never compare
+    /// against a moving counter.
+    #[tokio::test]
+    async fn sign_counter_persists_through_store_round_trip() {
+        let users: Arc<dyn UserStore> = Arc::new(MemUserStore::default());
+        let cred_id = vec![1u8, 2, 3, 4];
+        let cred = PasskeyCred {
+            credential_id: cred_id.clone(),
+            public_key: vec![9, 9, 9],
+            sign_count: 5,
+            transports: vec![],
+            created_at: now_secs(),
+            passkey_json: Some("{\"blob\":\"v5\"}".to_string()),
+        };
+        users.add_passkey("user_a", &cred).await.unwrap();
+
+        // Owner + blob resolve from the credential id alone (no client
+        // identity trusted).
+        let (owner, fetched) = users.get_passkey(&cred_id).await.unwrap().unwrap();
+        assert_eq!(owner, "user_a");
+        assert_eq!(fetched.sign_count, 5);
+        assert!(fetched.passkey_json.is_some());
+
+        // Persist a counter bump (what the finish handler does on a
+        // legitimate, advancing authentication).
+        let updated = users
+            .update_passkey_counter(&cred_id, 6, "{\"blob\":\"v6\"}")
+            .await
+            .unwrap();
+        assert!(updated);
+        let (_, after) = users.get_passkey(&cred_id).await.unwrap().unwrap();
+        assert_eq!(after.sign_count, 6);
+        assert_eq!(after.passkey_json.as_deref(), Some("{\"blob\":\"v6\"}"));
+    }
+
+    /// Defect (b), library policy: a stored credential whose blob is
+    /// missing (legacy row) fails closed on reconstruction rather than
+    /// silently authenticating with a zero counter.
+    #[test]
+    fn legacy_credential_without_blob_fails_closed() {
+        let legacy = PasskeyCred {
+            credential_id: vec![7, 7],
+            public_key: vec![1],
+            sign_count: 0,
+            transports: vec![],
+            created_at: now_secs(),
+            passkey_json: None,
+        };
+        let err = crate::passkey::cred_to_passkey(&legacy);
+        assert!(err.is_err(), "legacy row must not yield a usable Passkey");
+    }
+
+    /// Defect (c): a successful authentication mints a REAL session —
+    /// same store, same cookie pair, same attributes as the password
+    /// path. We drive the shared minting helper the passkey finish
+    /// handler uses and assert the session is resolvable and the cookies
+    /// are set.
+    #[tokio::test]
+    async fn successful_auth_mints_a_real_resolvable_session() {
+        let users: Arc<dyn UserStore> = Arc::new(MemUserStore::default());
+        let store = Arc::new(MemSessionStore::new());
+        let sessions: Arc<dyn SessionStore> = store.clone();
+        users
+            .create_user(&User {
+                id: "user_real".to_string(),
+                email: Some("real@example.com".to_string()),
+                email_verified: true,
+                display_name: None,
+                created_at: now_secs(),
+            })
+            .await
+            .unwrap();
+        let ctx = AuthCtx::new(users, sessions.clone());
+
+        let resp =
+            mint_session_response(&ctx, "user_real", Some("real@example.com".to_string())).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // Both cookies (session + CSRF) must be set.
+        let cookies = set_cookie_values(&resp);
+        assert!(
+            cookies.iter().any(|c| c.starts_with(SESSION_COOKIE)),
+            "session cookie missing: {cookies:?}"
+        );
+        assert!(
+            cookies.iter().any(|c| c.starts_with(CSRF_COOKIE)),
+            "csrf cookie missing: {cookies:?}"
+        );
+
+        // The session is actually persisted + resolvable for the user.
+        let body = body_json(resp).await;
+        assert_eq!(body["user_id"], "user_real");
+        let listed = sessions.list_for_user("user_real").await.unwrap();
+        assert_eq!(listed.len(), 1, "exactly one session minted");
+        let mgr = SessionManager::with_default_duration(sessions);
+        assert!(
+            mgr.resolve(&listed[0].id).await.unwrap().is_some(),
+            "minted session resolves"
+        );
     }
 }

--- a/crates/assay-auth/src/session.rs
+++ b/crates/assay-auth/src/session.rs
@@ -414,7 +414,10 @@ async fn passkey_register_finish(
         Ok(p) => p,
         Err(e) => return bad_request(&format!("finish_registration: {e}")),
     };
-    let cred = crate::passkey::passkey_to_cred(&passkey, now_secs());
+    let cred = match crate::passkey::passkey_to_cred(&passkey, now_secs()) {
+        Ok(c) => c,
+        Err(e) => return server_error(&format!("serialise passkey: {e}")),
+    };
     if let Err(e) = ctx.users.add_passkey(&body.user_id, &cred).await {
         return server_error(&format!("persist passkey: {e}"));
     }
@@ -520,6 +523,14 @@ async fn passkey_auth_finish(
     // Persist the sign-counter bump (+ backup-state) so the NEXT
     // authentication enforces against the new value. `update_credential`
     // returns the re-serialised blob; only write when it actually moved.
+    //
+    // Invariant: webauthn-rs sets `needs_update()` whenever the sign
+    // counter advanced OR backup-eligible/backup-state flags changed.
+    // Most platform passkeys use a zero counter (they sync, not clone),
+    // so `needs_update()` will be false on those authenticators and we
+    // skip the write — the stored blob stays valid for the next check.
+    // Hardware keys that increment the counter will always trigger the
+    // write, which is exactly when clone detection depends on it.
     let mut passkey = match crate::passkey::cred_to_passkey(&stored_cred) {
         Ok(p) => p,
         Err(e) => return server_error(&format!("rebuild stored passkey: {e}")),

--- a/crates/assay-auth/src/store/mod.rs
+++ b/crates/assay-auth/src/store/mod.rs
@@ -67,6 +67,27 @@ pub trait UserStore: Send + Sync + 'static {
     async fn add_passkey(&self, user_id: &str, cred: &PasskeyCred) -> anyhow::Result<()>;
     async fn remove_passkey(&self, credential_id: &[u8]) -> anyhow::Result<bool>;
 
+    /// Fetch a single stored credential by its raw credential id, plus
+    /// the `user_id` that owns it. Returns `Ok(None)` when no row
+    /// matches. The authentication ceremony uses this to resolve the
+    /// owning user from the credential the authenticator asserted —
+    /// server-side, never trusting a client-supplied identity.
+    async fn get_passkey(
+        &self,
+        credential_id: &[u8],
+    ) -> anyhow::Result<Option<(String, PasskeyCred)>>;
+
+    /// Persist the post-authentication sign-count bump (and the refreshed
+    /// serialised blob, which carries the same counter + any backup-state
+    /// changes) for the credential. Keyed on `credential_id`. Returns
+    /// `Ok(true)` iff a row was updated.
+    async fn update_passkey_counter(
+        &self,
+        credential_id: &[u8],
+        sign_count: u32,
+        passkey_json: &str,
+    ) -> anyhow::Result<bool>;
+
     // Federated upstream links — `auth.user_upstream`.
     async fn link_upstream(
         &self,

--- a/crates/assay-auth/src/store/postgres.rs
+++ b/crates/assay-auth/src/store/postgres.rs
@@ -114,7 +114,7 @@ impl UserStore for PostgresUserStore {
 
     async fn list_passkeys(&self, user_id: &str) -> Result<Vec<PasskeyCred>> {
         let rows = sqlx::query(
-            "SELECT credential_id, public_key, sign_count, transports, created_at
+            "SELECT credential_id, public_key, sign_count, transports, created_at, passkey_json
              FROM auth.passkeys WHERE user_id = $1
              ORDER BY created_at",
         )
@@ -128,8 +128,8 @@ impl UserStore for PostgresUserStore {
     async fn add_passkey(&self, user_id: &str, cred: &PasskeyCred) -> Result<()> {
         sqlx::query(
             "INSERT INTO auth.passkeys
-                 (credential_id, user_id, public_key, sign_count, transports, created_at)
-             VALUES ($1, $2, $3, $4, $5, $6)",
+                 (credential_id, user_id, public_key, sign_count, transports, created_at, passkey_json)
+             VALUES ($1, $2, $3, $4, $5, $6, $7)",
         )
         .bind(&cred.credential_id)
         .bind(user_id)
@@ -137,6 +137,7 @@ impl UserStore for PostgresUserStore {
         .bind(cred.sign_count as i32)
         .bind(cred.transports.join(","))
         .bind(cred.created_at)
+        .bind(cred.passkey_json.as_deref())
         .execute(&self.pool)
         .await
         .context("auth.passkeys insert")?;
@@ -149,6 +150,43 @@ impl UserStore for PostgresUserStore {
             .execute(&self.pool)
             .await
             .context("auth.passkeys delete")?;
+        Ok(res.rows_affected() > 0)
+    }
+
+    async fn get_passkey(
+        &self,
+        credential_id: &[u8],
+    ) -> Result<Option<(String, PasskeyCred)>> {
+        let row = sqlx::query(
+            "SELECT credential_id, user_id, public_key, sign_count, transports, created_at, passkey_json
+             FROM auth.passkeys WHERE credential_id = $1",
+        )
+        .bind(credential_id)
+        .fetch_optional(&self.pool)
+        .await
+        .context("auth.passkeys get")?;
+        Ok(row.map(|r| {
+            let user_id: String = r.get("user_id");
+            (user_id, map_passkey_row_pg(r))
+        }))
+    }
+
+    async fn update_passkey_counter(
+        &self,
+        credential_id: &[u8],
+        sign_count: u32,
+        passkey_json: &str,
+    ) -> Result<bool> {
+        let res = sqlx::query(
+            "UPDATE auth.passkeys SET sign_count = $1, passkey_json = $2
+             WHERE credential_id = $3",
+        )
+        .bind(sign_count as i32)
+        .bind(passkey_json)
+        .bind(credential_id)
+        .execute(&self.pool)
+        .await
+        .context("auth.passkeys counter update")?;
         Ok(res.rows_affected() > 0)
     }
 
@@ -449,5 +487,6 @@ fn map_passkey_row_pg(row: sqlx::postgres::PgRow) -> PasskeyCred {
             transports.split(',').map(|s| s.to_string()).collect()
         },
         created_at: row.get("created_at"),
+        passkey_json: row.get("passkey_json"),
     }
 }

--- a/crates/assay-auth/src/store/sqlite.rs
+++ b/crates/assay-auth/src/store/sqlite.rs
@@ -116,7 +116,7 @@ impl UserStore for SqliteUserStore {
 
     async fn list_passkeys(&self, user_id: &str) -> Result<Vec<PasskeyCred>> {
         let rows = sqlx::query(
-            "SELECT credential_id, public_key, sign_count, transports, created_at
+            "SELECT credential_id, public_key, sign_count, transports, created_at, passkey_json
              FROM auth.passkeys WHERE user_id = ?
              ORDER BY created_at",
         )
@@ -130,8 +130,8 @@ impl UserStore for SqliteUserStore {
     async fn add_passkey(&self, user_id: &str, cred: &PasskeyCred) -> Result<()> {
         sqlx::query(
             "INSERT INTO auth.passkeys
-                 (credential_id, user_id, public_key, sign_count, transports, created_at)
-             VALUES (?, ?, ?, ?, ?, ?)",
+                 (credential_id, user_id, public_key, sign_count, transports, created_at, passkey_json)
+             VALUES (?, ?, ?, ?, ?, ?, ?)",
         )
         .bind(&cred.credential_id)
         .bind(user_id)
@@ -139,6 +139,7 @@ impl UserStore for SqliteUserStore {
         .bind(cred.sign_count as i64)
         .bind(cred.transports.join(","))
         .bind(cred.created_at)
+        .bind(cred.passkey_json.as_deref())
         .execute(&self.pool)
         .await
         .context("auth.passkeys insert")?;
@@ -151,6 +152,43 @@ impl UserStore for SqliteUserStore {
             .execute(&self.pool)
             .await
             .context("auth.passkeys delete")?;
+        Ok(res.rows_affected() > 0)
+    }
+
+    async fn get_passkey(
+        &self,
+        credential_id: &[u8],
+    ) -> Result<Option<(String, PasskeyCred)>> {
+        let row = sqlx::query(
+            "SELECT credential_id, user_id, public_key, sign_count, transports, created_at, passkey_json
+             FROM auth.passkeys WHERE credential_id = ?",
+        )
+        .bind(credential_id)
+        .fetch_optional(&self.pool)
+        .await
+        .context("auth.passkeys get")?;
+        Ok(row.map(|r| {
+            let user_id: String = r.get("user_id");
+            (user_id, map_passkey_row_sqlite(r))
+        }))
+    }
+
+    async fn update_passkey_counter(
+        &self,
+        credential_id: &[u8],
+        sign_count: u32,
+        passkey_json: &str,
+    ) -> Result<bool> {
+        let res = sqlx::query(
+            "UPDATE auth.passkeys SET sign_count = ?, passkey_json = ?
+             WHERE credential_id = ?",
+        )
+        .bind(sign_count as i64)
+        .bind(passkey_json)
+        .bind(credential_id)
+        .execute(&self.pool)
+        .await
+        .context("auth.passkeys counter update")?;
         Ok(res.rows_affected() > 0)
     }
 
@@ -452,5 +490,6 @@ fn map_passkey_row_sqlite(row: sqlx::sqlite::SqliteRow) -> PasskeyCred {
             transports.split(',').map(|s| s.to_string()).collect()
         },
         created_at: row.get("created_at"),
+        passkey_json: row.get("passkey_json"),
     }
 }

--- a/crates/assay-auth/src/store/types.rs
+++ b/crates/assay-auth/src/store/types.rs
@@ -27,6 +27,15 @@ pub struct PasskeyCred {
     pub sign_count: u32,
     pub transports: Vec<String>,
     pub created_at: f64,
+    /// Full serialised [`webauthn_rs::prelude::Passkey`] JSON blob. This
+    /// is the *authoritative* re-verification material: the server feeds
+    /// it (carrying the persisted sign-count) back into the library on
+    /// the authentication ceremony so counter / clone-detection works.
+    /// `None` only for legacy rows written before the column existed —
+    /// those rows can no longer drive a discoverable login and must be
+    /// re-registered.
+    #[serde(default)]
+    pub passkey_json: Option<String>,
 }
 
 /// Opaque server-side session. `id` is the cookie value the client


### PR DESCRIPTION
## Security fix (CRITICAL)

Passkey login had three defects that made it a demo, not authentication:
1. Trusted a **client-supplied** credential list (`let _ = body.user_id;` — the server store was never consulted)
2. Never checked the WebAuthn sign counter (clone detection documented but not executed)
3. Never minted a session on success

## Changes

- `passkey_auth_start`: client-supplied `passkeys` body field removed; allowed credentials resolved server-side via `list_passkeys(user_id)`; empty store fails closed 401.
- Full serialized `Passkey` blob now persisted (`passkey_json` column); `passkey_auth_finish` resolves the owning user from the asserted `cred_id()` server-side, feeds the persisted blob to webauthn-rs (counter enforcement: regression → `CredentialPossibleCompromise` → 401), persists the bumped counter via new `update_passkey_counter`.
- Session minted via `mint_session_response` — extracted verbatim from `login_post`, so password and passkey paths share one session-creation code path (same store, cookies, CSRF token).
- **Schema**: `passkey_json` added to V1 CREATE *and* delivered to existing deployments via new V6 migration pack (`ALTER TABLE … ADD COLUMN IF NOT EXISTS` on PG, duplicate-column-tolerant ADD on SQLite); `MIGRATION_VERSION` 5→6; upgrade test simulates a pre-V6 DB and asserts registration + lookup work post-migrate.
- `passkey_to_cred` now propagates serialization errors instead of silently storing a NULL blob.
- 7 regression/upgrade tests added; `MemUserStore` test mock.

## Verification

- `cargo test -p assay-auth`: 171 passed, 0 failed (lib) + 22/18/12/1 integration/doc suites green; clippy clean; workspace builds.
- Independent security review (separate lane): the original commit was BLOCKED for the missing-ALTER migration gap (existing deployments would 500 on every passkey op); fixed in the follow-up commit using the repo's existing V5 ALTER pattern. Session-minting parity, no-enumeration at auth_start, and the "legacy rows could never authenticate anyway" claim were all verified against origin/main.

## Breaking / behavioral notes

- `UserStore` trait gained `get_passkey` + `update_passkey_counter` (all in-tree impls updated; out-of-tree impls must add them — correct fail-closed for a security trait).
- Legacy `auth.passkeys` rows (pre-blob) fail closed at login → users re-register. Old rows were never usable for real login (see above), so this is a non-regression; worth a release-note line.
- `PasskeyAuthStartBody.passkeys` removed — no `deny_unknown_fields`, so old clients sending it are silently tolerated.

## Follow-ups (deliberately out of scope)

- Server-pinned single-use challenge store for ceremony state (pre-existing pattern shared with the register flow).
- Auto-revoke policy on counter regression (currently fail-closed 401, RP-discretion per WebAuthn L2 §6.1.1).
- Full browser-ceremony e2e via authenticator simulator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)