### PR TITLE
chore(release): assay-vault 0.4.2 — rebuild against assay-auth 0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to Assay are documented here.
 
+## assay-vault 0.4.2 — 2026-06-28
+
+### Changed
+
+- Rebuild against `assay-auth 0.6` (no code change). assay-auth's 0.6.0 major bump means the
+  previously-published assay-vault 0.4.1 (which pinned `assay-auth 0.5`) would pull a second
+  `assay-auth` into the crates.io dependency graph when `assay-engine` is published, breaking the
+  `cargo publish --verify` build (`FromRef` resolves across two `assay_auth` versions). Bumping
+  assay-vault so it republishes with the `assay-auth 0.6` requirement keeps a single `assay-auth` in
+  the graph.
+
 ## assay-engine 0.5.3 — 2026-06-28
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,7 +393,7 @@ dependencies = [
 
 [[package]]
 name = "assay-vault"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "aes-gcm-siv",
  "anyhow",

--- a/crates/assay-vault/Cargo.toml
+++ b/crates/assay-vault/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-vault"
-version = "0.4.1"
+version = "0.4.2"
 categories = ["cryptography", "asynchronous", "database"]
 edition = "2024"
 keywords = ["vault", "secrets", "kv", "transit", "biscuit"]


### PR DESCRIPTION
## Why

The `assay-engine v0.5.3` release (#173, the OIDC JWKS-rotation fix) FAILED at the
`release-assay-engine → Publish assay-engine to crates.io` step:

```
Compiling assay-auth v0.5.1
Compiling assay-auth v0.6.0
error[E0277]: the trait bound `assay_auth::ctx::AuthCtx: FromRef<EngineState<S>>` is not satisfied
  = note: there are multiple different versions of crate `assay_auth` in the dependency graph
```

#173 bumped `assay-auth` 0.5.1 → 0.6.0 (a real SemVer break — `OidcClient` lost
`UnwindSafe`/`RefUnwindSafe`). The `libraries` job published assay-auth 0.6.0, but the
already-published **assay-vault 0.4.1 still pins `assay-auth 0.5`**, so when CI ran
`cargo publish --verify` for assay-engine it resolved BOTH assay-auth 0.5.1 (via vault) and
0.6.0 (direct) → `FromRef` across two `assay_auth` versions → verify build failed → the engine
was never published and the GitHub release `assay-engine-v0.5.3` was never created.

## Fix

Bump `assay-vault` 0.4.1 → 0.4.2 (its `assay-auth` dep requirement is already `"0.6"` on main
from #173; **no code change**). On the next release the `libraries` job republishes assay-vault
0.4.2 against assay-auth 0.6, leaving a single `assay_auth` in the graph, so assay-engine 0.5.3
verifies + publishes cleanly.

## Verification

`cargo check -p assay-vault -p assay-engine` clean (assay-auth 0.6.0 / assay-vault 0.4.2 /
assay-engine 0.5.3); fmt + dprint clean. Merging re-triggers the Release workflow to publish
assay-vault 0.4.2 then assay-engine 0.5.3 (+ the `assay-engine-linux-x86_64` GitHub artifact the
gondor deploy consumes).