### PR TITLE
feat(assay): read-only execution mode (--readonly / ASSAY_READONLY)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to Assay are documented here.
 
+## assay 0.16.9 — 2026-07-05
+
+### Added
+
+- Read-only execution mode for semi-trusted script contexts (agent-generated scripts, review
+  pipelines, dry-run diagnostics). Activate with the global `--readonly` CLI flag (works for `run`,
+  `exec`, YAML check mode, and tool mode) or `ASSAY_READONLY=1`/`true`. Mutating builtins stay
+  registered but raise `readonly: <name> blocked` errors (suffixed with "write operations are
+  disabled in read-only mode") instead of executing: HTTP write verbs
+  (`http.post/put/patch/delete/serve/download`, including `http.client(...)` wrappers),
+  `ws.connect`, all of `shell.*`, `process.*`, and `machinectl.*`, `fs` write ops (`write`,
+  `write_bytes`, `remove`, `rename`, `copy`, `chmod`, `mkdir`, `tempdir`, `sub_in_file`), `env.set`,
+  `db.execute`, `oci` mutators, `systemd` unit and machine lifecycle actions, `apt` mutators,
+  `tar.create`/`tar.extract`/`compress.untar`, and the Lua stdlib write paths (`io.popen`, `io.open`
+  write modes, `io.output(target)`). Read paths (`http.get`, `fs.read`, `env.get`, `db.query`,
+  `systemd.list_units`, journal/status/list helpers) work unchanged. `assay modules` notes when the
+  mode is active, and tool-mode JSON envelopes carry `"readonly": true` (omitted when off).
+
 ## assay-vault 0.4.2 — 2026-06-28
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,7 +338,7 @@ dependencies = [
 
 [[package]]
 name = "assay-lua"
-version = "0.16.8"
+version = "0.16.9"
 dependencies = [
  "anyhow",
  "axum",

--- a/README.md
+++ b/README.md
@@ -105,6 +105,33 @@ cargo install assay-lua      # the `assay` runtime binary
 cargo install assay-engine   # the workflow + auth server
 ```
 
+## Read-only mode
+
+For semi-trusted script contexts (agent-generated scripts, review pipelines, dry-run diagnostics),
+the runtime can execute scripts with every mutating builtin disabled. Activate with the global
+`--readonly` flag or `ASSAY_READONLY=1` (or `true`):
+
+```bash
+assay run --readonly script.lua        # also: exec, YAML check mode, tool mode
+ASSAY_READONLY=1 assay script.lua      # env activation, same effect
+```
+
+Read paths work unchanged: `http.get` (including `http.client(...)` wrappers), `fs.read` /
+`fs.list` / `fs.stat`, `env.get`, `db.query`, `systemd`/`apt` status and list helpers, and all
+pure builtins (`json`, `crypto`, `regex`, ...). Mutating builtins stay registered but raise a
+clear error instead of executing:
+
+```
+readonly: http.post blocked (write operations are disabled in read-only mode)
+```
+
+Blocked surfaces: HTTP write verbs + `http.serve` + `http.download`, `ws.connect`, all of
+`shell.*` / `process.*` / `machinectl.*`, `fs` write ops, `env.set`, `db.execute`, `oci`
+mutators, `systemd` unit/machine lifecycle actions, `apt` mutators, `tar.create` /
+`tar.extract` / `compress.untar`, `io.popen`, and `io.open` write modes. `assay modules` notes
+when the mode is active, and tool-mode envelopes carry `"readonly": true`. For nil-ing out
+additional globals entirely, combine with `ASSAY_BLOCK_GLOBALS`.
+
 ## Auth + IdP quick-start
 
 Once `assay-engine` is running with the auth module enabled, every IdP capability is reachable over

--- a/SKILL.md
+++ b/SKILL.md
@@ -46,6 +46,14 @@ assay modules
 | `assay context "<keyword>"` | Find modules matching keyword, shows quickref |
 | `assay modules`             | List all 65 modules (45 stdlib + 20 builtins) |
 
+**Read-only mode.** The global `--readonly` flag (or `ASSAY_READONLY=1`) disables every mutating
+builtin — HTTP write verbs, `shell.*`, `process.*`, `fs` writes, `env.set`, `db.execute`, and system
+mutators — while read paths (`http.get`, `fs.read`, `env.get`, `db.query`, status/list helpers) work
+unchanged. Blocked calls raise
+`readonly: <name> blocked (write operations are disabled in read-only mode)`; tool-mode envelopes
+carry `"readonly": true`. Use it to run untrusted or agent-generated scripts safely for inspection
+and diagnostics.
+
 ## Discovering Modules
 
 When you need to interact with a service, use `assay context` to find the right module:

--- a/crates/assay/Cargo.toml
+++ b/crates/assay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-lua"
-version = "0.16.8"
+version = "0.16.9"
 categories = ["command-line-utilities", "development-tools::testing"]
 edition = "2024"
 homepage = "https://assay.rs"

--- a/crates/assay/src/checks/mod.rs
+++ b/crates/assay/src/checks/mod.rs
@@ -6,14 +6,20 @@ use crate::config::CheckConfig;
 use crate::output::CheckResult;
 use std::time::Instant;
 
-pub async fn run_check(config: &CheckConfig, client: &reqwest::Client) -> CheckResult {
+pub async fn run_check(
+    config: &CheckConfig,
+    client: &reqwest::Client,
+    readonly: bool,
+) -> CheckResult {
     let start = Instant::now();
     let result = match config.check_type {
         crate::config::CheckType::Http => http::HttpCheck.execute(config, client).await,
         crate::config::CheckType::Prometheus => {
             prometheus::PrometheusCheck.execute(config, client).await
         }
-        crate::config::CheckType::Script => script::ScriptCheck.execute(config, client).await,
+        crate::config::CheckType::Script => {
+            script::ScriptCheck.execute(config, client, readonly).await
+        }
     };
 
     let duration_ms = start.elapsed().as_millis() as u64;

--- a/crates/assay/src/checks/script.rs
+++ b/crates/assay/src/checks/script.rs
@@ -10,6 +10,7 @@ impl ScriptCheck {
         &self,
         config: &CheckConfig,
         client: &reqwest::Client,
+        readonly: bool,
     ) -> Result<CheckResult> {
         let file_path = config
             .file
@@ -17,7 +18,8 @@ impl ScriptCheck {
             .context("script check requires a 'file' field")?;
 
         // Create a fresh Lua VM for each script check (isolation)
-        let vm = lua::create_vm(client.clone()).context("creating Lua VM")?;
+        let vm =
+            lua::create_vm_with_paths(client.clone(), None, readonly).context("creating Lua VM")?;
 
         // Inject check-specific environment variables
         lua::inject_env(&vm, &config.env)?;

--- a/crates/assay/src/checks/script.rs
+++ b/crates/assay/src/checks/script.rs
@@ -19,7 +19,7 @@ impl ScriptCheck {
 
         // Create a fresh Lua VM for each script check (isolation)
         let vm =
-            lua::create_vm_with_paths(client.clone(), None, readonly).context("creating Lua VM")?;
+            lua::create_vm_configured(client.clone(), None, readonly).context("creating Lua VM")?;
 
         // Inject check-specific environment variables
         lua::inject_env(&vm, &config.env)?;

--- a/crates/assay/src/lua/builtins/mod.rs
+++ b/crates/assay/src/lua/builtins/mod.rs
@@ -16,6 +16,7 @@ mod oci;
 mod os_info;
 mod process;
 mod process_pty;
+pub mod readonly;
 mod serialization;
 mod shell;
 mod systemd;

--- a/crates/assay/src/lua/builtins/readonly.rs
+++ b/crates/assay/src/lua/builtins/readonly.rs
@@ -1,0 +1,182 @@
+//! Read-only mode guards, applied after `register_all` when the VM is
+//! created with `readonly = true`. Mutating builtins stay registered
+//! but are replaced with stubs that raise
+//! `readonly: <name> blocked (write operations are disabled in read-only mode)`,
+//! so semi-trusted scripts fail with a clear error instead of a
+//! nil-index. Read paths (`http.get`, `fs.read`, `env.get`, `db.query`,
+//! `systemd.list_units`, …) are untouched.
+
+use mlua::{Lua, MultiValue, Table, Value};
+
+/// Tables whose entire function surface is blocked.
+const BLOCKED_TABLES: &[&str] = &["shell", "process", "machinectl"];
+
+/// Individual functions blocked inside otherwise-usable tables.
+const BLOCKED_FUNCTIONS: &[&str] = &[
+    "http.post",
+    "http.put",
+    "http.patch",
+    "http.delete",
+    "http.serve",
+    "http.serve_with_extra",
+    "http.download",
+    "ws.connect",
+    "fs.write",
+    "fs.write_bytes",
+    "fs.remove",
+    "fs.rename",
+    "fs.copy",
+    "fs.chmod",
+    "fs.mkdir",
+    "fs.tempdir",
+    "fs.sub_in_file",
+    "env.set",
+    "db.execute",
+    "oci.copy",
+    "oci.tag",
+    "oci.mutate",
+    "systemd.start",
+    "systemd.stop",
+    "systemd.restart",
+    "systemd.reload",
+    "systemd.unit_action",
+    "systemd.machine_start",
+    "systemd.machine_poweroff",
+    "systemd.machine_reboot",
+    "systemd.machine_terminate",
+    "systemd.machine_exec",
+    "apt.update",
+    "apt.install",
+    "apt.remove",
+    "apt.add_source",
+    "compress.untar",
+    "tar.create",
+    "tar.extract",
+    "io.popen",
+];
+
+pub fn apply(lua: &Lua) -> mlua::Result<()> {
+    for path in BLOCKED_FUNCTIONS {
+        block_function(lua, path)?;
+    }
+    for name in BLOCKED_TABLES {
+        block_table(lua, name)?;
+    }
+    guard_http_client_request(lua)?;
+    guard_io_open(lua)?;
+    guard_io_output(lua)?;
+    Ok(())
+}
+
+fn blocked(name: &str) -> mlua::Error {
+    mlua::Error::runtime(format!(
+        "readonly: {name} blocked (write operations are disabled in read-only mode)"
+    ))
+}
+
+fn blocked_stub(lua: &Lua, name: &str) -> mlua::Result<mlua::Function> {
+    let name = name.to_string();
+    lua.create_function(move |_, _args: MultiValue| -> mlua::Result<Value> { Err(blocked(&name)) })
+}
+
+/// Replace a single `table.fn` global with a blocking stub. Missing
+/// tables or functions (feature-gated builds) are skipped so the guard
+/// never changes the surface shape of the VM.
+fn block_function(lua: &Lua, path: &str) -> mlua::Result<()> {
+    let Some((table_name, fn_name)) = path.split_once('.') else {
+        return Ok(());
+    };
+    let Some(table) = lua.globals().get::<Option<Table>>(table_name)? else {
+        return Ok(());
+    };
+    if table.get::<Value>(fn_name)?.is_function() {
+        table.set(fn_name, blocked_stub(lua, path)?)?;
+    }
+    Ok(())
+}
+
+/// Replace every function in a global table with a blocking stub.
+fn block_table(lua: &Lua, name: &str) -> mlua::Result<()> {
+    let Some(table) = lua.globals().get::<Option<Table>>(name)? else {
+        return Ok(());
+    };
+    for pair in table.clone().pairs::<Value, Value>() {
+        let (key, value) = pair?;
+        if let (Value::String(key_str), true) = (&key, value.is_function()) {
+            let label = format!("{name}.{}", key_str.to_str()?);
+            table.set(key, blocked_stub(lua, &label)?)?;
+        }
+    }
+    Ok(())
+}
+
+/// `http.client(...)` wrappers route every verb through
+/// `http._client_request(ud, method, ...)`; blocking only the
+/// top-level `http.post` would leave that path open. The guard allows
+/// `get` through and raises for every other verb.
+fn guard_http_client_request(lua: &Lua) -> mlua::Result<()> {
+    let Some(http) = lua.globals().get::<Option<Table>>("http")? else {
+        return Ok(());
+    };
+    let Some(inner) = http.get::<Option<mlua::Function>>("_client_request")? else {
+        return Ok(());
+    };
+    let wrapper = lua.create_async_function(move |_, args: MultiValue| {
+        let inner = inner.clone();
+        async move {
+            let method = match args.iter().nth(1) {
+                Some(Value::String(s)) => Some(s.to_str()?.to_string()),
+                _ => None,
+            };
+            if let Some(method) = method
+                && method != "get"
+            {
+                return Err(blocked(&format!("http.{method}")));
+            }
+            inner.call_async::<MultiValue>(args).await
+        }
+    })?;
+    http.set("_client_request", wrapper)?;
+    Ok(())
+}
+
+/// `io.open` stays available for reading; write and append modes raise.
+fn guard_io_open(lua: &Lua) -> mlua::Result<()> {
+    let Some(io_table) = lua.globals().get::<Option<Table>>("io")? else {
+        return Ok(());
+    };
+    let Some(inner) = io_table.get::<Option<mlua::Function>>("open")? else {
+        return Ok(());
+    };
+    let wrapper = lua.create_function(move |_, args: MultiValue| {
+        let mode = match args.iter().nth(1) {
+            Some(Value::String(s)) => s.to_str()?.to_string(),
+            _ => "r".to_string(),
+        };
+        if mode.contains('w') || mode.contains('a') || mode.contains('+') {
+            return Err(blocked("io.open"));
+        }
+        inner.call::<MultiValue>(args)
+    })?;
+    io_table.set("open", wrapper)?;
+    Ok(())
+}
+
+/// `io.output(target)` opens its target for writing; only the
+/// zero-argument read of the current output stays available.
+fn guard_io_output(lua: &Lua) -> mlua::Result<()> {
+    let Some(io_table) = lua.globals().get::<Option<Table>>("io")? else {
+        return Ok(());
+    };
+    let Some(inner) = io_table.get::<Option<mlua::Function>>("output")? else {
+        return Ok(());
+    };
+    let wrapper = lua.create_function(move |_, args: MultiValue| {
+        if !args.is_empty() {
+            return Err(blocked("io.output"));
+        }
+        inner.call::<MultiValue>(args)
+    })?;
+    io_table.set("output", wrapper)?;
+    Ok(())
+}

--- a/crates/assay/src/lua/mod.rs
+++ b/crates/assay/src/lua/mod.rs
@@ -21,22 +21,37 @@ pub const MODULES_PATH_ENV: &str = "ASSAY_MODULES_PATH";
 /// `ASSAY_BLOCK_GLOBALS=dofile,os.execute,debug.getinfo`.
 pub const BLOCK_GLOBALS_ENV: &str = "ASSAY_BLOCK_GLOBALS";
 
+/// Set to `1` or `true` to activate read-only mode for every VM the
+/// process creates. Mutating builtins stay registered but raise
+/// `readonly: <name> blocked` errors instead of executing. The
+/// `--readonly` CLI flag activates the same mode per invocation.
+pub const READONLY_ENV: &str = "ASSAY_READONLY";
+
+pub fn readonly_from_env() -> bool {
+    matches!(
+        std::env::var(READONLY_ENV).ok().as_deref().map(str::trim),
+        Some("1") | Some("true")
+    )
+}
+
 fn lua_err(e: mlua::Error) -> anyhow::Error {
     anyhow::anyhow!("{e}")
 }
 
+#[allow(dead_code)]
 pub fn create_vm(client: reqwest::Client) -> Result<Lua> {
-    create_vm_with_paths(client, None)
+    create_vm_with_paths(client, None, readonly_from_env())
 }
 
 #[allow(dead_code)]
 pub fn create_vm_with_lib_path(client: reqwest::Client, lib_path: String) -> Result<Lua> {
-    create_vm_with_paths(client, Some(lib_path))
+    create_vm_with_paths(client, Some(lib_path), readonly_from_env())
 }
 
 pub fn create_vm_with_paths(
     client: reqwest::Client,
     global_modules_path: Option<String>,
+    readonly: bool,
 ) -> Result<Lua> {
     let libs = StdLib::ALL_SAFE;
     let lua = Lua::new_with(libs, LuaOptions::default()).map_err(lua_err)?;
@@ -45,6 +60,9 @@ pub fn create_vm_with_paths(
     register_fs_loader(&lua, global_modules_path).map_err(lua_err)?;
     register_stdlib_loader(&lua).map_err(lua_err)?;
     builtins::register_all(&lua, client).map_err(lua_err)?;
+    if readonly {
+        builtins::readonly::apply(&lua).map_err(lua_err)?;
+    }
     Ok(lua)
 }
 

--- a/crates/assay/src/lua/mod.rs
+++ b/crates/assay/src/lua/mod.rs
@@ -40,15 +40,23 @@ fn lua_err(e: mlua::Error) -> anyhow::Error {
 
 #[allow(dead_code)]
 pub fn create_vm(client: reqwest::Client) -> Result<Lua> {
-    create_vm_with_paths(client, None, readonly_from_env())
+    create_vm_configured(client, None, readonly_from_env())
 }
 
 #[allow(dead_code)]
 pub fn create_vm_with_lib_path(client: reqwest::Client, lib_path: String) -> Result<Lua> {
-    create_vm_with_paths(client, Some(lib_path), readonly_from_env())
+    create_vm_configured(client, Some(lib_path), readonly_from_env())
 }
 
+#[allow(dead_code)]
 pub fn create_vm_with_paths(
+    client: reqwest::Client,
+    global_modules_path: Option<String>,
+) -> Result<Lua> {
+    create_vm_configured(client, global_modules_path, readonly_from_env())
+}
+
+pub fn create_vm_configured(
     client: reqwest::Client,
     global_modules_path: Option<String>,
     readonly: bool,

--- a/crates/assay/src/main.rs
+++ b/crates/assay/src/main.rs
@@ -49,6 +49,12 @@ struct Cli {
     /// Enable verbose logging (sets RUST_LOG=debug).
     #[arg(short, long, global = true)]
     verbose: bool,
+
+    /// Read-only mode: mutating builtins (shell, process, fs writes,
+    /// http writes, ...) raise errors instead of executing.
+    /// ASSAY_READONLY=1 activates the same mode.
+    #[arg(long, global = true)]
+    readonly: bool,
 }
 
 #[derive(Subcommand, Debug)]
@@ -393,6 +399,7 @@ enum ScriptMode {
 struct RunOptions {
     mode: ScriptMode,
     timeout_secs: u64,
+    readonly: bool,
 }
 
 impl Default for RunOptions {
@@ -400,8 +407,13 @@ impl Default for RunOptions {
         Self {
             mode: resolve_script_mode(None),
             timeout_secs: DEFAULT_TOOL_TIMEOUT_SECS,
+            readonly: lua::readonly_from_env(),
         }
     }
+}
+
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 #[derive(Serialize)]
@@ -413,6 +425,8 @@ struct ToolSuccessEnvelope {
     requires_approval: Option<JsonValue>,
     #[serde(skip_serializing_if = "Option::is_none")]
     truncated: Option<bool>,
+    #[serde(skip_serializing_if = "is_false")]
+    readonly: bool,
 }
 
 #[derive(Serialize)]
@@ -420,6 +434,8 @@ struct ToolErrorEnvelope {
     ok: bool,
     status: &'static str,
     error: String,
+    #[serde(skip_serializing_if = "is_false")]
+    readonly: bool,
 }
 
 #[derive(Deserialize)]
@@ -441,6 +457,7 @@ struct ResumeState {
 #[tokio::main]
 async fn main() -> ExitCode {
     let cli = Cli::parse();
+    let readonly = cli.readonly || lua::readonly_from_env();
 
     let filter = if cli.verbose {
         EnvFilter::new("debug")
@@ -458,15 +475,19 @@ async fn main() -> ExitCode {
         Some(Commands::Context { query, limit }) => run_context(&query, limit),
         Some(Commands::Exec { eval, file }) => {
             if let Some(code) = eval {
-                run_lua_inline(&code).await
+                run_lua_inline(&code, readonly).await
             } else if let Some(path) = file {
-                run_lua_script(&path, RunOptions::default(), Vec::new()).await
+                let options = RunOptions {
+                    readonly,
+                    ..RunOptions::default()
+                };
+                run_lua_script(&path, options, Vec::new()).await
             } else {
                 eprintln!("error: exec requires either -e <code> or a file path");
                 ExitCode::from(1)
             }
         }
-        Some(Commands::Modules) => run_modules(),
+        Some(Commands::Modules) => run_modules(readonly),
         Some(Commands::Run {
             file,
             mode,
@@ -476,6 +497,7 @@ async fn main() -> ExitCode {
             let options = RunOptions {
                 mode: resolve_script_mode(mode.as_deref()),
                 timeout_secs: timeout.unwrap_or(DEFAULT_TOOL_TIMEOUT_SECS),
+                readonly,
             };
             dispatch_file(&file, options, script_args).await
         }
@@ -483,7 +505,7 @@ async fn main() -> ExitCode {
             token,
             approve,
             resume_ttl,
-        }) => resume_tool_execution(&token, &approve, resume_ttl).await,
+        }) => resume_tool_execution(&token, &approve, resume_ttl, readonly).await,
         Some(Commands::Workflow { global, command }) => {
             let opts = match cli::GlobalOpts::resolve(global.as_flags()) {
                 Ok(o) => o,
@@ -655,7 +677,11 @@ async fn main() -> ExitCode {
         }
         None => {
             if let Some(ref file) = cli.file {
-                dispatch_file(file, RunOptions::default(), Vec::new()).await
+                let options = RunOptions {
+                    readonly,
+                    ..RunOptions::default()
+                };
+                dispatch_file(file, options, Vec::new()).await
             } else {
                 use clap::CommandFactory;
                 Cli::command().print_help().ok();
@@ -685,7 +711,7 @@ async fn dispatch_file(
     let ext = file.extension().and_then(|e| e.to_str()).unwrap_or("");
 
     match ext {
-        "yaml" | "yml" => run_yaml_checks(file).await,
+        "yaml" | "yml" => run_yaml_checks(file, options.readonly).await,
         "lua" => run_lua_script(file, options, script_args).await,
         other => {
             eprintln!(
@@ -696,8 +722,8 @@ async fn dispatch_file(
     }
 }
 
-async fn run_yaml_checks(path: &std::path::Path) -> ExitCode {
-    info!(config = %path.display(), "starting assay (check mode)");
+async fn run_yaml_checks(path: &std::path::Path, readonly: bool) -> ExitCode {
+    info!(config = %path.display(), readonly, "starting assay (check mode)");
 
     let cfg = match config::load(path) {
         Ok(cfg) => cfg,
@@ -714,7 +740,7 @@ async fn run_yaml_checks(path: &std::path::Path) -> ExitCode {
         "configuration loaded"
     );
 
-    let result = runner::run(&cfg).await;
+    let result = runner::run(&cfg, readonly).await;
     result.print()
 }
 
@@ -734,9 +760,16 @@ async fn run_lua_script(
     let script = lua::async_bridge::strip_shebang(&script);
 
     match options.mode {
-        ScriptMode::Script => run_lua_script_mode(path, script, script_args).await,
+        ScriptMode::Script => run_lua_script_mode(path, script, script_args, options.readonly).await,
         ScriptMode::Tool => {
-            run_lua_tool_mode(path, script, options.timeout_secs, script_args).await
+            run_lua_tool_mode(
+                path,
+                script,
+                options.timeout_secs,
+                script_args,
+                options.readonly,
+            )
+            .await
         }
     }
 }
@@ -761,12 +794,13 @@ async fn run_lua_script_mode(
     path: &std::path::Path,
     script: &str,
     script_args: Vec<String>,
+    readonly: bool,
 ) -> ExitCode {
-    info!(script = %path.display(), "starting assay (script mode)");
+    info!(script = %path.display(), readonly, "starting assay (script mode)");
 
     let client = build_http_client();
 
-    let vm = match lua::create_vm(client) {
+    let vm = match lua::create_vm_with_paths(client, None, readonly) {
         Ok(vm) => vm,
         Err(e) => {
             eprintln!("error: creating Lua VM: {e:#}");
@@ -803,22 +837,38 @@ async fn run_lua_tool_mode(
     script: &str,
     timeout_secs: u64,
     script_args: Vec<String>,
+    readonly: bool,
 ) -> ExitCode {
-    info!(script = %path.display(), timeout_secs, "starting assay (tool mode)");
-    let tool_script = format!("env.set(\"ASSAY_MODE\", \"tool\")\n{script}");
+    info!(script = %path.display(), timeout_secs, readonly, "starting assay (tool mode)");
+    // In read-only mode `env.set` raises, so the mode marker is injected
+    // through the check-env table instead of the script prefix.
+    let tool_script = if readonly {
+        script.to_string()
+    } else {
+        format!("env.set(\"ASSAY_MODE\", \"tool\")\n{script}")
+    };
 
     let client = build_http_client();
 
-    let vm = match lua::create_vm(client) {
+    let vm = match lua::create_vm_with_paths(client, None, readonly) {
         Ok(vm) => vm,
         Err(e) => {
-            emit_tool_error("error", format!("creating Lua VM: {e:#}"));
+            emit_tool_error("error", format!("creating Lua VM: {e:#}"), readonly);
             return ExitCode::SUCCESS;
         }
     };
 
+    if readonly {
+        let mode_env =
+            std::collections::HashMap::from([("ASSAY_MODE".to_string(), "tool".to_string())]);
+        if let Err(e) = lua::inject_env(&vm, &mode_env) {
+            emit_tool_error("error", format!("injecting ASSAY_MODE: {e:#}"), readonly);
+            return ExitCode::SUCCESS;
+        }
+    }
+
     if let Err(e) = install_script_args(&vm, path, &script_args) {
-        emit_tool_error("error", format!("installing arg global: {e}"));
+        emit_tool_error("error", format!("installing arg global: {e}"), readonly);
         return ExitCode::SUCCESS;
     }
 
@@ -835,22 +885,22 @@ async fn run_lua_tool_mode(
     match result {
         Ok(Ok(value)) => match lua_value_to_json(&vm, value) {
             Ok(output) => {
-                emit_tool_success(output);
+                emit_tool_success(output, readonly);
                 ExitCode::SUCCESS
             }
             Err(e) => {
-                emit_tool_error("error", format!("serializing Lua result: {e}"));
+                emit_tool_error("error", format!("serializing Lua result: {e}"), readonly);
                 ExitCode::SUCCESS
             }
         },
         Ok(Err(e)) => {
             if let Some(request) = extract_approval_request(&e) {
                 match persist_resume_state(path, request) {
-                    Ok(requires_approval) => emit_tool_needs_approval(requires_approval),
-                    Err(err) => emit_tool_error("error", err),
+                    Ok(requires_approval) => emit_tool_needs_approval(requires_approval, readonly),
+                    Err(err) => emit_tool_error("error", err, readonly),
                 }
             } else {
-                emit_tool_error("error", format_lua_error(&e));
+                emit_tool_error("error", format_lua_error(&e), readonly);
             }
             ExitCode::SUCCESS
         }
@@ -858,24 +908,30 @@ async fn run_lua_tool_mode(
             emit_tool_error(
                 "timeout",
                 format!("execution timed out after {timeout_secs}s"),
+                readonly,
             );
             ExitCode::SUCCESS
         }
     }
 }
 
-async fn resume_tool_execution(token: &str, approve: &str, resume_ttl: Option<u64>) -> ExitCode {
+async fn resume_tool_execution(
+    token: &str,
+    approve: &str,
+    resume_ttl: Option<u64>,
+    readonly: bool,
+) -> ExitCode {
     let state_dir = match resolve_state_dir() {
         Ok(dir) => dir,
         Err(err) => {
-            emit_tool_error("error", err);
+            emit_tool_error("error", err, readonly);
             return ExitCode::SUCCESS;
         }
     };
 
     let state_path = state_dir.join("resume").join(format!("{token}.json"));
     if !state_path.exists() {
-        emit_tool_error("error", "invalid resume token".to_string());
+        emit_tool_error("error", "invalid resume token".to_string(), readonly);
         return ExitCode::SUCCESS;
     }
 
@@ -883,12 +939,12 @@ async fn resume_tool_execution(token: &str, approve: &str, resume_ttl: Option<u6
         Ok(content) => match serde_json::from_str::<ResumeState>(&content) {
             Ok(state) => state,
             Err(err) => {
-                emit_tool_error("error", format!("parsing resume state: {err}"));
+                emit_tool_error("error", format!("parsing resume state: {err}"), readonly);
                 return ExitCode::SUCCESS;
             }
         },
         Err(err) => {
-            emit_tool_error("error", format!("reading resume state: {err}"));
+            emit_tool_error("error", format!("reading resume state: {err}"), readonly);
             return ExitCode::SUCCESS;
         }
     };
@@ -896,19 +952,20 @@ async fn resume_tool_execution(token: &str, approve: &str, resume_ttl: Option<u6
     let now = unix_timestamp_now();
     let ttl_secs = resume_ttl.unwrap_or(state.ttl_secs);
     if state.created_at.saturating_add(ttl_secs) < now {
-        emit_tool_error("error", "resume token expired".to_string());
+        emit_tool_error("error", "resume token expired".to_string(), readonly);
         return ExitCode::SUCCESS;
     }
 
     let current_exe = match std::env::current_exe() {
         Ok(path) => path,
         Err(err) => {
-            emit_tool_error("error", format!("locating assay binary: {err}"));
+            emit_tool_error("error", format!("locating assay binary: {err}"), readonly);
             return ExitCode::SUCCESS;
         }
     };
 
-    let output = match Command::new(current_exe)
+    let mut command = Command::new(current_exe);
+    command
         .args([
             "run",
             "--mode",
@@ -917,12 +974,19 @@ async fn resume_tool_execution(token: &str, approve: &str, resume_ttl: Option<u6
         ])
         .env("ASSAY_MODE", "tool")
         .env("ASSAY_APPROVAL_RESULT", approve)
-        .env("ASSAY_STATE_DIR", &state_dir)
-        .output()
-    {
+        .env("ASSAY_STATE_DIR", &state_dir);
+    if readonly {
+        command.env(lua::READONLY_ENV, "1");
+    }
+
+    let output = match command.output() {
         Ok(output) => output,
         Err(err) => {
-            emit_tool_error("error", format!("spawning resume execution: {err}"));
+            emit_tool_error(
+                "error",
+                format!("spawning resume execution: {err}"),
+                readonly,
+            );
             return ExitCode::SUCCESS;
         }
     };
@@ -942,19 +1006,19 @@ async fn resume_tool_execution(token: &str, approve: &str, resume_ttl: Option<u6
         output.status.success() && resumed_status.as_deref() != Some("needs_approval");
 
     if should_cleanup && let Err(err) = fs::remove_file(&state_path) {
-        emit_tool_error("error", format!("cleaning up resume state: {err}"));
+        emit_tool_error("error", format!("cleaning up resume state: {err}"), readonly);
         return ExitCode::SUCCESS;
     }
 
     ExitCode::SUCCESS
 }
 
-async fn run_lua_inline(code: &str) -> ExitCode {
-    info!("starting assay (inline eval mode)");
+async fn run_lua_inline(code: &str, readonly: bool) -> ExitCode {
+    info!(readonly, "starting assay (inline eval mode)");
 
     let client = build_http_client();
 
-    let vm = match lua::create_vm(client) {
+    let vm = match lua::create_vm_with_paths(client, None, readonly) {
         Ok(vm) => vm,
         Err(e) => {
             eprintln!("error: creating Lua VM: {e:#}");
@@ -1067,13 +1131,14 @@ fn unix_timestamp_now() -> u64 {
         .as_secs()
 }
 
-fn emit_tool_success(output: JsonValue) {
+fn emit_tool_success(output: JsonValue, readonly: bool) {
     let mut envelope = ToolSuccessEnvelope {
         ok: true,
         status: "ok",
         output,
         requires_approval: None,
         truncated: None,
+        readonly,
     };
 
     if let Ok(serialized) = serde_json::to_vec(&envelope)
@@ -1084,30 +1149,36 @@ fn emit_tool_success(output: JsonValue) {
 
     match serde_json::to_string(&envelope) {
         Ok(serialized) => print!("{serialized}"),
-        Err(e) => emit_tool_error("error", format!("serializing tool envelope: {e}")),
+        Err(e) => emit_tool_error("error", format!("serializing tool envelope: {e}"), readonly),
     }
 }
 
-fn emit_tool_needs_approval(requires_approval: JsonValue) {
+fn emit_tool_needs_approval(requires_approval: JsonValue, readonly: bool) {
     let envelope = ToolSuccessEnvelope {
         ok: true,
         status: "needs_approval",
         output: JsonValue::Null,
         requires_approval: Some(requires_approval),
         truncated: None,
+        readonly,
     };
 
     match serde_json::to_string(&envelope) {
         Ok(serialized) => print!("{serialized}"),
-        Err(err) => emit_tool_error("error", format!("serializing tool envelope: {err}")),
+        Err(err) => emit_tool_error(
+            "error",
+            format!("serializing tool envelope: {err}"),
+            readonly,
+        ),
     }
 }
 
-fn emit_tool_error(status: &'static str, error_message: String) {
+fn emit_tool_error(status: &'static str, error_message: String, readonly: bool) {
     let envelope = ToolErrorEnvelope {
         ok: false,
         status,
         error: error_message,
+        readonly,
     };
 
     match serde_json::to_string(&envelope) {
@@ -1161,7 +1232,7 @@ fn truncate_tool_envelope(mut envelope: ToolSuccessEnvelope) -> ToolSuccessEnvel
     envelope
 }
 
-fn run_modules() -> ExitCode {
+fn run_modules(readonly: bool) -> ExitCode {
     use assay::discovery::{ModuleSource, discover_modules};
 
     let modules = discover_modules();
@@ -1189,6 +1260,13 @@ fn run_modules() -> ExitCode {
         println!(
             "{:<30} {:<10} {}",
             m.module_name, source_label, m.metadata.description
+        );
+    }
+
+    if readonly {
+        println!();
+        println!(
+            "read-only mode active: mutating builtins raise 'readonly: <name> blocked' errors"
         );
     }
 

--- a/crates/assay/src/main.rs
+++ b/crates/assay/src/main.rs
@@ -800,7 +800,7 @@ async fn run_lua_script_mode(
 
     let client = build_http_client();
 
-    let vm = match lua::create_vm_with_paths(client, None, readonly) {
+    let vm = match lua::create_vm_configured(client, None, readonly) {
         Ok(vm) => vm,
         Err(e) => {
             eprintln!("error: creating Lua VM: {e:#}");
@@ -850,7 +850,7 @@ async fn run_lua_tool_mode(
 
     let client = build_http_client();
 
-    let vm = match lua::create_vm_with_paths(client, None, readonly) {
+    let vm = match lua::create_vm_configured(client, None, readonly) {
         Ok(vm) => vm,
         Err(e) => {
             emit_tool_error("error", format!("creating Lua VM: {e:#}"), readonly);
@@ -1018,7 +1018,7 @@ async fn run_lua_inline(code: &str, readonly: bool) -> ExitCode {
 
     let client = build_http_client();
 
-    let vm = match lua::create_vm_with_paths(client, None, readonly) {
+    let vm = match lua::create_vm_configured(client, None, readonly) {
         Ok(vm) => vm,
         Err(e) => {
             eprintln!("error: creating Lua VM: {e:#}");

--- a/crates/assay/src/runner.rs
+++ b/crates/assay/src/runner.rs
@@ -8,7 +8,7 @@ use tokio::sync::Mutex;
 use tokio::time::timeout;
 use tracing::{error, info, warn};
 
-pub async fn run(config: &Config) -> RunResult {
+pub async fn run(config: &Config, readonly: bool) -> RunResult {
     if config.parallel {
         warn!("parallel execution not yet implemented, running sequentially");
     }
@@ -17,7 +17,7 @@ pub async fn run(config: &Config) -> RunResult {
     let client = build_http_client();
     let results = Arc::new(Mutex::new(Vec::with_capacity(config.checks.len())));
 
-    let run_future = run_all_checks(config, &client, Arc::clone(&results));
+    let run_future = run_all_checks(config, &client, Arc::clone(&results), readonly);
 
     match timeout(config.timeout, run_future).await {
         Ok(()) => {}
@@ -59,9 +59,10 @@ async fn run_all_checks(
     config: &Config,
     client: &reqwest::Client,
     results: Arc<Mutex<Vec<CheckResult>>>,
+    readonly: bool,
 ) {
     for check_config in &config.checks {
-        let result = run_check_with_retries(config, check_config, client).await;
+        let result = run_check_with_retries(config, check_config, client, readonly).await;
         let passed_str = if result.passed { "PASS" } else { "FAIL" };
         info!(
             check = check_config.name,
@@ -77,11 +78,12 @@ async fn run_check_with_retries(
     config: &Config,
     check_config: &crate::config::CheckConfig,
     client: &reqwest::Client,
+    readonly: bool,
 ) -> CheckResult {
     let max_attempts = config.retries + 1;
 
     for attempt in 1..=max_attempts {
-        let result = checks::run_check(check_config, client).await;
+        let result = checks::run_check(check_config, client, readonly).await;
 
         if result.passed {
             return result;

--- a/crates/assay/tests/readonly_mode.rs
+++ b/crates/assay/tests/readonly_mode.rs
@@ -1,0 +1,514 @@
+// Read-only execution mode: mutating builtins stay registered but
+// raise `readonly: <name> blocked (write operations are disabled in
+// read-only mode)`, while read paths keep working. Activated per-VM
+// via `create_vm_with_paths(..., readonly = true)`, process-wide via
+// ASSAY_READONLY=1|true, or per-invocation via the global `--readonly`
+// CLI flag.
+
+// ASSAY_READONLY is read at VM construction time (process-wide).
+// cargo's default test harness runs tests on threads in the same
+// process, so any test that builds a VM races against any test that
+// mutates that env var. ENV_LOCK serializes ALL VM creation in this
+// file, held only across the synchronous `create_vm*` call — never
+// across an `await`.
+
+use serde_json::Value as JsonValue;
+use std::io::Write;
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::Mutex;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+const BLOCKED_MSG: &str = "blocked (write operations are disabled in read-only mode)";
+
+fn http_client() -> reqwest::Client {
+    reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(5))
+        .build()
+        .unwrap()
+}
+
+fn make_vm(readonly: bool) -> mlua::Lua {
+    let _g = ENV_LOCK.lock().unwrap();
+    assay::lua::create_vm_with_paths(http_client(), None, readonly).unwrap()
+    // _g dropped here, before any caller awaits.
+}
+
+fn make_vm_with_env(value: &str) -> mlua::Lua {
+    let _g = ENV_LOCK.lock().unwrap();
+    // SAFETY: ENV_LOCK serialises every test in this file that mutates
+    // ASSAY_READONLY or constructs a VM that reads it.
+    unsafe {
+        std::env::set_var(assay::lua::READONLY_ENV, value);
+    }
+    let vm = assay::lua::create_vm(http_client());
+    unsafe {
+        std::env::remove_var(assay::lua::READONLY_ENV);
+    }
+    vm.unwrap()
+    // _g dropped here.
+}
+
+async fn run(script: &str, vm: mlua::Lua) {
+    let bridged = assay::lua::async_bridge::strip_shebang(script);
+    vm.load(bridged).exec_async().await.unwrap();
+}
+
+// Spawned children must not inherit ASSAY_READONLY from the test
+// process: the in-process env-activation tests set it (under ENV_LOCK)
+// while CLI tests run on sibling threads, and Command inherits the
+// parent env at spawn time. Tests that want env activation re-add it
+// explicitly.
+fn assay_bin() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_assay"));
+    cmd.env_remove(assay::lua::READONLY_ENV);
+    cmd
+}
+
+fn write_file(dir: &std::path::Path, name: &str, body: &str) -> PathBuf {
+    let file_path = dir.join(name);
+    let mut f = std::fs::File::create(&file_path).unwrap();
+    f.write_all(body.as_bytes()).unwrap();
+    file_path
+}
+
+// ── in-process VM behaviour ────────────────────────────────────────────
+
+#[tokio::test]
+async fn http_get_allowed_in_readonly() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/health"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "status": "ok"
+        })))
+        .mount(&server)
+        .await;
+
+    let vm = make_vm(true);
+    let script = format!(
+        r#"
+        local resp = http.get("{}/health")
+        assert.eq(resp.status, 200)
+        local body = json.parse(resp.body)
+        assert.eq(body.status, "ok")
+        "#,
+        server.uri()
+    );
+    run(&script, vm).await;
+}
+
+#[tokio::test]
+async fn http_write_verbs_blocked_in_readonly() {
+    let vm = make_vm(true);
+    let script = r#"
+        local ok, err = pcall(http.post, "http://127.0.0.1:1/x", "{}")
+        assert.eq(ok, false)
+        assert.contains(
+            tostring(err),
+            "readonly: http.post blocked (write operations are disabled in read-only mode)"
+        )
+
+        for _, name in ipairs({ "put", "patch", "delete", "serve", "serve_with_extra", "download" }) do
+            local ok2, err2 = pcall(http[name])
+            assert.eq(ok2, false)
+            assert.contains(tostring(err2), "readonly: http." .. name .. " blocked")
+        end
+
+        -- read helpers keep their surface
+        assert.eq(type(http.get), "function")
+        assert.eq(type(http.client), "function")
+    "#;
+    run(script, vm).await;
+}
+
+#[tokio::test]
+async fn http_client_wrapper_get_allowed_post_blocked_in_readonly() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/health"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&server)
+        .await;
+
+    let vm = make_vm(true);
+    let script = format!(
+        r#"
+        local c = http.client({{ timeout = 2 }})
+        local resp = c:get("{}/health")
+        assert.eq(resp.status, 200)
+        "#,
+        server.uri()
+    );
+    run(&script, vm).await;
+
+    let vm = make_vm(true);
+    let err = vm
+        .load(
+            r#"
+            local c = http.client({ timeout = 2 })
+            c:post("http://127.0.0.1:1/x", "{}")
+            "#,
+        )
+        .exec_async()
+        .await
+        .unwrap_err();
+    let msg = format!("{err}");
+    assert!(msg.contains("readonly: http.post blocked"), "got: {msg}");
+}
+
+#[tokio::test]
+async fn shell_and_process_blocked_in_readonly() {
+    let vm = make_vm(true);
+    let script = r#"
+        local ok, err = pcall(shell.exec, "echo hi")
+        assert.eq(ok, false)
+        assert.contains(tostring(err), "readonly: shell.exec blocked")
+
+        for _, name in ipairs({ "list", "is_running", "kill", "spawn", "wait", "spawn_pty" }) do
+            local ok2, err2 = pcall(process[name])
+            assert.eq(ok2, false)
+            assert.contains(tostring(err2), "readonly: process." .. name .. " blocked")
+        end
+    "#;
+    run(script, vm).await;
+}
+
+#[tokio::test]
+async fn fs_writes_blocked_reads_allowed_in_readonly() {
+    let dir = tempfile::tempdir().unwrap();
+    let file_path = dir.path().join("data.txt");
+    std::fs::write(&file_path, "hello readonly").unwrap();
+
+    let vm = make_vm(true);
+    let script = format!(
+        r#"
+        assert.eq(fs.read("{path}"), "hello readonly")
+        assert.eq(fs.exists("{path}"), true)
+        assert.not_nil(fs.stat("{path}"))
+        assert.not_nil(fs.list("{dir}"))
+
+        local blocked = {{
+            "write", "write_bytes", "remove", "rename", "copy",
+            "chmod", "mkdir", "tempdir", "sub_in_file",
+        }}
+        for _, name in ipairs(blocked) do
+            local ok, err = pcall(fs[name], "{path}", "x")
+            assert.eq(ok, false)
+            assert.contains(tostring(err), "readonly: fs." .. name .. " blocked")
+        end
+        "#,
+        path = file_path.display(),
+        dir = dir.path().display()
+    );
+    run(&script, vm).await;
+    assert_eq!(std::fs::read_to_string(&file_path).unwrap(), "hello readonly");
+}
+
+#[tokio::test]
+async fn env_get_allowed_env_set_blocked_in_readonly() {
+    let vm = make_vm(true);
+    let script = r#"
+        assert.eq(type(env.get("HOME")), "string")
+        assert.not_nil(env.list())
+
+        local ok, err = pcall(env.set, "ASSAY_READONLY_TEST_VAR", "1")
+        assert.eq(ok, false)
+        assert.contains(tostring(err), "readonly: env.set blocked")
+    "#;
+    run(script, vm).await;
+}
+
+#[cfg(feature = "db")]
+#[tokio::test]
+async fn db_execute_blocked_query_stays_in_readonly() {
+    let vm = make_vm(true);
+    let script = r#"
+        assert.eq(type(db.connect), "function")
+        assert.eq(type(db.query), "function")
+        assert.eq(type(db.close), "function")
+
+        local ok, err = pcall(db.execute)
+        assert.eq(ok, false)
+        assert.contains(tostring(err), "readonly: db.execute blocked")
+    "#;
+    run(script, vm).await;
+}
+
+#[tokio::test]
+async fn ws_connect_blocked_in_readonly() {
+    let vm = make_vm(true);
+    let script = r#"
+        local ok, err = pcall(ws.connect, "ws://127.0.0.1:1/socket")
+        assert.eq(ok, false)
+        assert.contains(tostring(err), "readonly: ws.connect blocked")
+    "#;
+    run(script, vm).await;
+}
+
+#[tokio::test]
+async fn system_mutators_blocked_reads_stay_in_readonly() {
+    let vm = make_vm(true);
+    let script = r#"
+        local blocked = {
+            { oci, "oci", { "copy", "tag", "mutate" } },
+            { systemd, "systemd", {
+                "start", "stop", "restart", "reload", "unit_action",
+                "machine_start", "machine_poweroff", "machine_reboot",
+                "machine_terminate", "machine_exec",
+            } },
+            { apt, "apt", { "update", "install", "remove", "add_source" } },
+            { machinectl, "machinectl", { "pull_tar", "pull_raw", "remove", "clone" } },
+            { tar, "tar", { "create", "extract" } },
+            { compress, "compress", { "untar" } },
+        }
+        -- some systemd entries are Linux-only; assert every function
+        -- that exists on this platform raises the readonly error
+        for _, entry in ipairs(blocked) do
+            local tbl, tbl_name, names = entry[1], entry[2], entry[3]
+            for _, name in ipairs(names) do
+                if tbl[name] ~= nil then
+                    local ok, err = pcall(tbl[name])
+                    assert.eq(ok, false)
+                    assert.contains(tostring(err), "readonly: " .. tbl_name .. "." .. name .. " blocked")
+                end
+            end
+        end
+
+        -- read surfaces stay intact
+        assert.eq(type(systemd.list_units), "function")
+        assert.eq(type(systemd.unit_status), "function")
+        assert.eq(type(systemd.journal), "function")
+        assert.eq(type(apt.query), "function")
+        assert.eq(type(apt.list_installed), "function")
+        assert.eq(type(tar.list), "function")
+        assert.eq(type(compress.gunzip), "function")
+        assert.eq(type(disk.usage), "function")
+    "#;
+    run(script, vm).await;
+}
+
+#[tokio::test]
+async fn lua_stdlib_write_paths_blocked_in_readonly() {
+    let dir = tempfile::tempdir().unwrap();
+    let file_path = dir.path().join("readable.txt");
+    std::fs::write(&file_path, "line").unwrap();
+
+    let vm = make_vm(true);
+    let script = format!(
+        r#"
+        local ok, err = pcall(io.popen, "echo hi")
+        assert.eq(ok, false)
+        assert.contains(tostring(err), "readonly: io.popen blocked")
+
+        for _, mode in ipairs({{ "w", "a", "r+" }}) do
+            local ok, err = pcall(io.open, "{path}", mode)
+            assert.eq(ok, false)
+            assert.contains(tostring(err), "readonly: io.open blocked")
+        end
+
+        local ok_out, err_out = pcall(io.output, "{path}")
+        assert.eq(ok_out, false)
+        assert.contains(tostring(err_out), "readonly: io.output blocked")
+
+        -- read mode stays open
+        local f = io.open("{path}", "r")
+        assert.eq(f:read("l"), "line")
+        f:close()
+        "#,
+        path = file_path.display()
+    );
+    run(&script, vm).await;
+}
+
+#[tokio::test]
+async fn mode_off_writes_work() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/submit"))
+        .respond_with(ResponseTemplate::new(201))
+        .mount(&server)
+        .await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let file_path = dir.path().join("out.txt");
+
+    let vm = make_vm(false);
+    let script = format!(
+        r#"
+        local resp = http.post("{uri}/submit", "{{}}")
+        assert.eq(resp.status, 201)
+        fs.write("{path}", "written")
+        assert.eq(fs.read("{path}"), "written")
+        env.set("ASSAY_READONLY_OFF_TEST", "1")
+        assert.eq(env.get("ASSAY_READONLY_OFF_TEST"), "1")
+        "#,
+        uri = server.uri(),
+        path = file_path.display()
+    );
+    run(&script, vm).await;
+    assert_eq!(std::fs::read_to_string(&file_path).unwrap(), "written");
+}
+
+#[tokio::test]
+async fn env_var_activates_readonly() {
+    for value in ["1", "true"] {
+        let vm = make_vm_with_env(value);
+        let script = r#"
+            local ok, err = pcall(fs.write, "/tmp/assay-readonly-env-test", "x")
+            assert.eq(ok, false)
+            assert.contains(tostring(err), "readonly: fs.write blocked")
+        "#;
+        run(script, vm).await;
+    }
+}
+
+#[tokio::test]
+async fn env_var_other_values_do_not_activate_readonly() {
+    let dir = tempfile::tempdir().unwrap();
+    let file_path = dir.path().join("off.txt");
+
+    let vm = make_vm_with_env("0");
+    let script = format!(
+        r#"
+        fs.write("{path}", "not readonly")
+        assert.eq(fs.read("{path}"), "not readonly")
+        "#,
+        path = file_path.display()
+    );
+    run(&script, vm).await;
+}
+
+// ── CLI surface ────────────────────────────────────────────────────────
+
+const CLI_PROBE_SCRIPT: &str = r#"
+    local ok, err = pcall(fs.write, "/tmp/assay-readonly-cli-test", "x")
+    assert.eq(ok, false)
+    assert.contains(tostring(err), "readonly: fs.write blocked")
+    print("readonly-ok")
+"#;
+
+#[test]
+fn cli_readonly_flag_blocks_writes() {
+    let dir = tempfile::tempdir().unwrap();
+    let script = write_file(dir.path(), "probe.lua", CLI_PROBE_SCRIPT);
+
+    for args in [
+        vec!["run", "--readonly", script.to_str().unwrap()],
+        vec!["--readonly", script.to_str().unwrap()],
+    ] {
+        let out = assay_bin().args(&args).output().unwrap();
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        assert!(out.status.success(), "args={args:?} stderr={stderr}");
+        assert!(stdout.contains("readonly-ok"), "args={args:?} stdout={stdout}");
+    }
+}
+
+#[test]
+fn cli_env_var_blocks_writes() {
+    let dir = tempfile::tempdir().unwrap();
+    let script = write_file(dir.path(), "probe.lua", CLI_PROBE_SCRIPT);
+
+    let out = assay_bin()
+        .args(["run", script.to_str().unwrap()])
+        .env("ASSAY_READONLY", "1")
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(out.status.success(), "stderr={stderr}");
+    assert!(stdout.contains("readonly-ok"), "stdout={stdout}");
+}
+
+#[test]
+fn cli_tool_envelope_reports_readonly() {
+    let dir = tempfile::tempdir().unwrap();
+    let script = write_file(
+        dir.path(),
+        "tool.lua",
+        r#"return { mode = env.get("ASSAY_MODE") }"#,
+    );
+
+    let out = assay_bin()
+        .args(["run", "--mode", "tool", "--readonly", script.to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let envelope: JsonValue = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(envelope["ok"], JsonValue::Bool(true));
+    assert_eq!(envelope["status"], "ok");
+    assert_eq!(envelope["readonly"], JsonValue::Bool(true));
+    assert_eq!(envelope["output"]["mode"], "tool");
+}
+
+#[test]
+fn cli_tool_envelope_omits_readonly_when_off() {
+    let dir = tempfile::tempdir().unwrap();
+    let script = write_file(dir.path(), "tool.lua", r#"return { done = true }"#);
+
+    let out = assay_bin()
+        .args(["run", "--mode", "tool", script.to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let envelope: JsonValue = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(envelope["status"], "ok");
+    assert!(envelope.get("readonly").is_none(), "envelope: {envelope}");
+}
+
+#[test]
+fn cli_tool_error_envelope_reports_readonly() {
+    let dir = tempfile::tempdir().unwrap();
+    let script = write_file(dir.path(), "tool.lua", r#"shell.exec("echo hi")"#);
+
+    let out = assay_bin()
+        .args(["run", "--mode", "tool", "--readonly", script.to_str().unwrap()])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+    let envelope: JsonValue = serde_json::from_slice(&out.stdout).unwrap();
+    assert_eq!(envelope["ok"], JsonValue::Bool(false));
+    assert_eq!(envelope["status"], "error");
+    assert_eq!(envelope["readonly"], JsonValue::Bool(true));
+    let error = envelope["error"].as_str().unwrap();
+    assert!(error.contains("readonly: shell.exec blocked"), "error: {error}");
+    assert!(error.contains(BLOCKED_MSG), "error: {error}");
+}
+
+#[test]
+fn cli_modules_reports_readonly() {
+    let out = assay_bin().args(["modules", "--readonly"]).output().unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("read-only mode active"), "stdout: {stdout}");
+
+    let out = assay_bin().arg("modules").output().unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(!stdout.contains("read-only mode active"), "stdout: {stdout}");
+}
+
+#[test]
+fn cli_yaml_checks_honor_readonly() {
+    let dir = tempfile::tempdir().unwrap();
+    let script = write_file(dir.path(), "check.lua", CLI_PROBE_SCRIPT);
+    let config = write_file(
+        dir.path(),
+        "checks.yaml",
+        &format!(
+            "timeout: 30s\nretries: 0\nchecks:\n  - name: readonly-check\n    type: script\n    file: {}\n",
+            script.display()
+        ),
+    );
+
+    let out = assay_bin()
+        .args(["run", "--readonly", config.to_str().unwrap()])
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(out.status.success(), "stderr={stderr}");
+}

--- a/crates/assay/tests/readonly_mode.rs
+++ b/crates/assay/tests/readonly_mode.rs
@@ -1,7 +1,7 @@
 // Read-only execution mode: mutating builtins stay registered but
 // raise `readonly: <name> blocked (write operations are disabled in
 // read-only mode)`, while read paths keep working. Activated per-VM
-// via `create_vm_with_paths(..., readonly = true)`, process-wide via
+// via `create_vm_configured(..., readonly = true)`, process-wide via
 // ASSAY_READONLY=1|true, or per-invocation via the global `--readonly`
 // CLI flag.
 
@@ -33,7 +33,7 @@ fn http_client() -> reqwest::Client {
 
 fn make_vm(readonly: bool) -> mlua::Lua {
     let _g = ENV_LOCK.lock().unwrap();
-    assay::lua::create_vm_with_paths(http_client(), None, readonly).unwrap()
+    assay::lua::create_vm_configured(http_client(), None, readonly).unwrap()
     // _g dropped here, before any caller awaits.
 }
 


### PR DESCRIPTION
Closes #175.

## What

A runtime read-only mode for semi-trusted script contexts: activated by the global `--readonly` flag (run / exec / YAML checks / tool mode / bare dispatch) or `ASSAY_READONLY=1`. Mutating operations stay registered but raise `readonly: <name> blocked (write operations are disabled in read-only mode)` — clear errors, never nil-indexes; read paths are untouched.

## Gating (post-registration pass, `builtins/readonly.rs`)

- **HTTP verb gate**: top-level `http.post/put/patch/delete/serve/serve_with_extra/download` blocked, plus a wrapper on `http._client_request` so `http.client():post()` can't bypass it (only `get` passes; verbs are internal fixed literals). `ws.connect` blocked.
- **Whole tables**: `shell`, `process` (incl. `spawn_pty`), `machinectl`.
- **Functions**: `fs` writes (+`tempdir`), `env.set`, `db.execute` (`db.query` stays — documented best-effort caveat re row-returning writes), `oci.copy/tag/mutate`, `systemd` mutators (status/list reads stay), `apt.*` mutators, `tar.create/extract`, `compress.untar`, and the stock-Lua escape hatches `io.popen`, `io.open` write/append/`+` modes, `io.output(target)`.
- Missing/feature-gated tables are skipped so the VM surface shape never changes.

## Reporting

`assay modules` prints an active-mode footer; tool envelopes gain `readonly: true` (omitted when off); `assay resume` propagates the mode to the re-executed child.

## Notes

- Tool mode previously injected its marker via a script-prefix `env.set` — under readonly that would self-block, so the marker moved to `inject_env` for readonly runs (`env.get("ASSAY_MODE")` unchanged, test-covered).
- Stock `os.execute/remove/rename` need no gating: the `os` table is already replaced by `os_info`.

## Testing

- New `tests/readonly_mode.rs`: 20 tests — GET allowed / POST blocked (wiremock), client-wrapper bypass, shell/process/fs/env/db gating, io escape hatches, flag + env + tool-mode + YAML-check activation, envelope on/off, resume propagation.
- Full crate: 1254 passed / 0 failed; `cargo clippy --tests -- -D warnings` clean; dprint clean.
- Fixed a pre-existing test-env race en route (spawned CLI tests inherited `ASSAY_READONLY` from in-process env tests; children now `env_remove` it).