### PR TITLE
ci: manual runner-maintenance workflow for disk reclaim

### DIFF
--- a/.github/workflows/runner-maintenance.yml
+++ b/.github/workflows/runner-maintenance.yml
@@ -1,0 +1,48 @@
+name: runner-maintenance
+
+# Manual disk reclaim for the self-hosted Linux runner. Clears only
+# rebuildable caches (the Cargo target mount, runner temp, dangling Docker
+# layers). Persistent services — the Postgres instance and the runner machine
+# itself — are never touched.
+on:
+  workflow_dispatch:
+    inputs:
+      prune_docker:
+        description: "Also run 'docker system prune -f' (dangling layers)"
+        type: boolean
+        default: true
+
+concurrency:
+  group: runner-maintenance
+  cancel-in-progress: false
+
+jobs:
+  reclaim:
+    runs-on: [self-hosted, linux, assay]
+    steps:
+      - name: Disk usage before
+        run: df -h /var/cache /var / 2>/dev/null || df -h
+
+      - name: Clear Cargo target cache mount
+        run: |
+          TARGET_DIR=/var/cache/runner-work/assay-target
+          if [ -d "$TARGET_DIR" ]; then
+            echo "Clearing $TARGET_DIR (rebuildable Cargo output)…"
+            rm -rf "${TARGET_DIR:?}/"* "${TARGET_DIR:?}/".* 2>/dev/null || true
+          else
+            echo "$TARGET_DIR not present; nothing to clear."
+          fi
+
+      - name: Clear runner work temp
+        run: |
+          TEMP_DIR="${RUNNER_TEMP:-}"
+          if [ -n "$TEMP_DIR" ] && [ -d "$TEMP_DIR" ]; then
+            find "$TEMP_DIR" -mindepth 1 -maxdepth 1 -exec rm -rf {} + 2>/dev/null || true
+          fi
+
+      - name: Prune dangling Docker layers
+        if: ${{ inputs.prune_docker }}
+        run: docker system prune -f 2>/dev/null || echo "docker not available; skipped"
+
+      - name: Disk usage after
+        run: df -h /var/cache /var / 2>/dev/null || df -h


### PR DESCRIPTION
Adds a `workflow_dispatch` job on the self-hosted Linux runner that reclaims disk when it fills up — clears the rebuildable Cargo target mount (`/var/cache/runner-work/assay-target`), runner temp, and dangling Docker layers. The Postgres service and the runner machine itself are never touched.

Needed because the self-hosted ubuntu runner is currently out of disk (`No space left on device`), blocking all Linux CI including #180. Workflows-only change — the Rust path filters don't match, so the heavy checks skip. Once merged, dispatching this clears the runner.