### PR TITLE
feat(vault)!: seal KEK at rest under operator-supplied unseal key (closes #113)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,7 +309,7 @@ dependencies = [
 
 [[package]]
 name = "assay-engine"
-version = "0.5.2"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "assay-auth",
@@ -393,10 +393,11 @@ dependencies = [
 
 [[package]]
 name = "assay-vault"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",
+ "argon2",
  "assay-auth",
  "assay-domain",
  "async-trait",
@@ -421,6 +422,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+ "zeroize",
 ]
 
 [[package]]

--- a/crates/assay-engine/Cargo.toml
+++ b/crates/assay-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-engine"
-version = "0.5.2"
+version = "0.6.0"
 categories = ["asynchronous", "database", "web-programming::http-server"]
 edition = "2024"
 keywords = ["workflow", "auth", "oidc", "zanzibar", "postgres"]
@@ -95,7 +95,7 @@ backend-sqlite = [
 assay-auth = { path = "../assay-auth", version = "0.5" }
 assay-dashboard = { path = "../assay-dashboard", version = "0.4" }
 assay-domain = { path = "../assay-domain", version = "0.2" }
-assay-vault = { path = "../assay-vault", version = "0.4", optional = true, default-features = false }
+assay-vault = { path = "../assay-vault", version = "0.5", optional = true, default-features = false }
 assay-workflow = { path = "../assay-workflow", version = "0.4" }
 
 axum = "0.8"

--- a/crates/assay-engine/examples/postgres.toml
+++ b/crates/assay-engine/examples/postgres.toml
@@ -35,8 +35,13 @@ unseal_key_source = "env:ASSAY_VAULT_UNSEAL_KEY"
 # dev_plaintext_kek = true in production — it persists the KEK in
 # plaintext and logs a CRITICAL warning.
 #
-# Migration from a pre-#113 plaintext KEK: setting unseal_key_source
-# auto-re-seals the existing KEK in place on next boot (one-way).
+# Migration from a pre-#113 plaintext KEK (IRREVERSIBLE — back up DB first):
+#   1. Set unseal_key_source above.
+#   2. Uncomment allow_plaintext_migration below.
+#   3. Reboot — the engine re-seals the existing KEK in place (one-way).
+#   4. Remove allow_plaintext_migration once the "MIGRATED" log line appears.
+#
+# allow_plaintext_migration = true
 
 # Pass-through JWT validation against an upstream OIDC provider
 # (added in 0.3.2). Configure one block per trusted issuer. Tokens

--- a/crates/assay-engine/examples/postgres.toml
+++ b/crates/assay-engine/examples/postgres.toml
@@ -22,6 +22,22 @@ enabled = true
 [dashboard]
 enabled = true
 
+# Vault module (default-enabled when the `vault` feature is compiled in).
+# The master KEK is sealed at rest (#113) under operator-supplied unseal
+# material — the engine fails closed rather than persist the KEK in
+# plaintext. Inject a base64 32-byte key out-of-band (K8s Secret env,
+# systemd EnvironmentFile, …), exactly like DATABASE_URL above:
+#   export ASSAY_VAULT_UNSEAL_KEY=$(openssl rand -base64 32)
+[vault]
+unseal_key_source = "env:ASSAY_VAULT_UNSEAL_KEY"
+# Alternatives: `file:/run/secrets/assay_unseal` (must be 0600) or an
+# inline `passphrase:...` (Argon2id-stretched). NEVER set
+# dev_plaintext_kek = true in production — it persists the KEK in
+# plaintext and logs a CRITICAL warning.
+#
+# Migration from a pre-#113 plaintext KEK: setting unseal_key_source
+# auto-re-seals the existing KEK in place on next boot (one-way).
+
 # Pass-through JWT validation against an upstream OIDC provider
 # (added in 0.3.2). Configure one block per trusted issuer. Tokens
 # whose `iss` matches a configured `issuer_url` are verified against

--- a/crates/assay-engine/examples/sqlite.toml
+++ b/crates/assay-engine/examples/sqlite.toml
@@ -22,6 +22,28 @@ enabled = true
 [dashboard]
 enabled = true
 
+# Vault module (default-enabled when the `vault` feature is compiled in).
+# The master KEK is sealed at rest (#113): the engine will NOT boot with
+# an unsealed KEK. Provide unseal material via ONE of:
+#
+#   1. (recommended) An env var holding a base64 32-byte key:
+#        export ASSAY_VAULT_UNSEAL_KEY=$(openssl rand -base64 32)
+#      then point the engine at it:
+[vault]
+unseal_key_source = "env:ASSAY_VAULT_UNSEAL_KEY"
+#
+#   2. A 0600 file:        unseal_key_source = "file:/var/lib/assay/unseal.key"
+#   3. A passphrase:       unseal_key_source = "passphrase:correct horse battery staple"
+#                          (also: a var/file whose contents start with `passphrase:`)
+#
+# Local demos ONLY — persist the KEK in PLAINTEXT (logs a CRITICAL
+# warning; never use for real secrets):
+#   dev_plaintext_kek = true
+#
+# Day-one boot: set the env var above, then run the engine. Migration:
+# if a pre-#113 plaintext KEK already exists, setting unseal_key_source
+# auto-re-seals it in place on next boot (one-way upgrade).
+
 [logging]
 level = "info"
 format = "pretty"

--- a/crates/assay-engine/examples/sqlite.toml
+++ b/crates/assay-engine/examples/sqlite.toml
@@ -40,9 +40,15 @@ unseal_key_source = "env:ASSAY_VAULT_UNSEAL_KEY"
 # warning; never use for real secrets):
 #   dev_plaintext_kek = true
 #
-# Day-one boot: set the env var above, then run the engine. Migration:
-# if a pre-#113 plaintext KEK already exists, setting unseal_key_source
-# auto-re-seals it in place on next boot (one-way upgrade).
+# Day-one boot: set the env var above, then run the engine.
+#
+# Migration from a pre-#113 plaintext KEK (IRREVERSIBLE — back up DB first):
+#   1. Set unseal_key_source above.
+#   2. Uncomment allow_plaintext_migration below.
+#   3. Reboot — the engine re-seals the existing KEK in place (one-way).
+#   4. Remove allow_plaintext_migration once the "MIGRATED" log line appears.
+#
+# allow_plaintext_migration = true
 
 [logging]
 level = "info"

--- a/crates/assay-engine/src/config.rs
+++ b/crates/assay-engine/src/config.rs
@@ -26,6 +26,8 @@ pub struct EngineConfig {
     #[serde(default)]
     pub auth: AuthConfig,
     #[serde(default)]
+    pub vault: VaultConfig,
+    #[serde(default)]
     pub dashboard: DashboardConfig,
     #[serde(default)]
     pub logging: LoggingConfig,
@@ -206,6 +208,35 @@ pub struct ExternalIssuerConfig {
 
 fn default_jwks_refresh_secs() -> u64 {
     3600
+}
+
+/// Vault-module deployment shape. Read by the engine binary when the
+/// `vault` Cargo feature is compiled in AND `engine.modules.vault` is
+/// enabled. The master KEK is sealed at rest under operator-supplied
+/// unseal material (#113) — boot fails closed if neither
+/// `unseal_key_source` nor `dev_plaintext_kek` is set.
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[non_exhaustive]
+pub struct VaultConfig {
+    /// Where the engine reads the KEK unseal material. One of:
+    /// - `env:NAME`        — base64 32-byte key (or `passphrase:<text>`)
+    ///   from environment variable `NAME`. Preferred for K8s/systemd.
+    /// - `file:/path`      — same, read from a `0600` file.
+    /// - `base64:BBBB`     — inline base64 raw key (dev/test).
+    /// - `passphrase:TEXT` — inline passphrase, Argon2id-stretched.
+    ///
+    /// Empty (the default) ⇒ no source. Combined with
+    /// `dev_plaintext_kek = false` this makes the vault fail closed at
+    /// boot rather than persist the KEK in plaintext. Supports the
+    /// engine's `${VAR}` expansion, so `unseal_key_source = "env:..."`
+    /// is the recommended indirection (don't inline secrets in TOML).
+    #[serde(default)]
+    pub unseal_key_source: String,
+    /// Dev-only escape hatch. When `true`, the KEK is persisted in
+    /// PLAINTEXT at rest and boot logs a CRITICAL warning. NEVER enable
+    /// for real secrets — a DB read decrypts everything. Default false.
+    #[serde(default)]
+    pub dev_plaintext_kek: bool,
 }
 
 /// Session module knobs.

--- a/crates/assay-engine/src/config.rs
+++ b/crates/assay-engine/src/config.rs
@@ -237,6 +237,17 @@ pub struct VaultConfig {
     /// for real secrets — a DB read decrypts everything. Default false.
     #[serde(default)]
     pub dev_plaintext_kek: bool,
+    /// Gate for the irreversible plaintext→sealed-v1 auto-migration.
+    ///
+    /// When an existing `plaintext` KEK row is found on boot and
+    /// `unseal_key_source` is set, the engine will NOT overwrite the row
+    /// unless this flag is `true`. This prevents an accidental one-way
+    /// migration on first upgrade. Back up the database before enabling.
+    ///
+    /// Once the migration completes (log line "MIGRATED plaintext KEK"),
+    /// this flag may be removed from `engine.toml`. Default false.
+    #[serde(default)]
+    pub allow_plaintext_migration: bool,
 }
 
 /// Session module knobs.

--- a/crates/assay-engine/src/embedded.rs
+++ b/crates/assay-engine/src/embedded.rs
@@ -127,7 +127,7 @@ async fn build_pg(cfg: EngineConfig, b: crate::init::PgBoot) -> anyhow::Result<E
         .map_err(|e| anyhow::anyhow!("workflow store (pg): {e}"))?;
     let auth_ctx = crate::build_auth_ctx_pg(&cfg, &b.pool).await?;
     #[cfg(feature = "vault")]
-    let vault_ctx = crate::build_vault_ctx_pg(&b.modules, &b.pool).await?;
+    let vault_ctx = crate::build_vault_ctx_pg(&b.modules, &cfg.vault, &b.pool).await?;
     #[cfg(not(feature = "vault"))]
     let vault_ctx: Option<()> = None;
 
@@ -154,7 +154,7 @@ async fn build_sqlite(
         .map_err(|e| anyhow::anyhow!("workflow store (sqlite): {e}"))?;
     let auth_ctx = crate::build_auth_ctx_sqlite(&cfg, &b.pool).await?;
     #[cfg(feature = "vault")]
-    let vault_ctx = crate::build_vault_ctx_sqlite(&b.modules, &b.pool).await?;
+    let vault_ctx = crate::build_vault_ctx_sqlite(&b.modules, &cfg.vault, &b.pool).await?;
     #[cfg(not(feature = "vault"))]
     let vault_ctx: Option<()> = None;
 

--- a/crates/assay-engine/src/lib.rs
+++ b/crates/assay-engine/src/lib.rs
@@ -53,7 +53,7 @@ pub use assay_workflow as workflow;
 
 pub use config::{
     AuthConfig, AuthOidcProviderConfig, AuthPasskeyConfig, AuthSessionConfig, BackendConfig,
-    DashboardConfig, EngineConfig, ServerConfig,
+    DashboardConfig, EngineConfig, ServerConfig, VaultConfig,
 };
 pub use state::{AdminApiKeys, EngineState};
 
@@ -76,19 +76,28 @@ pub async fn run(cfg: EngineConfig) -> anyhow::Result<()> {
 #[cfg(all(feature = "vault", feature = "backend-postgres"))]
 async fn build_vault_ctx_pg(
     modules: &[String],
+    vault_cfg: &VaultConfig,
     pool: &sqlx::PgPool,
 ) -> anyhow::Result<Option<assay_vault::VaultCtx>> {
     if !modules.iter().any(|m| m == "vault") {
         return Ok(None);
     }
-    let kek = assay_vault::crypto::kek_store::load_or_init_postgres(pool)
+    let boot = resolve_kek_boot_config(vault_cfg)?;
+    let sealed_at_rest = boot.material.is_some();
+    let kek = assay_vault::crypto::kek_store::load_or_init_postgres(pool, &boot)
         .await
         .map_err(|e| anyhow::anyhow!("vault KEK bootstrap (pg): {e}"))?;
     // The `vault` umbrella feature on assay-vault implies vault-kv +
     // vault-transit, so the with_* methods are unconditionally
-    // available here.
-    let mut ctx = assay_vault::VaultCtx::new()
-        .with_kek(kek)
+    // available here. Report the at-rest method honestly in seal-status:
+    // sealed-v1 when an unseal key sealed it, plaintext for the dev hatch.
+    let base = assay_vault::VaultCtx::new();
+    let base = if sealed_at_rest {
+        base.with_kek_sealed(kek)
+    } else {
+        base.with_kek(kek)
+    };
+    let mut ctx = base
         .with_kv(assay_vault::store::postgres::PgKvStore::new(pool.clone()))
         .with_transit(assay_vault::store::postgres::PgTransitStore::new(
             pool.clone(),
@@ -142,16 +151,24 @@ async fn build_vault_ctx_pg(
 #[cfg(all(feature = "vault", feature = "backend-sqlite"))]
 async fn build_vault_ctx_sqlite(
     modules: &[String],
+    vault_cfg: &VaultConfig,
     pool: &sqlx::SqlitePool,
 ) -> anyhow::Result<Option<assay_vault::VaultCtx>> {
     if !modules.iter().any(|m| m == "vault") {
         return Ok(None);
     }
-    let kek = assay_vault::crypto::kek_store::load_or_init_sqlite(pool)
+    let boot = resolve_kek_boot_config(vault_cfg)?;
+    let sealed_at_rest = boot.material.is_some();
+    let kek = assay_vault::crypto::kek_store::load_or_init_sqlite(pool, &boot)
         .await
         .map_err(|e| anyhow::anyhow!("vault KEK bootstrap (sqlite): {e}"))?;
-    let mut ctx = assay_vault::VaultCtx::new()
-        .with_kek(kek)
+    let base = assay_vault::VaultCtx::new();
+    let base = if sealed_at_rest {
+        base.with_kek_sealed(kek)
+    } else {
+        base.with_kek(kek)
+    };
+    let mut ctx = base
         .with_kv(assay_vault::store::sqlite::SqliteKvStore::new(pool.clone()))
         .with_transit(assay_vault::store::sqlite::SqliteTransitStore::new(
             pool.clone(),
@@ -199,6 +216,40 @@ async fn build_vault_ctx_sqlite(
         ctx = ctx.with_dynamic(svc);
     }
     Ok(Some(ctx))
+}
+
+/// Resolve the `[vault]` config into the vault crate's [`KekBootConfig`]
+/// — read the unseal material from its configured source (env/file/
+/// inline) and honor the dev escape hatch. Fail-closed semantics live
+/// in the vault crate's loader; this just resolves the source. A
+/// configured-but-unreadable source is a hard boot error (never a
+/// silent plaintext fallback).
+#[cfg(feature = "vault")]
+fn resolve_kek_boot_config(
+    cfg: &VaultConfig,
+) -> anyhow::Result<assay_vault::crypto::kek_store::KekBootConfig> {
+    use assay_vault::crypto::kek_store::KekBootConfig;
+    use assay_vault::crypto::kek_seal::UnsealSource;
+
+    let source = UnsealSource::parse(&cfg.unseal_key_source)
+        .map_err(|e| anyhow::anyhow!("vault.unseal_key_source: {e}"))?;
+    match source {
+        Some(src) => {
+            let material = src
+                .resolve()
+                .map_err(|e| anyhow::anyhow!("resolve vault unseal material: {e}"))?;
+            if cfg.dev_plaintext_kek {
+                tracing::warn!(
+                    target: "assay-engine",
+                    "both vault.unseal_key_source and vault.dev_plaintext_kek are set; using the \
+                     unseal key and IGNORING dev_plaintext_kek"
+                );
+            }
+            Ok(KekBootConfig::sealed(material))
+        }
+        None if cfg.dev_plaintext_kek => Ok(KekBootConfig::dev_plaintext()),
+        None => Ok(KekBootConfig::unset()),
+    }
 }
 
 #[cfg(feature = "backend-postgres")]

--- a/crates/assay-engine/src/lib.rs
+++ b/crates/assay-engine/src/lib.rs
@@ -245,7 +245,11 @@ fn resolve_kek_boot_config(
                      unseal key and IGNORING dev_plaintext_kek"
                 );
             }
-            Ok(KekBootConfig::sealed(material))
+            if cfg.allow_plaintext_migration {
+                Ok(KekBootConfig::sealed_allow_migration(material))
+            } else {
+                Ok(KekBootConfig::sealed(material))
+            }
         }
         None if cfg.dev_plaintext_kek => Ok(KekBootConfig::dev_plaintext()),
         None => Ok(KekBootConfig::unset()),

--- a/crates/assay-engine/tests-e2e/fixtures/engine.toml
+++ b/crates/assay-engine/tests-e2e/fixtures/engine.toml
@@ -24,6 +24,13 @@ rp_name = "Assay E2E"
 [auth.oidc_provider]
 enabled = true
 
+# Vault module is default-enabled when compiled in. This is a throwaway
+# E2E fixture (never production) so it uses an inline base64 32-byte
+# unseal key to exercise the real sealed-at-rest boot path (#113). The
+# value below decodes to 32 zero bytes — fine for an ephemeral fixture.
+[vault]
+unseal_key_source = "base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+
 [logging]
 level = "info"
 format = "pretty"

--- a/crates/assay-engine/tests/engine_smoke.rs
+++ b/crates/assay-engine/tests/engine_smoke.rs
@@ -53,6 +53,13 @@ path = "{db}"
 [auth]
 admin_api_keys = ["engine-smoke-test-key"]
 
+[vault]
+# KEK sealing (#113): the smoke test exercises the real sealed-at-rest
+# path with an inline base64 32-byte unseal key. Boot fails closed
+# without this (or dev_plaintext_kek), which is the whole point of the
+# change. `AAAA...` decodes to 32 zero bytes — fine for a test key.
+unseal_key_source = "base64:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="
+
 [logging]
 level = "error"
 format = "pretty"
@@ -291,8 +298,10 @@ async fn engine_smoke_sqlite() {
     assert_eq!(decoded, plaintext);
 
     // ── /api/v1/vault/sys/seal-status ─────────────────────────────────
-    // Phase 2 sealing: status reflects unsealed (plaintext-method,
-    // first-boot path), `sealed = false`.
+    // KEK sealing (#113): the KEK was sealed at rest under the inline
+    // unseal key and unsealed into memory at boot, so the vault is
+    // operational (`sealed = false`) and reports method `sealed-v1`
+    // (NOT plaintext — that would mean the KEK is unsealed on disk).
     let r = client
         .get(engine.url("/api/v1/vault/sys/seal-status"))
         .header("Authorization", admin_bearer)
@@ -302,7 +311,7 @@ async fn engine_smoke_sqlite() {
     assert_eq!(r.status(), 200);
     let body: serde_json::Value = r.json().await.unwrap();
     assert_eq!(body["sealed"], false);
-    assert_eq!(body["method"], "plaintext");
+    assert_eq!(body["method"], "sealed-v1");
 
     // ── /api/v1/vault/sys/seal — fail-closed semantics ────────────────
     let r = client

--- a/crates/assay-vault/Cargo.toml
+++ b/crates/assay-vault/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-vault"
-version = "0.4.1"
+version = "0.5.0"
 categories = ["cryptography", "asynchronous", "database"]
 edition = "2024"
 keywords = ["vault", "secrets", "kv", "transit", "biscuit"]
@@ -101,6 +101,15 @@ aes-gcm-siv = "0.11"
 data-encoding = "2"
 rand = "0.9"
 sha2 = "0.10"
+
+# KEK sealing at rest (#113). The master KEK is never persisted in
+# plaintext: it is sealed under operator-supplied unseal material. A raw
+# 32-byte key is used verbatim as the wrapping key; a passphrase is
+# stretched with Argon2id at the SAME cost envelope assay-auth uses for
+# password hashing (m=64MiB, t=3, p=4). `zeroize` wipes the unseal
+# material and the derived wrapping key from memory on drop.
+argon2 = "0.5"
+zeroize = "1.8"
 
 # Shamir Secret Sharing for the init-unseal flow (plan 17 §S7).
 # Galois-field-256 SSS, pure Rust, audited. ~50 KB on disk.

--- a/crates/assay-vault/src/crypto/kek.rs
+++ b/crates/assay-vault/src/crypto/kek.rs
@@ -7,17 +7,25 @@
 //! At rest the KEK lives in `vault.kek_metadata.sealed_blob`; how the
 //! blob maps back to raw bytes depends on `sealing_method`:
 //!
-//! - `plaintext` (Phase 1 placeholder): blob *is* the 32 raw bytes.
-//!   Engine boot logs a warning at INFO level so operators know to
-//!   migrate to a real sealing method as Phase 2 lands.
-//! - `shamir` / `kms-*` / `hsm` (Phase 2): real sealing — the unsealed
-//!   bytes never touch disk; this handle holds them in memory only.
+//! - `sealed-v1` (default since 0.5.0): the blob is the KEK encrypted
+//!   with AES-256-GCM-SIV under a wrapping key derived from operator-
+//!   supplied unseal material (env var, file, or Argon2id passphrase).
+//!   The KEK never touches disk in plaintext. See
+//!   [`crate::crypto::kek_seal`] for the blob format.
+//! - `plaintext` (dev-only opt-in via `dev_plaintext_kek = true`): blob
+//!   *is* the 32 raw bytes. Logs a CRITICAL warning. NOT safe for real
+//!   secrets.
+//! - `shamir` / `kms-*` / `hsm` (Phase 2 / future): real sealing with
+//!   an unseal ceremony — the unsealed bytes never touch disk; this
+//!   handle holds them in memory only.
 //!
 //! The handle exposes envelope ops (wrap / unwrap a DEK) but never
 //! exposes the raw bytes — every consumer goes through the wrap/unwrap
 //! API. That confines the KEK material to this file.
 
 use std::sync::Arc;
+
+use zeroize::Zeroize;
 
 use crate::crypto::aead::{KEY_LEN, NONCE_LEN, decrypt, encrypt, random_nonce};
 use crate::error::{Result, VaultError};
@@ -33,6 +41,22 @@ pub struct KekHandle {
 struct KekInner {
     kid: String,
     key: [u8; KEY_LEN],
+}
+
+impl Drop for KekInner {
+    fn drop(&mut self) {
+        self.key.zeroize();
+    }
+}
+
+/// Redacting Debug — never prints key bytes.
+impl std::fmt::Debug for KekHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("KekHandle")
+            .field("kid", &self.inner.kid)
+            .field("key", &"<redacted>")
+            .finish()
+    }
 }
 
 /// Fully-resolved wrapped DEK — the bytes the storage layer puts on

--- a/crates/assay-vault/src/crypto/kek_seal.rs
+++ b/crates/assay-vault/src/crypto/kek_seal.rs
@@ -314,6 +314,22 @@ fn read_unseal_file(path: &std::path::Path) -> Result<Zeroizing<String>> {
             )));
         }
     }
+    #[cfg(not(unix))]
+    {
+        // File permission enforcement (0600 check) is Unix-only.
+        // On non-Unix platforms the check is skipped — ensure the
+        // unseal key file is access-controlled at the OS/filesystem
+        // level (e.g. NTFS ACLs on Windows).
+        let _ = &meta; // suppress unused warning
+        tracing::warn!(
+            target: "assay-vault",
+            path = %path.display(),
+            "unseal-key file permission check is not supported on this platform; \
+             ensure '{}' is protected by OS-level access controls (e.g. NTFS ACLs). \
+             Use `env:` or `base64:` sources on non-Unix platforms to avoid this gap.",
+            path.display()
+        );
+    }
     let s = std::fs::read_to_string(path).map_err(|e| {
         VaultError::Invalid(format!(
             "vault unseal key file '{}' could not be read: {e}",

--- a/crates/assay-vault/src/crypto/kek_seal.rs
+++ b/crates/assay-vault/src/crypto/kek_seal.rs
@@ -1,0 +1,643 @@
+//! KEK sealing under operator-supplied unseal material.
+//!
+//! Closes #113 ("vault master key stored in plaintext next to the data
+//! it encrypts"). The master KEK is the root of the vault's key
+//! hierarchy: every per-record DEK, transit-key version, and collection
+//! envelope is wrapped under it. Storing it in plaintext meant a single
+//! DB read decrypted every secret. This module seals it at rest under a
+//! key the operator supplies out-of-band (env var, file, or — for the
+//! Shamir / KMS phases — a different code path entirely).
+//!
+//! ## At-rest format (`sealing_method = 'sealed-v1'`)
+//!
+//! The `vault.kek_metadata.sealed_blob` for a sealed row is:
+//!
+//! ```text
+//! version (1) | kdf (1) | salt_len (1) | salt (salt_len) | nonce (12) | ciphertext (48)
+//! ```
+//!
+//! - `version` — format tag. `1` today; future KMS/HSM phases bump it so
+//!   an old binary refuses a blob it can't interpret instead of
+//!   mis-parsing.
+//! - `kdf` — how the operator material maps to the 32-byte wrapping key:
+//!   - `0x00` [`KDF_RAW`]: the material IS a 32-byte high-entropy key
+//!     (base64-decoded). No salt; `salt_len = 0`.
+//!   - `0x01` [`KDF_ARGON2ID`]: the material is a passphrase run through
+//!     Argon2id (m=64MiB, t=3, p=4 — the same params assay-auth uses for
+//!     password hashing) with the embedded random salt.
+//! - `nonce` / `ciphertext` — AES-256-GCM-SIV (the vault's only AEAD).
+//!   The ciphertext is the 32-byte KEK plus the 16-byte auth tag. AAD
+//!   binds the format version + the KEK `kid` so a blob can't be lifted
+//!   onto a different row.
+//!
+//! ## Why this shape
+//!
+//! - Reuses the existing AEAD ([`crate::crypto::aead`]) — "are we doing
+//!   AEAD correctly?" stays a one-file question.
+//! - The version tag makes the Shamir / KMS / HSM phases additive: they
+//!   ship new `sealing_method` strings + new blob versions without
+//!   touching this path.
+//! - Wrong unseal material fails at the AEAD tag check — there is no
+//!   plaintext fallback, no oracle, no silent garbage KEK.
+
+use argon2::{Algorithm, Argon2, Params, Version};
+use rand::RngCore;
+use zeroize::Zeroizing;
+
+use crate::crypto::aead::{KEY_LEN, NONCE_LEN, decrypt, encrypt, random_nonce};
+use crate::error::{Result, VaultError};
+
+/// `sealing_method` column value for a KEK sealed by this module.
+pub const METHOD_SEALED_V1: &str = "sealed-v1";
+
+/// Blob format version. Bumped by future KMS/HSM phases.
+const SEAL_BLOB_VERSION: u8 = 1;
+
+/// KDF tag: the unseal material is raw 32-byte key material (base64).
+const KDF_RAW: u8 = 0x00;
+/// KDF tag: the unseal material is a passphrase run through Argon2id.
+const KDF_ARGON2ID: u8 = 0x01;
+
+/// Argon2id memory cost in KiB — 64 MiB. Matches assay-auth's password
+/// hasher (`crates/assay-auth/src/password.rs`), above the OWASP 2024
+/// minimum. Kept in sync deliberately: one cost envelope for the whole
+/// product.
+const ARGON2_MEMORY_KIB: u32 = 65_536;
+/// Argon2id time cost (passes).
+const ARGON2_TIME_COST: u32 = 3;
+/// Argon2id parallelism.
+const ARGON2_PARALLELISM: u32 = 4;
+/// Salt length for the Argon2id path, bytes.
+const ARGON2_SALT_LEN: usize = 16;
+
+/// Domain-separation prefix for the seal AEAD's AAD. The full AAD is
+/// `SEAL_AAD_PREFIX || kid` so a sealed blob is bound to its KEK kid.
+const SEAL_AAD_PREFIX: &[u8] = b"assay-vault/kek-seal/v1:";
+
+/// Operator-supplied material that unseals the KEK. Resolved from config
+/// before any DB work so a missing/unreadable source fails boot fast and
+/// loud, never silently.
+///
+/// Variants intentionally hold the material by value so the caller can
+/// drop it as soon as seal/unseal returns. The bytes are zeroized on
+/// drop via [`Zeroizing`].
+pub enum UnsealMaterial {
+    /// High-entropy 32-byte key (preferred). Used verbatim as the
+    /// AES-256-GCM-SIV wrapping key — no KDF.
+    RawKey(Zeroizing<[u8; KEY_LEN]>),
+    /// A passphrase. Stretched to a 32-byte wrapping key via Argon2id.
+    Passphrase(Zeroizing<String>),
+}
+
+// Manual, redacting Debug — the material is a secret and must never
+// land in logs or panic messages. Reveals only the variant kind.
+impl std::fmt::Debug for UnsealMaterial {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::RawKey(_) => f.write_str("UnsealMaterial::RawKey(<redacted>)"),
+            Self::Passphrase(_) => f.write_str("UnsealMaterial::Passphrase(<redacted>)"),
+        }
+    }
+}
+
+impl UnsealMaterial {
+    /// Parse a base64 string as a raw 32-byte key. The preferred source
+    /// shape: `ASSAY_VAULT_UNSEAL_KEY=$(openssl rand -base64 32)`.
+    ///
+    /// Accepts standard and URL-safe base64, with or without padding —
+    /// operators paste from many tools. Rejects anything that doesn't
+    /// decode to exactly 32 bytes with an actionable error (so a
+    /// truncated paste is caught at boot, not at first unwrap).
+    pub fn raw_key_from_base64(s: &str) -> Result<Self> {
+        let trimmed = s.trim();
+        let raw = decode_base64_any(trimmed).ok_or_else(|| {
+            VaultError::Invalid(
+                "ASSAY_VAULT_UNSEAL_KEY: value is not valid base64. Provide a base64-encoded \
+                 32-byte key, e.g. `openssl rand -base64 32`, or set the source kind to \
+                 `passphrase:` for a human passphrase."
+                    .into(),
+            )
+        })?;
+        if raw.len() != KEY_LEN {
+            return Err(VaultError::Invalid(format!(
+                "ASSAY_VAULT_UNSEAL_KEY: decoded to {} bytes; a raw unseal key must be exactly \
+                 {KEY_LEN} bytes (base64 of 32 random bytes). For a human-memorable secret use a \
+                 `passphrase:` source instead.",
+                raw.len()
+            )));
+        }
+        let mut key = [0u8; KEY_LEN];
+        key.copy_from_slice(&raw);
+        Ok(Self::RawKey(Zeroizing::new(key)))
+    }
+
+    /// Treat the string as a passphrase (stretched via Argon2id). Rejects
+    /// empty / whitespace-only passphrases.
+    pub fn passphrase(s: impl Into<String>) -> Result<Self> {
+        let pw = s.into();
+        if pw.trim().is_empty() {
+            return Err(VaultError::Invalid(
+                "vault unseal passphrase is empty; refusing to seal the KEK under an empty \
+                 passphrase"
+                    .into(),
+            ));
+        }
+        Ok(Self::Passphrase(Zeroizing::new(pw)))
+    }
+
+    /// Derive the 32-byte wrapping key for the seal AEAD, given the KDF
+    /// tag + salt that were (or will be) stored in the blob.
+    fn wrapping_key(
+        &self,
+        kdf: u8,
+        salt: &[u8],
+    ) -> Result<Zeroizing<[u8; KEY_LEN]>> {
+        match (self, kdf) {
+            (Self::RawKey(k), KDF_RAW) => Ok(Zeroizing::new(**k)),
+            (Self::Passphrase(pw), KDF_ARGON2ID) => {
+                let params = Params::new(ARGON2_MEMORY_KIB, ARGON2_TIME_COST, ARGON2_PARALLELISM, Some(KEY_LEN))
+                    .map_err(|e| VaultError::Crypto(format!("argon2 params: {e}")))?;
+                let argon = Argon2::new(Algorithm::Argon2id, Version::V0x13, params);
+                let mut out = Zeroizing::new([0u8; KEY_LEN]);
+                argon
+                    .hash_password_into(pw.as_bytes(), salt, out.as_mut_slice())
+                    .map_err(|e| VaultError::Crypto(format!("argon2 derive: {e}")))?;
+                Ok(out)
+            }
+            // A blob's KDF tag must match the material kind. This only
+            // fires on a misconfiguration (e.g. operator switched from a
+            // raw key to a passphrase without re-sealing) — surface it
+            // clearly rather than feeding a mismatched key to the AEAD
+            // (which would just fail the tag check with a vaguer error).
+            (Self::RawKey(_), KDF_ARGON2ID) => Err(VaultError::Invalid(
+                "vault KEK was sealed with a passphrase (Argon2id) but the configured unseal \
+                 material is a raw key. Provide the original passphrase, or re-seal."
+                    .into(),
+            )),
+            (Self::Passphrase(_), KDF_RAW) => Err(VaultError::Invalid(
+                "vault KEK was sealed with a raw key but the configured unseal material is a \
+                 passphrase. Provide the original raw key, or re-seal."
+                    .into(),
+            )),
+            (_, other) => Err(VaultError::Invalid(format!(
+                "unknown KEK seal KDF tag {other}; this build understands raw (0x00) + \
+                 argon2id (0x01)"
+            ))),
+        }
+    }
+
+    /// KDF tag this material seals under for a fresh seal.
+    fn fresh_kdf(&self) -> u8 {
+        match self {
+            Self::RawKey(_) => KDF_RAW,
+            Self::Passphrase(_) => KDF_ARGON2ID,
+        }
+    }
+}
+
+/// How the engine should obtain the unseal material. Parsed from the
+/// `vault.unseal_key_source` config string (mirrors the repo's
+/// `${VAR}`-style source-string convention in `engine.toml`).
+///
+/// Supported source strings:
+/// - `env:NAME` — read base64 raw key (or passphrase, if `passphrase:`
+///   prefixed inside the var) from environment variable `NAME`.
+/// - `file:/path` — read the material from a file. The file MUST be
+///   `0600` (owner-read/write only) or boot fails; a world-readable
+///   unseal key is no better than a plaintext KEK.
+/// - `base64:BBBB` — an inline base64 raw key. Convenient for dev /
+///   tests; in production prefer `env:`/`file:` so the key isn't in the
+///   config file.
+/// - `passphrase:TEXT` — an inline passphrase (Argon2id-stretched).
+///
+/// `env:`/`file:` values may themselves be prefixed with `passphrase:`
+/// to opt into the Argon2id path instead of base64-raw-key.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum UnsealSource {
+    Env(String),
+    File(std::path::PathBuf),
+    InlineBase64(String),
+    InlinePassphrase(String),
+}
+
+impl UnsealSource {
+    /// Parse a `vault.unseal_key_source` string. Returns `None` for an
+    /// empty/whitespace string (i.e. "no source configured") so the
+    /// caller can decide whether that's a fail-closed condition.
+    pub fn parse(s: &str) -> Result<Option<Self>> {
+        let s = s.trim();
+        if s.is_empty() {
+            return Ok(None);
+        }
+        let src = if let Some(v) = s.strip_prefix("env:") {
+            UnsealSource::Env(v.trim().to_string())
+        } else if let Some(v) = s.strip_prefix("file:") {
+            UnsealSource::File(std::path::PathBuf::from(v.trim()))
+        } else if let Some(v) = s.strip_prefix("base64:") {
+            UnsealSource::InlineBase64(v.trim().to_string())
+        } else if let Some(v) = s.strip_prefix("passphrase:") {
+            UnsealSource::InlinePassphrase(v.to_string())
+        } else {
+            return Err(VaultError::Invalid(format!(
+                "vault.unseal_key_source '{s}' has no recognized prefix. Use one of \
+                 `env:NAME`, `file:/path`, `base64:...`, or `passphrase:...`."
+            )));
+        };
+        Ok(Some(src))
+    }
+
+    /// Resolve the source into concrete [`UnsealMaterial`]. Reads the
+    /// env var / file and applies the 0600 permission check on files.
+    /// A leading `passphrase:` inside the resolved value selects the
+    /// Argon2id path; otherwise the value is treated as a base64 raw key.
+    pub fn resolve(&self) -> Result<UnsealMaterial> {
+        match self {
+            UnsealSource::Env(name) => {
+                let val = std::env::var(name).map_err(|_| {
+                    VaultError::Invalid(format!(
+                        "vault unseal env var '{name}' is not set. Set it to a base64 32-byte key \
+                         (e.g. `export {name}=$(openssl rand -base64 32)`) or a \
+                         `passphrase:<text>` value, then reboot."
+                    ))
+                })?;
+                material_from_value(&val).map_err(|e| annotate(e, &format!("env var '{name}'")))
+            }
+            UnsealSource::File(path) => {
+                let val = read_unseal_file(path)?;
+                material_from_value(val.trim())
+                    .map_err(|e| annotate(e, &format!("file '{}'", path.display())))
+            }
+            UnsealSource::InlineBase64(b64) => UnsealMaterial::raw_key_from_base64(b64),
+            UnsealSource::InlinePassphrase(pw) => UnsealMaterial::passphrase(pw.clone()),
+        }
+    }
+}
+
+/// Interpret a resolved unseal-source value: a leading `passphrase:`
+/// selects Argon2id; everything else is a base64 raw key.
+fn material_from_value(val: &str) -> Result<UnsealMaterial> {
+    if let Some(pw) = val.strip_prefix("passphrase:") {
+        UnsealMaterial::passphrase(pw)
+    } else {
+        UnsealMaterial::raw_key_from_base64(val)
+    }
+}
+
+fn annotate(e: VaultError, src: &str) -> VaultError {
+    match e {
+        VaultError::Invalid(m) => VaultError::Invalid(format!("{m} (source: {src})")),
+        other => other,
+    }
+}
+
+/// Read an unseal-key file, enforcing `0600` perms on Unix. A
+/// world/group-readable unseal key would defeat the purpose, so we
+/// fail closed rather than warn.
+fn read_unseal_file(path: &std::path::Path) -> Result<Zeroizing<String>> {
+    let meta = std::fs::metadata(path).map_err(|e| {
+        VaultError::Invalid(format!(
+            "vault unseal key file '{}' could not be read: {e}",
+            path.display()
+        ))
+    })?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = meta.permissions().mode() & 0o777;
+        if mode & 0o077 != 0 {
+            return Err(VaultError::Invalid(format!(
+                "vault unseal key file '{}' has permissions {:o}; it must be 0600 \
+                 (owner read/write only). Run `chmod 600 {}` and reboot.",
+                path.display(),
+                mode,
+                path.display()
+            )));
+        }
+    }
+    let s = std::fs::read_to_string(path).map_err(|e| {
+        VaultError::Invalid(format!(
+            "vault unseal key file '{}' could not be read: {e}",
+            path.display()
+        ))
+    })?;
+    Ok(Zeroizing::new(s))
+}
+
+/// Seal a 32-byte KEK under `material`, producing the `sealed_blob`
+/// bytes for `vault.kek_metadata`. The plaintext KEK is never written;
+/// only this blob is persisted.
+pub fn seal_kek(kek: &[u8; KEY_LEN], kid: &str, material: &UnsealMaterial) -> Result<Vec<u8>> {
+    let kdf = material.fresh_kdf();
+    let salt: Vec<u8> = match kdf {
+        KDF_ARGON2ID => {
+            let mut s = vec![0u8; ARGON2_SALT_LEN];
+            rand::rng().fill_bytes(&mut s);
+            s
+        }
+        _ => Vec::new(),
+    };
+    if salt.len() > u8::MAX as usize {
+        return Err(VaultError::Crypto("seal salt too long".into()));
+    }
+    let wrapping = material.wrapping_key(kdf, &salt)?;
+    let nonce = random_nonce();
+    let aad = seal_aad(kid);
+    let ct = encrypt(&wrapping, &nonce, &aad, kek)?;
+
+    let mut blob = Vec::with_capacity(3 + salt.len() + NONCE_LEN + ct.len());
+    blob.push(SEAL_BLOB_VERSION);
+    blob.push(kdf);
+    blob.push(salt.len() as u8);
+    blob.extend_from_slice(&salt);
+    blob.extend_from_slice(&nonce);
+    blob.extend_from_slice(&ct);
+    Ok(blob)
+}
+
+/// Unseal a `sealed_blob` produced by [`seal_kek`], returning the raw
+/// 32-byte KEK. Fails (no fallback) if:
+/// - the blob version/format is unrecognized,
+/// - the material kind doesn't match the blob's KDF tag,
+/// - the AEAD tag doesn't validate (wrong key/passphrase, tampered blob,
+///   or wrong `kid`).
+pub fn unseal_kek(blob: &[u8], kid: &str, material: &UnsealMaterial) -> Result<[u8; KEY_LEN]> {
+    // version(1) + kdf(1) + salt_len(1) + nonce(12) + ciphertext(>=KEY_LEN+16)
+    const MIN_LEN: usize = 3 + NONCE_LEN + KEY_LEN + 16;
+    if blob.len() < MIN_LEN {
+        return Err(VaultError::Crypto(format!(
+            "sealed KEK blob is {} bytes; too short to be a valid sealed-v1 blob (min {MIN_LEN})",
+            blob.len()
+        )));
+    }
+    let version = blob[0];
+    if version != SEAL_BLOB_VERSION {
+        return Err(VaultError::Invalid(format!(
+            "sealed KEK blob version {version} is not supported by this build (expects \
+             {SEAL_BLOB_VERSION}). A newer engine wrote this row; upgrade the engine."
+        )));
+    }
+    let kdf = blob[1];
+    let salt_len = blob[2] as usize;
+    let body = &blob[3..];
+    if body.len() < salt_len + NONCE_LEN + KEY_LEN + 16 {
+        return Err(VaultError::Crypto(
+            "sealed KEK blob truncated: salt_len exceeds remaining bytes".into(),
+        ));
+    }
+    let salt = &body[..salt_len];
+    let rest = &body[salt_len..];
+    let mut nonce = [0u8; NONCE_LEN];
+    nonce.copy_from_slice(&rest[..NONCE_LEN]);
+    let ct = &rest[NONCE_LEN..];
+
+    let wrapping = material.wrapping_key(kdf, salt)?;
+    let aad = seal_aad(kid);
+    let pt = decrypt(&wrapping, &nonce, &aad, ct).map_err(|_| {
+        VaultError::Crypto(
+            "vault KEK unseal failed: the auth tag did not validate. The unseal key/passphrase is \
+             wrong, the sealed blob was tampered with, or it belongs to a different KEK. The \
+             engine will NOT fall back to plaintext."
+                .into(),
+        )
+    })?;
+    if pt.len() != KEY_LEN {
+        return Err(VaultError::Crypto(format!(
+            "unsealed KEK is {} bytes; expected {KEY_LEN}",
+            pt.len()
+        )));
+    }
+    let mut key = [0u8; KEY_LEN];
+    key.copy_from_slice(&pt);
+    Ok(key)
+}
+
+fn seal_aad(kid: &str) -> Vec<u8> {
+    let mut aad = Vec::with_capacity(SEAL_AAD_PREFIX.len() + kid.len());
+    aad.extend_from_slice(SEAL_AAD_PREFIX);
+    aad.extend_from_slice(kid.as_bytes());
+    aad
+}
+
+/// Decode base64 in whichever common alphabet the operator pasted —
+/// standard or URL-safe, padded or not. Returns `None` on failure.
+fn decode_base64_any(s: &str) -> Option<Vec<u8>> {
+    use data_encoding::{BASE64, BASE64URL, BASE64URL_NOPAD, BASE64_NOPAD};
+    for enc in [&BASE64, &BASE64_NOPAD, &BASE64URL, &BASE64URL_NOPAD] {
+        if let Ok(v) = enc.decode(s.as_bytes()) {
+            return Some(v);
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crypto::aead::random_dek;
+
+    fn raw_material() -> UnsealMaterial {
+        let key = random_dek();
+        UnsealMaterial::RawKey(Zeroizing::new(key))
+    }
+
+    #[test]
+    fn raw_key_seal_unseal_round_trip() {
+        let kek = random_dek();
+        let m = raw_material();
+        let blob = seal_kek(&kek, "kek-abc", &m).unwrap();
+        // The plaintext KEK must not appear verbatim in the blob.
+        assert!(
+            blob.windows(KEY_LEN).all(|w| w != kek),
+            "sealed blob must not contain the raw KEK"
+        );
+        let recovered = unseal_kek(&blob, "kek-abc", &m).unwrap();
+        assert_eq!(recovered, kek);
+    }
+
+    #[test]
+    fn passphrase_seal_unseal_round_trip() {
+        let kek = random_dek();
+        let m = UnsealMaterial::passphrase("correct horse battery staple").unwrap();
+        let blob = seal_kek(&kek, "kek-pw", &m).unwrap();
+        assert_eq!(blob[1], KDF_ARGON2ID, "passphrase seal must tag argon2id");
+        let m2 = UnsealMaterial::passphrase("correct horse battery staple").unwrap();
+        let recovered = unseal_kek(&blob, "kek-pw", &m2).unwrap();
+        assert_eq!(recovered, kek);
+    }
+
+    #[test]
+    fn wrong_raw_key_fails_tag() {
+        let kek = random_dek();
+        let m = raw_material();
+        let blob = seal_kek(&kek, "kek-1", &m).unwrap();
+        let wrong = raw_material();
+        let res = unseal_kek(&blob, "kek-1", &wrong);
+        assert!(matches!(res, Err(VaultError::Crypto(_))), "wrong key must fail");
+    }
+
+    #[test]
+    fn wrong_passphrase_fails_tag() {
+        let kek = random_dek();
+        let m = UnsealMaterial::passphrase("right-passphrase").unwrap();
+        let blob = seal_kek(&kek, "kek-1", &m).unwrap();
+        let wrong = UnsealMaterial::passphrase("wrong-passphrase").unwrap();
+        assert!(unseal_kek(&blob, "kek-1", &wrong).is_err());
+    }
+
+    #[test]
+    fn wrong_kid_fails_tag() {
+        let kek = random_dek();
+        let m = raw_material();
+        let blob = seal_kek(&kek, "kek-correct", &m).unwrap();
+        // Same material, different kid → AAD mismatch → tag fails.
+        assert!(unseal_kek(&blob, "kek-other", &m).is_err());
+    }
+
+    #[test]
+    fn tampered_blob_fails() {
+        let kek = random_dek();
+        let m = raw_material();
+        let mut blob = seal_kek(&kek, "kek-t", &m).unwrap();
+        let last = blob.len() - 1;
+        blob[last] ^= 0xff;
+        assert!(unseal_kek(&blob, "kek-t", &m).is_err());
+    }
+
+    #[test]
+    fn material_kind_mismatch_is_actionable() {
+        let kek = random_dek();
+        let m = raw_material();
+        let blob = seal_kek(&kek, "kek-x", &m).unwrap();
+        let pw = UnsealMaterial::passphrase("pw").unwrap();
+        let err = unseal_kek(&blob, "kek-x", &pw).unwrap_err();
+        assert!(
+            matches!(err, VaultError::Invalid(_)),
+            "raw-sealed blob unsealed with a passphrase should be an actionable Invalid, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn truncated_blob_rejected() {
+        let m = raw_material();
+        assert!(unseal_kek(&[1u8, 2, 3], "kid", &m).is_err());
+    }
+
+    #[test]
+    fn future_version_rejected() {
+        let kek = random_dek();
+        let m = raw_material();
+        let mut blob = seal_kek(&kek, "kek-v", &m).unwrap();
+        blob[0] = 99;
+        let err = unseal_kek(&blob, "kek-v", &m).unwrap_err();
+        assert!(matches!(err, VaultError::Invalid(_)));
+    }
+
+    #[test]
+    fn raw_key_from_base64_validates_length() {
+        // 32 bytes → ok.
+        let good = data_encoding::BASE64.encode(&[7u8; KEY_LEN]);
+        assert!(UnsealMaterial::raw_key_from_base64(&good).is_ok());
+        // 16 bytes → rejected with actionable error.
+        let short = data_encoding::BASE64.encode(&[7u8; 16]);
+        let err = UnsealMaterial::raw_key_from_base64(&short).unwrap_err();
+        assert!(matches!(err, VaultError::Invalid(_)));
+        // Not base64 at all.
+        assert!(UnsealMaterial::raw_key_from_base64("not base64!!!").is_err());
+    }
+
+    #[test]
+    fn raw_key_from_base64_accepts_urlsafe_and_nopad() {
+        let bytes = [3u8; KEY_LEN];
+        for enc in [
+            &data_encoding::BASE64,
+            &data_encoding::BASE64_NOPAD,
+            &data_encoding::BASE64URL,
+            &data_encoding::BASE64URL_NOPAD,
+        ] {
+            let s = enc.encode(&bytes);
+            assert!(
+                UnsealMaterial::raw_key_from_base64(&s).is_ok(),
+                "should accept {s}"
+            );
+        }
+    }
+
+    #[test]
+    fn empty_passphrase_rejected() {
+        assert!(UnsealMaterial::passphrase("   ").is_err());
+    }
+
+    #[test]
+    fn source_parse_recognizes_prefixes() {
+        assert_eq!(
+            UnsealSource::parse("env:FOO").unwrap(),
+            Some(UnsealSource::Env("FOO".into()))
+        );
+        assert_eq!(
+            UnsealSource::parse("file:/etc/key").unwrap(),
+            Some(UnsealSource::File("/etc/key".into()))
+        );
+        assert_eq!(
+            UnsealSource::parse("base64:AAAA").unwrap(),
+            Some(UnsealSource::InlineBase64("AAAA".into()))
+        );
+        assert_eq!(
+            UnsealSource::parse("passphrase:hunter2").unwrap(),
+            Some(UnsealSource::InlinePassphrase("hunter2".into()))
+        );
+        // Empty → no source configured.
+        assert_eq!(UnsealSource::parse("   ").unwrap(), None);
+        // Unknown prefix → actionable error.
+        assert!(UnsealSource::parse("vault:secret").is_err());
+    }
+
+    #[test]
+    fn source_env_resolves_base64_and_passphrase() {
+        let key_b64 = data_encoding::BASE64.encode(&[9u8; KEY_LEN]);
+        // SAFETY: single-threaded test; var name is unique per test.
+        unsafe {
+            std::env::set_var("ASSAY_TEST_UNSEAL_RAW", &key_b64);
+            std::env::set_var("ASSAY_TEST_UNSEAL_PW", "passphrase:my secret");
+        }
+        let m = UnsealSource::Env("ASSAY_TEST_UNSEAL_RAW".into())
+            .resolve()
+            .unwrap();
+        assert!(matches!(m, UnsealMaterial::RawKey(_)));
+        let m2 = UnsealSource::Env("ASSAY_TEST_UNSEAL_PW".into())
+            .resolve()
+            .unwrap();
+        assert!(matches!(m2, UnsealMaterial::Passphrase(_)));
+        unsafe {
+            std::env::remove_var("ASSAY_TEST_UNSEAL_RAW");
+            std::env::remove_var("ASSAY_TEST_UNSEAL_PW");
+        }
+    }
+
+    #[test]
+    fn source_env_missing_is_actionable() {
+        let err = UnsealSource::Env("ASSAY_DEFINITELY_UNSET_VAR_XYZ".into())
+            .resolve()
+            .unwrap_err();
+        assert!(matches!(err, VaultError::Invalid(_)));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn source_file_rejects_loose_perms() {
+        use std::io::Write;
+        use std::os::unix::fs::PermissionsExt;
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!("assay-unseal-perm-{}.key", std::process::id()));
+        let mut f = std::fs::File::create(&path).unwrap();
+        write!(f, "{}", data_encoding::BASE64.encode(&[1u8; KEY_LEN])).unwrap();
+        drop(f);
+        // 0644 → must be rejected.
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644)).unwrap();
+        let err = UnsealSource::File(path.clone()).resolve().unwrap_err();
+        assert!(matches!(err, VaultError::Invalid(_)));
+        // 0600 → accepted.
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600)).unwrap();
+        assert!(UnsealSource::File(path.clone()).resolve().is_ok());
+        let _ = std::fs::remove_file(&path);
+    }
+}

--- a/crates/assay-vault/src/crypto/kek_store.rs
+++ b/crates/assay-vault/src/crypto/kek_store.rs
@@ -1,28 +1,92 @@
-//! KEK persistence — load the active KEK from `vault.kek_metadata` or
-//! generate a fresh one on first boot.
+//! KEK persistence — load the active KEK from `vault.kek_metadata`,
+//! sealing it at rest under operator-supplied unseal material, or
+//! generate + seal a fresh one on first boot.
 //!
-//! ## Phase 1 stance
+//! ## Sealing stance (#113)
 //!
-//! Phase 1 ships `sealing_method = 'plaintext'` only — the KEK lives in
-//! `kek_metadata.sealed_blob` as raw bytes. Engine boot logs a WARN so
-//! operators know vault is running unsealed and that Phase 2 is the path
-//! to real sealing.
+//! The master KEK is **never persisted in plaintext** unless the operator
+//! explicitly opts into a dev escape hatch. The default boot path:
+//!
+//! - **First boot, unseal material present** — mint a random KEK, seal it
+//!   ([`crate::crypto::kek_seal::seal_kek`]) and persist only the sealed
+//!   blob with `sealing_method = 'sealed-v1'`.
+//! - **Boot with a sealed row** — unseal it with the configured material.
+//!   Wrong material fails the AEAD tag → boot fails closed.
+//! - **Boot without unseal material** — fail closed with an actionable
+//!   error telling the operator how to set the unseal key + migrate.
+//! - **Existing plaintext row found** — if unseal material is present,
+//!   automatically re-seal it in place (one-way upgrade) and log the
+//!   migration. If not, fail closed with migration instructions.
+//! - **Dev escape hatch** — `dev_plaintext_kek = true` keeps the old
+//!   plaintext behavior for demo flows, behind a loud CRITICAL warning.
+//!   Never the default.
 //!
 //! ## Phase 2 plug-in shape
 //!
-//! Phase 2 will add `load_with_unseal` variants that take an
-//! `UnsealMaterial` enum (Shamir shares, KMS handle, HSM session). The
-//! Phase 1 loader stays usable for the plaintext path indefinitely so
-//! tests don't need to set up KMS.
+//! Shamir / KMS / HSM sealing live on their own code paths
+//! ([`load_active_*`], [`init_shamir_*`]) and bump the blob version tag
+//! so an old binary refuses a row it can't interpret.
 
 use anyhow::Context;
 
 use crate::crypto::aead::{KEY_LEN, random_dek};
 use crate::crypto::kek::KekHandle;
+use crate::crypto::kek_seal::{METHOD_SEALED_V1, UnsealMaterial, seal_kek, unseal_kek};
 
 /// Sealing method — the column value in `vault.kek_metadata`.
 pub const METHOD_PLAINTEXT: &str = "plaintext";
 pub const METHOD_SHAMIR: &str = "shamir";
+
+/// What the engine-boot caller resolved about KEK sealing from config.
+/// Built in `assay-engine` from the `[vault]` config section and handed
+/// to [`load_or_init_postgres`] / [`load_or_init_sqlite`].
+#[non_exhaustive]
+pub struct KekBootConfig {
+    /// Resolved unseal material, if a source was configured. `None` ⇒
+    /// no source — fail closed unless `dev_plaintext` is set.
+    pub material: Option<UnsealMaterial>,
+    /// Explicit opt-in to the plaintext escape hatch. Logs CRITICAL.
+    pub dev_plaintext: bool,
+}
+
+impl KekBootConfig {
+    /// Sealed boot with concrete unseal material (the production path).
+    pub fn sealed(material: UnsealMaterial) -> Self {
+        Self {
+            material: Some(material),
+            dev_plaintext: false,
+        }
+    }
+
+    /// Dev-only: no unseal material, plaintext KEK at rest. Loud warning.
+    pub fn dev_plaintext() -> Self {
+        Self {
+            material: None,
+            dev_plaintext: true,
+        }
+    }
+
+    /// No unseal material and no dev opt-in — boot must fail closed.
+    pub fn unset() -> Self {
+        Self {
+            material: None,
+            dev_plaintext: false,
+        }
+    }
+}
+
+/// Shared, backend-agnostic error for the "no unseal material, not dev"
+/// fail-closed case. Actionable: tells the operator exactly what to do.
+fn fail_closed_no_material() -> anyhow::Error {
+    anyhow::anyhow!(
+        "vault is enabled but no KEK unseal material is configured. The master KEK will NOT be \
+         persisted in plaintext. Set `vault.unseal_key_source` in engine.toml (e.g. \
+         `unseal_key_source = \"env:ASSAY_VAULT_UNSEAL_KEY\"`) and export a base64 32-byte key \
+         (`export ASSAY_VAULT_UNSEAL_KEY=$(openssl rand -base64 32)`), then reboot. For local \
+         demos only, set `vault.dev_plaintext_kek = true` (logs a CRITICAL warning and is NOT \
+         safe for real secrets)."
+    )
+}
 
 /// Outcome of [`load_active_*`] — fully describes the at-rest state so
 /// engine boot can construct the right [`crate::crypto::seal_state::SealState`].
@@ -42,16 +106,25 @@ pub enum ActiveKek {
 #[cfg(feature = "vault-sealing-shamir")]
 use crate::crypto::sealing::shamir::{Share, split_kek};
 
-/// Load the active KEK or generate one on first boot.
+/// Load the active KEK or generate one on first boot, sealing it at rest
+/// per `cfg`.
 ///
-/// "Active" = the row with the most recent `created_at`. If no row
-/// exists, a fresh 32-byte KEK is minted, persisted with
-/// `sealing_method = 'plaintext'`, and returned.
+/// "Active" = the row with the most recent `created_at`. Behavior by
+/// at-rest state (see module docs for the full matrix):
 ///
-/// The returned handle holds the unsealed bytes in memory; persisting
-/// them in plaintext is the explicit Phase 1 trade-off.
+/// - No row: mint + seal a fresh KEK (or persist plaintext iff
+///   `cfg.dev_plaintext`).
+/// - `sealed-v1` row: unseal with `cfg.material`; wrong material ⇒
+///   fail closed.
+/// - `plaintext` row + material present: auto-migrate (re-seal in place).
+/// - `plaintext` row + no material + `dev_plaintext`: keep plaintext,
+///   warn loudly.
+/// - `plaintext` row + no material + not dev: fail closed.
 #[cfg(feature = "backend-postgres")]
-pub async fn load_or_init_postgres(pool: &sqlx::PgPool) -> anyhow::Result<KekHandle> {
+pub async fn load_or_init_postgres(
+    pool: &sqlx::PgPool,
+    cfg: &KekBootConfig,
+) -> anyhow::Result<KekHandle> {
     let existing: Option<(String, String, Vec<u8>)> = sqlx::query_as(
         "SELECT kid, sealing_method, sealed_blob
            FROM vault.kek_metadata
@@ -63,32 +136,129 @@ pub async fn load_or_init_postgres(pool: &sqlx::PgPool) -> anyhow::Result<KekHan
     .context("read vault.kek_metadata")?;
 
     if let Some((kid, method, blob)) = existing {
-        let key = parse_plaintext_blob(&method, &blob)
-            .with_context(|| format!("unwrap KEK kid={kid}"))?;
-        warn_if_plaintext(&kid, &method);
-        return Ok(KekHandle::from_bytes(kid, key));
+        return load_existing_pg(pool, cfg, kid, method, blob).await;
     }
 
+    // ── First boot ────────────────────────────────────────────────
     let key = random_dek();
-    let handle = KekHandle::from_bytes(content_addressed_kid(&key), key);
+    let kid = content_addressed_kid(&key);
+    if let Some(material) = &cfg.material {
+        let sealed_blob = seal_kek(&key, &kid, material).context("seal fresh KEK")?;
+        sqlx::query(
+            "INSERT INTO vault.kek_metadata
+                (kid, sealing_method, sealed, sealed_blob, sealed_at, unsealed_at)
+             VALUES ($1, $2, TRUE, $3, EXTRACT(EPOCH FROM NOW()), EXTRACT(EPOCH FROM NOW()))",
+        )
+        .bind(&kid)
+        .bind(METHOD_SEALED_V1)
+        .bind(sealed_blob.as_slice())
+        .execute(pool)
+        .await
+        .context("seed sealed vault.kek_metadata")?;
+        tracing::info!(target: "assay-vault", kid = %kid, "first-boot KEK minted and sealed at rest");
+        Ok(KekHandle::from_bytes(kid, key))
+    } else if cfg.dev_plaintext {
+        seed_plaintext_pg(pool, &kid, &key).await?;
+        warn_dev_plaintext(&kid);
+        Ok(KekHandle::from_bytes(kid, key))
+    } else {
+        Err(fail_closed_no_material())
+    }
+}
+
+#[cfg(feature = "backend-postgres")]
+async fn load_existing_pg(
+    pool: &sqlx::PgPool,
+    cfg: &KekBootConfig,
+    kid: String,
+    method: String,
+    blob: Vec<u8>,
+) -> anyhow::Result<KekHandle> {
+    match method.as_str() {
+        METHOD_SEALED_V1 => {
+            let material = cfg
+                .material
+                .as_ref()
+                .ok_or_else(fail_closed_no_material)?;
+            let key = unseal_kek(&blob, &kid, material)
+                .with_context(|| format!("unseal KEK kid={kid}"))?;
+            tracing::info!(target: "assay-vault", kid = %kid, "KEK unsealed at boot");
+            Ok(KekHandle::from_bytes(kid, key))
+        }
+        METHOD_PLAINTEXT => {
+            let key = parse_plaintext_blob(&method, &blob)
+                .with_context(|| format!("unwrap plaintext KEK kid={kid}"))?;
+            if let Some(material) = &cfg.material {
+                // ── One-way migration: re-seal the plaintext KEK ──
+                let sealed_blob =
+                    seal_kek(&key, &kid, material).context("seal KEK during plaintext migration")?;
+                sqlx::query(
+                    "UPDATE vault.kek_metadata
+                        SET sealing_method = $1, sealed = TRUE, sealed_blob = $2,
+                            sealed_at = EXTRACT(EPOCH FROM NOW())
+                      WHERE kid = $3",
+                )
+                .bind(METHOD_SEALED_V1)
+                .bind(sealed_blob.as_slice())
+                .bind(&kid)
+                .execute(pool)
+                .await
+                .context("re-seal plaintext KEK row")?;
+                tracing::warn!(
+                    target: "assay-vault",
+                    kid = %kid,
+                    "MIGRATED plaintext KEK to sealed-v1 at rest. The plaintext blob has been \
+                     overwritten with the sealed blob. Keep your unseal key safe — it is now \
+                     required to boot."
+                );
+                Ok(KekHandle::from_bytes(kid, key))
+            } else if cfg.dev_plaintext {
+                warn_dev_plaintext(&kid);
+                Ok(KekHandle::from_bytes(kid, key))
+            } else {
+                Err(anyhow::anyhow!(
+                    "vault.kek_metadata holds a PLAINTEXT master KEK (kid={kid}) but no unseal \
+                     material is configured to migrate it. Set `vault.unseal_key_source` (e.g. \
+                     `env:ASSAY_VAULT_UNSEAL_KEY`) + export a base64 32-byte key, then reboot — \
+                     the engine will automatically re-seal the existing KEK in place. Refusing to \
+                     boot with an unsealed KEK."
+                ))
+            }
+        }
+        other => Err(anyhow::anyhow!(
+            "vault.kek_metadata.sealing_method = '{other}' (kid={kid}) is not handled by the \
+             boot loader. Shamir / KMS rows are unsealed via the /sys/unseal ceremony, not the \
+             boot path."
+        )),
+    }
+}
+
+#[cfg(feature = "backend-postgres")]
+async fn seed_plaintext_pg(
+    pool: &sqlx::PgPool,
+    kid: &str,
+    key: &[u8; KEY_LEN],
+) -> anyhow::Result<()> {
     sqlx::query(
         "INSERT INTO vault.kek_metadata
             (kid, sealing_method, sealed, sealed_blob, sealed_at, unsealed_at)
          VALUES ($1, $2, FALSE, $3, NULL, EXTRACT(EPOCH FROM NOW()))",
     )
-    .bind(handle.kid())
+    .bind(kid)
     .bind(METHOD_PLAINTEXT)
     .bind(key.as_slice())
     .execute(pool)
     .await
-    .context("seed vault.kek_metadata")?;
-    warn_first_boot_plaintext(handle.kid());
-    Ok(handle)
+    .context("seed plaintext vault.kek_metadata (dev mode)")?;
+    Ok(())
 }
 
 /// SQLite mirror of [`load_or_init_postgres`].
 #[cfg(feature = "backend-sqlite")]
-pub async fn load_or_init_sqlite(pool: &sqlx::SqlitePool) -> anyhow::Result<KekHandle> {
+pub async fn load_or_init_sqlite(
+    pool: &sqlx::SqlitePool,
+    cfg: &KekBootConfig,
+) -> anyhow::Result<KekHandle> {
     let existing: Option<(String, String, Vec<u8>)> = sqlx::query_as(
         "SELECT kid, sealing_method, sealed_blob
            FROM vault.kek_metadata
@@ -100,33 +270,135 @@ pub async fn load_or_init_sqlite(pool: &sqlx::SqlitePool) -> anyhow::Result<KekH
     .context("read vault.kek_metadata")?;
 
     if let Some((kid, method, blob)) = existing {
-        let key = parse_plaintext_blob(&method, &blob)
-            .with_context(|| format!("unwrap KEK kid={kid}"))?;
-        warn_if_plaintext(&kid, &method);
-        return Ok(KekHandle::from_bytes(kid, key));
+        return load_existing_sqlite(pool, cfg, kid, method, blob).await;
     }
 
+    // ── First boot ────────────────────────────────────────────────
     let key = random_dek();
-    let handle = KekHandle::from_bytes(content_addressed_kid(&key), key);
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs_f64();
+    let kid = content_addressed_kid(&key);
+    let now = unix_now();
+    if let Some(material) = &cfg.material {
+        let sealed_blob = seal_kek(&key, &kid, material).context("seal fresh KEK")?;
+        sqlx::query(
+            "INSERT INTO vault.kek_metadata
+                (kid, sealing_method, sealed, sealed_blob, sealed_at, unsealed_at, created_at)
+             VALUES (?, ?, 1, ?, ?, ?, ?)",
+        )
+        .bind(&kid)
+        .bind(METHOD_SEALED_V1)
+        .bind(sealed_blob.as_slice())
+        .bind(now)
+        .bind(now)
+        .bind(now)
+        .execute(pool)
+        .await
+        .context("seed sealed vault.kek_metadata")?;
+        tracing::info!(target: "assay-vault", kid = %kid, "first-boot KEK minted and sealed at rest");
+        Ok(KekHandle::from_bytes(kid, key))
+    } else if cfg.dev_plaintext {
+        seed_plaintext_sqlite(pool, &kid, &key, now).await?;
+        warn_dev_plaintext(&kid);
+        Ok(KekHandle::from_bytes(kid, key))
+    } else {
+        Err(fail_closed_no_material())
+    }
+}
+
+#[cfg(feature = "backend-sqlite")]
+async fn load_existing_sqlite(
+    pool: &sqlx::SqlitePool,
+    cfg: &KekBootConfig,
+    kid: String,
+    method: String,
+    blob: Vec<u8>,
+) -> anyhow::Result<KekHandle> {
+    match method.as_str() {
+        METHOD_SEALED_V1 => {
+            let material = cfg
+                .material
+                .as_ref()
+                .ok_or_else(fail_closed_no_material)?;
+            let key = unseal_kek(&blob, &kid, material)
+                .with_context(|| format!("unseal KEK kid={kid}"))?;
+            tracing::info!(target: "assay-vault", kid = %kid, "KEK unsealed at boot");
+            Ok(KekHandle::from_bytes(kid, key))
+        }
+        METHOD_PLAINTEXT => {
+            let key = parse_plaintext_blob(&method, &blob)
+                .with_context(|| format!("unwrap plaintext KEK kid={kid}"))?;
+            if let Some(material) = &cfg.material {
+                let sealed_blob =
+                    seal_kek(&key, &kid, material).context("seal KEK during plaintext migration")?;
+                sqlx::query(
+                    "UPDATE vault.kek_metadata
+                        SET sealing_method = ?, sealed = 1, sealed_blob = ?, sealed_at = ?
+                      WHERE kid = ?",
+                )
+                .bind(METHOD_SEALED_V1)
+                .bind(sealed_blob.as_slice())
+                .bind(unix_now())
+                .bind(&kid)
+                .execute(pool)
+                .await
+                .context("re-seal plaintext KEK row")?;
+                tracing::warn!(
+                    target: "assay-vault",
+                    kid = %kid,
+                    "MIGRATED plaintext KEK to sealed-v1 at rest. The plaintext blob has been \
+                     overwritten with the sealed blob. Keep your unseal key safe — it is now \
+                     required to boot."
+                );
+                Ok(KekHandle::from_bytes(kid, key))
+            } else if cfg.dev_plaintext {
+                warn_dev_plaintext(&kid);
+                Ok(KekHandle::from_bytes(kid, key))
+            } else {
+                Err(anyhow::anyhow!(
+                    "vault.kek_metadata holds a PLAINTEXT master KEK (kid={kid}) but no unseal \
+                     material is configured to migrate it. Set `vault.unseal_key_source` (e.g. \
+                     `env:ASSAY_VAULT_UNSEAL_KEY`) + export a base64 32-byte key, then reboot — \
+                     the engine will automatically re-seal the existing KEK in place. Refusing to \
+                     boot with an unsealed KEK."
+                ))
+            }
+        }
+        other => Err(anyhow::anyhow!(
+            "vault.kek_metadata.sealing_method = '{other}' (kid={kid}) is not handled by the \
+             boot loader. Shamir / KMS rows are unsealed via the /sys/unseal ceremony, not the \
+             boot path."
+        )),
+    }
+}
+
+#[cfg(feature = "backend-sqlite")]
+async fn seed_plaintext_sqlite(
+    pool: &sqlx::SqlitePool,
+    kid: &str,
+    key: &[u8; KEY_LEN],
+    now: f64,
+) -> anyhow::Result<()> {
     sqlx::query(
         "INSERT INTO vault.kek_metadata
             (kid, sealing_method, sealed, sealed_blob, sealed_at, unsealed_at, created_at)
          VALUES (?, ?, 0, ?, NULL, ?, ?)",
     )
-    .bind(handle.kid())
+    .bind(kid)
     .bind(METHOD_PLAINTEXT)
     .bind(key.as_slice())
     .bind(now)
     .bind(now)
     .execute(pool)
     .await
-    .context("seed vault.kek_metadata")?;
-    warn_first_boot_plaintext(handle.kid());
-    Ok(handle)
+    .context("seed plaintext vault.kek_metadata (dev mode)")?;
+    Ok(())
+}
+
+#[cfg(any(feature = "backend-postgres", feature = "backend-sqlite"))]
+fn unix_now() -> f64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs_f64()
 }
 
 fn parse_plaintext_blob(method: &str, blob: &[u8]) -> anyhow::Result<[u8; KEY_LEN]> {
@@ -403,12 +675,16 @@ fn warn_if_plaintext(kid: &str, method: &str) {
     }
 }
 
-fn warn_first_boot_plaintext(kid: &str) {
-    tracing::warn!(
+/// Loud warning for the dev-only plaintext escape hatch. Emitted at
+/// ERROR level (the loudest `tracing` carries) and prefixed `CRITICAL`
+/// so it is impossible to miss in logs — the KEK is unsealed on disk.
+fn warn_dev_plaintext(kid: &str) {
+    tracing::error!(
         target: "assay-vault",
         kid,
-        "first-boot plaintext KEK persisted. Phase 1 placeholder; rotate to a real sealing method as \
-         Phase 2 lands."
+        "CRITICAL: vault.dev_plaintext_kek is ENABLED — the master KEK is persisted in PLAINTEXT \
+         at rest. A DB read decrypts every secret. This is for local demos ONLY. Do NOT use for \
+         real secrets. Set `vault.unseal_key_source` to seal the KEK."
     );
 }
 
@@ -462,18 +738,141 @@ mod tests {
         pool
     }
 
+    fn raw_cfg() -> KekBootConfig {
+        let key = crate::crypto::aead::random_dek();
+        let b64 = data_encoding::BASE64.encode(&key);
+        KekBootConfig::sealed(UnsealMaterial::raw_key_from_base64(&b64).unwrap())
+    }
+
+    async fn sealing_method(pool: &sqlx::SqlitePool) -> String {
+        let (m,): (String,) =
+            sqlx::query_as("SELECT sealing_method FROM vault.kek_metadata LIMIT 1")
+                .fetch_one(pool)
+                .await
+                .unwrap();
+        m
+    }
+
+    async fn stored_blob(pool: &sqlx::SqlitePool) -> Vec<u8> {
+        let (b,): (Vec<u8>,) =
+            sqlx::query_as("SELECT sealed_blob FROM vault.kek_metadata LIMIT 1")
+                .fetch_one(pool)
+                .await
+                .unwrap();
+        b
+    }
+
     #[tokio::test]
-    async fn first_boot_seeds_kek() {
+    async fn first_boot_seals_kek_and_round_trips() {
         let pool = boot_pool().await;
-        let h1 = load_or_init_sqlite(&pool).await.unwrap();
-        let h2 = load_or_init_sqlite(&pool).await.unwrap();
-        // Same kid both times — second call loads, doesn't re-seed.
+        let cfg = raw_cfg();
+        let h1 = load_or_init_sqlite(&pool, &cfg).await.unwrap();
+        // Reboot loads + unseals the same KEK without re-seeding.
+        let h2 = load_or_init_sqlite(&pool, &cfg).await.unwrap();
         assert_eq!(h1.kid(), h2.kid());
         let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM vault.kek_metadata")
             .fetch_one(&pool)
             .await
             .unwrap();
         assert_eq!(count.0, 1, "second load must not insert a new row");
+        assert_eq!(sealing_method(&pool).await, METHOD_SEALED_V1);
+        // The raw KEK bytes never appear in the at-rest blob.
+        let key = h1.unwrap_dek(&h1.wrap_dek(&[5u8; KEY_LEN]).unwrap()).unwrap();
+        assert_eq!(key, [5u8; KEY_LEN]); // handle works
+        assert_eq!(stored_blob(&pool).await[0], 1, "blob version tag = 1");
+    }
+
+    #[tokio::test]
+    async fn first_boot_without_material_fails_closed() {
+        let pool = boot_pool().await;
+        let res = load_or_init_sqlite(&pool, &KekBootConfig::unset()).await;
+        assert!(res.is_err(), "no unseal material must fail closed");
+        let count: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM vault.kek_metadata")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(count.0, 0, "fail-closed boot must not persist any KEK row");
+    }
+
+    #[tokio::test]
+    async fn wrong_unseal_key_fails() {
+        let pool = boot_pool().await;
+        // Seal under one key…
+        let _ = load_or_init_sqlite(&pool, &raw_cfg()).await.unwrap();
+        // …then boot with a different key → AEAD tag fails.
+        let res = load_or_init_sqlite(&pool, &raw_cfg()).await;
+        assert!(res.is_err(), "wrong unseal key must fail the auth tag");
+    }
+
+    #[tokio::test]
+    async fn plaintext_row_migrates_to_sealed() {
+        let pool = boot_pool().await;
+        // Seed a legacy plaintext KEK directly.
+        let key = crate::crypto::aead::random_dek();
+        let kid = content_addressed_kid(&key);
+        sqlx::query(
+            "INSERT INTO vault.kek_metadata
+                (kid, sealing_method, sealed, sealed_blob, created_at)
+             VALUES (?, 'plaintext', 0, ?, 0.0)",
+        )
+        .bind(&kid)
+        .bind(key.as_slice())
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let cfg = raw_cfg();
+        let h = load_or_init_sqlite(&pool, &cfg).await.unwrap();
+        assert_eq!(h.kid(), kid, "migration must preserve the KEK identity");
+        // Row is now sealed-v1, and the plaintext key is gone from disk.
+        assert_eq!(sealing_method(&pool).await, METHOD_SEALED_V1);
+        let blob = stored_blob(&pool).await;
+        assert_ne!(blob.as_slice(), key.as_slice(), "plaintext must be overwritten");
+        // Re-boot unseals the migrated row to the same KEK.
+        let h2 = load_or_init_sqlite(&pool, &cfg).await.unwrap();
+        assert_eq!(h2.kid(), kid);
+    }
+
+    #[tokio::test]
+    async fn plaintext_row_without_material_fails_closed() {
+        let pool = boot_pool().await;
+        let key = crate::crypto::aead::random_dek();
+        let kid = content_addressed_kid(&key);
+        sqlx::query(
+            "INSERT INTO vault.kek_metadata
+                (kid, sealing_method, sealed, sealed_blob, created_at)
+             VALUES (?, 'plaintext', 0, ?, 0.0)",
+        )
+        .bind(&kid)
+        .bind(key.as_slice())
+        .execute(&pool)
+        .await
+        .unwrap();
+        let res = load_or_init_sqlite(&pool, &KekBootConfig::unset()).await;
+        assert!(res.is_err(), "plaintext row + no material must fail closed");
+        // Row is untouched (still plaintext) — no silent destruction.
+        assert_eq!(sealing_method(&pool).await, METHOD_PLAINTEXT);
+    }
+
+    #[tokio::test]
+    async fn dev_plaintext_opt_in_still_works() {
+        let pool = boot_pool().await;
+        let cfg = KekBootConfig::dev_plaintext();
+        let h1 = load_or_init_sqlite(&pool, &cfg).await.unwrap();
+        assert_eq!(sealing_method(&pool).await, METHOD_PLAINTEXT);
+        // Reboot in dev mode loads the same plaintext KEK.
+        let h2 = load_or_init_sqlite(&pool, &cfg).await.unwrap();
+        assert_eq!(h1.kid(), h2.kid());
+    }
+
+    #[tokio::test]
+    async fn passphrase_seal_round_trips_across_boot() {
+        let pool = boot_pool().await;
+        let cfg = || KekBootConfig::sealed(UnsealMaterial::passphrase("a strong passphrase").unwrap());
+        let h1 = load_or_init_sqlite(&pool, &cfg()).await.unwrap();
+        let h2 = load_or_init_sqlite(&pool, &cfg()).await.unwrap();
+        assert_eq!(h1.kid(), h2.kid());
+        assert_eq!(sealing_method(&pool).await, METHOD_SEALED_V1);
     }
 
     #[tokio::test]
@@ -487,24 +886,10 @@ mod tests {
         .execute(&pool)
         .await
         .unwrap();
-        let res = load_or_init_sqlite(&pool).await;
+        let res = load_or_init_sqlite(&pool, &raw_cfg()).await;
         assert!(
             res.is_err(),
-            "non-plaintext sealing must be rejected in Phase 1"
+            "unhandled sealing method must be rejected at the boot loader"
         );
-    }
-
-    #[tokio::test]
-    async fn rejects_truncated_plaintext_blob() {
-        let pool = boot_pool().await;
-        sqlx::query(
-            "INSERT INTO vault.kek_metadata
-                (kid, sealing_method, sealed, sealed_blob, created_at)
-             VALUES ('kek-y', 'plaintext', 0, x'beef', 0.0)",
-        )
-        .execute(&pool)
-        .await
-        .unwrap();
-        assert!(load_or_init_sqlite(&pool).await.is_err());
     }
 }

--- a/crates/assay-vault/src/crypto/kek_store.rs
+++ b/crates/assay-vault/src/crypto/kek_store.rs
@@ -14,9 +14,11 @@
 //!   Wrong material fails the AEAD tag → boot fails closed.
 //! - **Boot without unseal material** — fail closed with an actionable
 //!   error telling the operator how to set the unseal key + migrate.
-//! - **Existing plaintext row found** — if unseal material is present,
-//!   automatically re-seal it in place (one-way upgrade) and log the
-//!   migration. If not, fail closed with migration instructions.
+//! - **Existing plaintext row found + material present + `allow_plaintext_migration = true`** —
+//!   automatically re-seal it in place (irreversible one-way upgrade) and log
+//!   the migration. Material present but flag unset → fail closed with
+//!   instructions to back up the DB and set the flag. No material → fail
+//!   closed with migration instructions.
 //! - **Dev escape hatch** — `dev_plaintext_kek = true` keeps the old
 //!   plaintext behavior for demo flows, behind a loud CRITICAL warning.
 //!   Never the default.
@@ -47,14 +49,38 @@ pub struct KekBootConfig {
     pub material: Option<UnsealMaterial>,
     /// Explicit opt-in to the plaintext escape hatch. Logs CRITICAL.
     pub dev_plaintext: bool,
+    /// Gate for the irreversible plaintext→sealed-v1 auto-migration.
+    ///
+    /// When a `plaintext` row is found and unseal material is present,
+    /// the engine will **not** overwrite the row unless this flag is
+    /// `true`. Default is `false`. Set via
+    /// `vault.allow_plaintext_migration = true` in `engine.toml`.
+    ///
+    /// The gate exists because the migration is **one-way and
+    /// destructive**: the raw KEK bytes in `sealed_blob` are
+    /// overwritten with the sealed blob. Operators MUST back up the
+    /// database before enabling this flag.
+    pub allow_plaintext_migration: bool,
 }
 
 impl KekBootConfig {
     /// Sealed boot with concrete unseal material (the production path).
+    /// `allow_plaintext_migration` defaults to `false` — operator must
+    /// explicitly set it to trigger the one-way migration.
     pub fn sealed(material: UnsealMaterial) -> Self {
         Self {
             material: Some(material),
             dev_plaintext: false,
+            allow_plaintext_migration: false,
+        }
+    }
+
+    /// Like [`Self::sealed`] but with `allow_plaintext_migration = true`.
+    pub fn sealed_allow_migration(material: UnsealMaterial) -> Self {
+        Self {
+            material: Some(material),
+            dev_plaintext: false,
+            allow_plaintext_migration: true,
         }
     }
 
@@ -63,6 +89,7 @@ impl KekBootConfig {
         Self {
             material: None,
             dev_plaintext: true,
+            allow_plaintext_migration: false,
         }
     }
 
@@ -71,6 +98,7 @@ impl KekBootConfig {
         Self {
             material: None,
             dev_plaintext: false,
+            allow_plaintext_migration: false,
         }
     }
 }
@@ -189,6 +217,16 @@ async fn load_existing_pg(
             let key = parse_plaintext_blob(&method, &blob)
                 .with_context(|| format!("unwrap plaintext KEK kid={kid}"))?;
             if let Some(material) = &cfg.material {
+                if !cfg.allow_plaintext_migration {
+                    return Err(anyhow::anyhow!(
+                        "vault.kek_metadata holds a PLAINTEXT master KEK (kid={kid}) and unseal \
+                         material is configured, but `vault.allow_plaintext_migration` is not set. \
+                         This migration is IRREVERSIBLE — the plaintext blob will be overwritten \
+                         with the sealed blob and cannot be undone. Back up the database first, \
+                         then set `vault.allow_plaintext_migration = true` in engine.toml and \
+                         reboot to perform the one-way migration."
+                    ));
+                }
                 // ── One-way migration: re-seal the plaintext KEK ──
                 let sealed_blob =
                     seal_kek(&key, &kid, material).context("seal KEK during plaintext migration")?;
@@ -327,6 +365,16 @@ async fn load_existing_sqlite(
             let key = parse_plaintext_blob(&method, &blob)
                 .with_context(|| format!("unwrap plaintext KEK kid={kid}"))?;
             if let Some(material) = &cfg.material {
+                if !cfg.allow_plaintext_migration {
+                    return Err(anyhow::anyhow!(
+                        "vault.kek_metadata holds a PLAINTEXT master KEK (kid={kid}) and unseal \
+                         material is configured, but `vault.allow_plaintext_migration` is not set. \
+                         This migration is IRREVERSIBLE — the plaintext blob will be overwritten \
+                         with the sealed blob and cannot be undone. Back up the database first, \
+                         then set `vault.allow_plaintext_migration = true` in engine.toml and \
+                         reboot to perform the one-way migration."
+                    ));
+                }
                 let sealed_blob =
                     seal_kek(&key, &kid, material).context("seal KEK during plaintext migration")?;
                 sqlx::query(
@@ -804,6 +852,12 @@ mod tests {
         assert!(res.is_err(), "wrong unseal key must fail the auth tag");
     }
 
+    fn raw_cfg_allow_migration() -> KekBootConfig {
+        let key = crate::crypto::aead::random_dek();
+        let b64 = data_encoding::BASE64.encode(&key);
+        KekBootConfig::sealed_allow_migration(UnsealMaterial::raw_key_from_base64(&b64).unwrap())
+    }
+
     #[tokio::test]
     async fn plaintext_row_migrates_to_sealed() {
         let pool = boot_pool().await;
@@ -821,7 +875,8 @@ mod tests {
         .await
         .unwrap();
 
-        let cfg = raw_cfg();
+        // allow_plaintext_migration = true → migration proceeds.
+        let cfg = raw_cfg_allow_migration();
         let h = load_or_init_sqlite(&pool, &cfg).await.unwrap();
         assert_eq!(h.kid(), kid, "migration must preserve the KEK identity");
         // Row is now sealed-v1, and the plaintext key is gone from disk.
@@ -831,6 +886,49 @@ mod tests {
         // Re-boot unseals the migrated row to the same KEK.
         let h2 = load_or_init_sqlite(&pool, &cfg).await.unwrap();
         assert_eq!(h2.kid(), kid);
+    }
+
+    #[tokio::test]
+    async fn plaintext_row_with_material_but_flag_unset_fails_closed() {
+        let pool = boot_pool().await;
+        // Seed a legacy plaintext KEK.
+        let key = crate::crypto::aead::random_dek();
+        let kid = content_addressed_kid(&key);
+        sqlx::query(
+            "INSERT INTO vault.kek_metadata
+                (kid, sealing_method, sealed, sealed_blob, created_at)
+             VALUES (?, 'plaintext', 0, ?, 0.0)",
+        )
+        .bind(&kid)
+        .bind(key.as_slice())
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        // Material IS configured but allow_plaintext_migration = false (default).
+        let cfg = raw_cfg(); // sealed(), allow_plaintext_migration = false
+        let res = load_or_init_sqlite(&pool, &cfg).await;
+        assert!(
+            res.is_err(),
+            "plaintext row + material + flag unset must fail closed"
+        );
+        let msg = res.unwrap_err().to_string();
+        assert!(
+            msg.contains("allow_plaintext_migration"),
+            "error must mention the flag; got: {msg}"
+        );
+        // Row must be untouched — still plaintext, blob unchanged.
+        assert_eq!(
+            sealing_method(&pool).await,
+            METHOD_PLAINTEXT,
+            "row must not be mutated when migration is gated"
+        );
+        let stored = stored_blob(&pool).await;
+        assert_eq!(
+            stored.as_slice(),
+            key.as_slice(),
+            "plaintext blob must be untouched"
+        );
     }
 
     #[tokio::test]

--- a/crates/assay-vault/src/crypto/mod.rs
+++ b/crates/assay-vault/src/crypto/mod.rs
@@ -13,6 +13,7 @@
 
 pub mod aead;
 pub mod kek;
+pub mod kek_seal;
 pub mod seal_state;
 pub mod sealing;
 
@@ -24,5 +25,6 @@ pub mod kek_store;
 
 pub use aead::{NONCE_LEN, decrypt, encrypt, random_dek, random_nonce};
 pub use kek::KekHandle;
+pub use kek_seal::{METHOD_SEALED_V1, UnsealMaterial, UnsealSource, seal_kek, unseal_kek};
 pub use seal_state::{SealState, SealStatus};
 pub use sealing::{KmsSeal, SealStore, SealingMethod};

--- a/crates/assay-vault/src/crypto/sealing.rs
+++ b/crates/assay-vault/src/crypto/sealing.rs
@@ -29,6 +29,11 @@ use crate::error::{Result, VaultError};
 pub enum SealingMethod {
     /// Phase-1 placeholder. Blob IS the raw 32 bytes. WARN-logged.
     Plaintext,
+    /// KEK sealed at rest under operator-supplied unseal material
+    /// (#113) — env-var/file base64 key or Argon2id passphrase. The
+    /// KEK is unsealed into memory at boot; the runtime is operational
+    /// (not gated on an unseal ceremony like Shamir).
+    SealedV1,
     /// Shamir Secret Sharing — KEK split into N shares; threshold K
     /// shares reconstruct on unseal. Phase 2 default for non-cloud.
     Shamir { threshold: u8, shares_count: u8 },
@@ -49,6 +54,7 @@ impl SealingMethod {
     pub fn as_column(&self) -> &'static str {
         match self {
             Self::Plaintext => "plaintext",
+            Self::SealedV1 => "sealed-v1",
             Self::Shamir { .. } => "shamir",
             Self::KmsAws { .. } => "kms-aws",
             Self::KmsGcp { .. } => "kms-gcp",
@@ -58,6 +64,7 @@ impl SealingMethod {
     pub fn parse(s: &str) -> Result<Self> {
         match s {
             "plaintext" => Ok(Self::Plaintext),
+            "sealed-v1" => Ok(Self::SealedV1),
             // Shamir + KMS variants need their parameters from
             // surrounding columns (share_threshold, share_count, KMS
             // config from engine.toml). The store layer hands the

--- a/crates/assay-vault/src/ctx.rs
+++ b/crates/assay-vault/src/ctx.rs
@@ -131,6 +131,20 @@ impl VaultCtx {
         self
     }
 
+    /// Like [`Self::with_kek`] but records the runtime seal method as
+    /// `sealed-v1` (#113) — the KEK was unsealed from an at-rest sealed
+    /// blob at boot. Functionally identical to `with_kek` (the KEK is
+    /// live in memory and the vault is operational); only the reported
+    /// `seal-status.method` differs, so operators can confirm the KEK is
+    /// sealed at rest rather than plaintext.
+    pub fn with_kek_sealed(mut self, kek: KekHandle) -> Self {
+        let seal_state =
+            SealState::unsealed(SealingMethod::SealedV1, kek.kid().to_string(), kek.clone());
+        self.kek = kek;
+        self.seal_state = seal_state;
+        self
+    }
+
     /// Phase-2 builder: vault starts sealed; operator must submit
     /// shares via `/sys/unseal` to bring it up. The KEK held on the
     /// ctx is a placeholder until then — handlers must check

--- a/docs/migration-to-vault-0.5.0.md
+++ b/docs/migration-to-vault-0.5.0.md
@@ -52,15 +52,32 @@ which means every wrapped secret is unrecoverable.
 If `vault.kek_metadata` already holds a `plaintext` KEK from a pre-0.5.0
 deployment:
 
-1. Set `unseal_key_source` and export the key (as above).
-2. Reboot. The engine **automatically re-seals the existing KEK in place**
-   (one-way upgrade): the row flips to `sealing_method = 'sealed-v1'`, the
-   plaintext blob is overwritten with the sealed blob, and a `MIGRATED ...` line
-   is logged. Your existing wrapped DEKs keep working — the KEK identity (`kid`)
-   is preserved.
+1. **Back up the database first.** The migration is one-way and irreversible —
+   the plaintext blob is overwritten with the sealed blob and cannot be undone.
+2. Set `unseal_key_source` and export the key (as above).
+3. Set `allow_plaintext_migration = true` to explicitly authorise the one-way
+   rewrite:
 
-If you reboot **without** setting `unseal_key_source`, the engine refuses to
-boot (fail-closed) and prints migration instructions. No data is touched.
+```toml
+[vault]
+unseal_key_source = "env:ASSAY_VAULT_UNSEAL_KEY"
+allow_plaintext_migration = true   # remove after migration completes
+```
+
+4. Reboot. The engine **re-seals the existing KEK in place**: the row flips to
+   `sealing_method = 'sealed-v1'`, the plaintext blob is overwritten with the
+   sealed blob, and a `MIGRATED ...` warning is logged. Your existing wrapped
+   DEKs keep working — the KEK identity (`kid`) is preserved.
+5. **Remove `allow_plaintext_migration = true`** from `engine.toml` once you
+   have confirmed the migration logged successfully. The flag is not needed
+   after a fresh `sealed-v1` row exists.
+
+If you reboot with `unseal_key_source` set but **without** `allow_plaintext_migration`,
+the engine refuses to boot (fail-closed) and prints instructions. No data is
+touched.
+
+If you reboot **without** `unseal_key_source` at all, the engine also refuses to
+boot (fail-closed). No data is touched.
 
 ## Dev / demo escape hatch
 

--- a/docs/migration-to-vault-0.5.0.md
+++ b/docs/migration-to-vault-0.5.0.md
@@ -1,0 +1,82 @@
+# Migrating to assay-vault 0.5.0 — KEK sealed at rest (#113)
+
+**Breaking change for anyone running the vault module.** Before 0.5.0 the
+vault's master key-encryption-key (KEK) was persisted in **plaintext** in
+`vault.kek_metadata.sealed_blob` and auto-seeded on first boot. A single DB
+read decrypted every secret. 0.5.0 closes that: the KEK is **sealed at rest**
+under operator-supplied unseal material, and the engine **fails closed** rather
+than boot with an unsealed KEK.
+
+Read this if `engine.modules.vault` is enabled (it is by default when the
+`vault` Cargo feature is compiled in).
+
+## What changed
+
+- `vault.kek_metadata` rows now use `sealing_method = 'sealed-v1'`. The
+  `sealed_blob` is the KEK encrypted with AES-256-GCM-SIV under a wrapping key
+  derived from your unseal material. Format:
+  `version(1) | kdf(1) | salt_len(1) | salt | nonce(12) | ciphertext(48)`.
+- Boot **requires** unseal material. No silent plaintext fallback.
+- The runtime `seal-status` now reports `method = "sealed-v1"` (was
+  `"plaintext"`). The vault is still unsealed-and-operational at boot — the KEK
+  is unsealed into memory; it is NOT gated on an unseal ceremony like Shamir.
+
+## What you must do
+
+Provide unseal material via the new `[vault]` config section. Pick one:
+
+```toml
+[vault]
+# Recommended: a base64-encoded 32-byte key from an env var.
+unseal_key_source = "env:ASSAY_VAULT_UNSEAL_KEY"
+```
+
+```sh
+export ASSAY_VAULT_UNSEAL_KEY=$(openssl rand -base64 32)
+```
+
+Other sources:
+
+| `unseal_key_source`              | Meaning                                                |
+| -------------------------------- | ------------------------------------------------------ |
+| `env:NAME`                       | base64 32-byte key (or `passphrase:<text>`) from `$NAME` |
+| `file:/path`                     | same, read from a file that **must be `0600`**         |
+| `base64:BBBB`                    | inline base64 raw key (dev/test)                       |
+| `passphrase:TEXT`                | inline passphrase (Argon2id m=64MiB/t=3/p=4)           |
+
+**Store the unseal key safely and durably.** Losing it means losing the KEK,
+which means every wrapped secret is unrecoverable.
+
+## Migrating an existing plaintext KEK
+
+If `vault.kek_metadata` already holds a `plaintext` KEK from a pre-0.5.0
+deployment:
+
+1. Set `unseal_key_source` and export the key (as above).
+2. Reboot. The engine **automatically re-seals the existing KEK in place**
+   (one-way upgrade): the row flips to `sealing_method = 'sealed-v1'`, the
+   plaintext blob is overwritten with the sealed blob, and a `MIGRATED ...` line
+   is logged. Your existing wrapped DEKs keep working — the KEK identity (`kid`)
+   is preserved.
+
+If you reboot **without** setting `unseal_key_source`, the engine refuses to
+boot (fail-closed) and prints migration instructions. No data is touched.
+
+## Dev / demo escape hatch
+
+For local demos where sealing is overkill, you can keep the old plaintext
+behavior explicitly:
+
+```toml
+[vault]
+dev_plaintext_kek = true
+```
+
+This logs a **CRITICAL** warning on every boot and persists the KEK in
+plaintext. Never use it for real secrets.
+
+## Future-proofing
+
+The sealed blob carries a version tag (`sealed-v1`). The planned Shamir / cloud
+KMS / HSM phases ship as new `sealing_method` values + new blob versions; an old
+binary refuses a row it can't interpret instead of mis-parsing it.


### PR DESCRIPTION
## Security fix (CRITICAL) — closes #113

The vault KEK was persisted in **plaintext** next to the data it encrypts (`kek_store.rs`), auto-seeded on first boot — a DB read decrypted every secret. The boot log even self-confessed: `WARN first-boot plaintext KEK persisted. Phase 1 placeholder`.

## Design

- New `kek_seal.rs`: KEK sealed in a versioned `sealed-v1` blob (`version|kdf|salt_len|salt|nonce|ciphertext`) using the vault's existing AES-256-GCM-SIV, with the KEK `kid` bound into the AEAD AAD (kid spoofing fails the tag). Version byte gates future KMS/HSM phases.
- Unseal material via `[vault] unseal_key_source`: `env:NAME` / `file:/path` (0600-enforced on unix; loud warn on non-unix) / `base64:` (raw 32-byte key) / `passphrase:` (Argon2id m=64MiB/t=3/p=4 — same envelope as assay-auth passwords).
- First boot with material → random KEK generated, sealed, only the sealed blob persisted. Boot without material → **fail closed** with copy-pasteable remediation. No silent plaintext fallback anywhere.
- Legacy plaintext rows: re-sealed in place, but only behind explicit `vault.allow_plaintext_migration = true` (default false) — without the flag, boot fails closed with "back up the DB first (IRREVERSIBLE)" instructions. Migration preserves `kid` so existing wrapped DEKs keep unwrapping.
- Dev hatch `vault.dev_plaintext_kek = true` (config-only, never default, no env shortcut) logs at ERROR. Deployments with no `[vault]` section are untouched (vault ctx short-circuits before KEK resolution).
- Zeroize discipline: `Zeroizing` on all unseal material + derived wrapping keys; `KekInner` now zeroizes on drop; redacting `Debug` impls; no log can print key material.

## Verification

- `cargo test -p assay-vault -p assay-engine`: 102 vault + 20 engine tests, 0 failed — boot matrix fully covered (first-boot seal, reboot, wrong-key tag failure, migration, flag-unset fail-closed with row-untouched assertion, no-material fail-closed, dev hatch, passphrase path, unknown method).
- `cargo clippy -p assay-vault --no-deps -- -D warnings`: clean.
- Independent security review (separate lane): all five fail-closed paths confirmed; nonce/salt/blob-parsing/AAD verified; no-`[vault]` boot verified unaffected. Review's MEDIUM findings (migration confirmation gate, KekInner zeroize) addressed in the follow-up commit.

## Breaking change / migration

assay-vault 0.4.1→0.5.0, assay-engine 0.5.2→0.6.0. Existing vault deployments: set `unseal_key_source`, back up the DB, set `allow_plaintext_migration = true`, boot (one-way re-seal), remove the flag. Full procedure in `docs/migration-to-vault-0.5.0.md` + commented blocks in both example configs.

## Follow-ups

- Postgres testcontainer test for the KEK store path (SQLite suite covers the boot matrix; PG SQL compile-verified, mirrors SQLite).
- Operator-tunable Argon2id params (blob already version-tags the KDF, so forward-compatible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)