### PR TITLE
feat(assay): enforced approval mode (--approval-mode / ASSAY_APPROVAL)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to Assay are documented here.
 
+## assay 0.16.10 — 2026-07-05
+
+### Added
+
+- Enforced approval mode for supervised script contexts (agent-generated remediation, self-service
+  automation), where each mutating operation is authorized individually by an operator or calling
+  system rather than trusted to the script. Activate with the global `--approval-mode` CLI flag
+  (works for `run`, `exec`, YAML check mode, and tool mode) or `ASSAY_APPROVAL=1`/`true`. When both
+  read-only and approval mode are requested, approval mode wins (ask, don't hard-block). Instead of
+  executing, a mutating builtin suspends the run and raises the existing tool-mode approval flow
+  (`status:"needs_approval"` + resume token) carrying a descriptor of the operation — `op` (the
+  dotted builtin name), `summary` (the salient argument: url for HTTP, path for filesystem, command
+  for shell, SQL for `db.execute`), and `index` (a per-run sequence number assigned to every gated
+  operation). The supervisor decides with `assay resume --token … --approve yes|no`:
+  - `yes` re-runs the script from the top with that one operation additionally permitted;
+    previously-approved operations execute and the run re-suspends at the next unapproved one, so a
+    two-write script takes two approval cycles before it completes. Grants are single-shot and
+    per-operation, never "unlock the rest of the run".
+  - `no` fails that operation terminally with `approval: <op> denied`, a clean error the script's
+    own error handling can observe. The gated surface is the same catalog read-only mode uses (now
+    shared between the two gates): HTTP write verbs (including `http.client(...)` wrappers),
+    `ws.connect`, all of `shell.*` / `process.*` / `machinectl.*`, `fs` write ops, `env.set`,
+    `db.execute`, `oci`/`systemd`/`apt`/`tar`/`compress` mutators, and the Lua stdlib write paths
+    (`io.popen`, `io.open` write modes, `io.output(target)`). Read paths (`http.get`, `fs.read`,
+    `env.get`, `db.query`, status/list helpers) run freely without prompting. `assay modules` notes
+    when the mode is active. Because approval matching is by sequence index, a read that changes
+    control flow between operations across re-runs can shift indices (the same class of limitation
+    as workflow replay); acceptable for supervised single-writer scripts.
+
 ## assay 0.16.9 — 2026-07-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -132,6 +132,47 @@ mutators, `systemd` unit/machine lifecycle actions, `apt` mutators, `tar.create`
 when the mode is active, and tool-mode envelopes carry `"readonly": true`. For nil-ing out
 additional globals entirely, combine with `ASSAY_BLOCK_GLOBALS`.
 
+## Approval mode
+
+Where read-only mode hard-blocks every write, approval mode enforces a per-operation human (or
+supervisor) decision on the same catalog of mutating builtins. It is aimed at supervised remediation
+contexts where each write must be individually authorized. Activate with the global
+`--approval-mode` flag or `ASSAY_APPROVAL=1` (approval mode wins if `--readonly` is also set):
+
+```bash
+assay run --mode tool --approval-mode remediate.lua   # also: run, exec, YAML check mode
+```
+
+When a script reaches a mutating operation, the run suspends and raises the existing tool-mode
+approval flow — `status:"needs_approval"` with a resume token — carrying a descriptor of the pending
+operation:
+
+```json
+{
+  "status": "needs_approval",
+  "requiresApproval": {
+    "op": "http.post",
+    "summary": "https://api.example.com/deploy",
+    "index": 0,
+    "resumeToken": "…"
+  }
+}
+```
+
+The supervisor inspects the descriptor and decides:
+
+```bash
+assay resume --token <token> --approve yes   # permit this one operation, re-run, suspend at the next
+assay resume --token <token> --approve no    # fail it with "approval: <op> denied"
+```
+
+Each `yes` re-runs the script from the top: previously-approved operations execute and the run
+re-suspends at the next unapproved one, so grants are single-shot and per-operation. Read paths
+(`http.get`, `fs.read`, `env.get`, `db.query`, status/list helpers) run freely without prompting.
+Because approvals are matched by the sequence index of mutating operations, a read that changes
+control flow between operations across re-runs can shift indices — the same replay limitation
+workflow engines have; suitable for supervised single-writer scripts.
+
 ## Auth + IdP quick-start
 
 Once `assay-engine` is running with the auth module enabled, every IdP capability is reachable over

--- a/SKILL.md
+++ b/SKILL.md
@@ -54,6 +54,14 @@ unchanged. Blocked calls raise
 carry `"readonly": true`. Use it to run untrusted or agent-generated scripts safely for inspection
 and diagnostics.
 
+**Approval mode.** The global `--approval-mode` flag (or `ASSAY_APPROVAL=1`, which wins over
+`--readonly`) gates the same mutating catalog behind per-operation approval instead of a hard block.
+A mutating call suspends the run and raises the tool-mode approval flow (`status:"needs_approval"` +
+resume token) with a descriptor — `op`, `summary`, and a per-run `index`. Decide with
+`assay resume --token … --approve yes|no`: `yes` re-runs the script permitting that one operation
+and re-suspends at the next; `no` fails it with `approval: <op> denied`. Use it for supervised
+remediation where a human or calling system authorizes each write individually.
+
 ## Discovering Modules
 
 When you need to interact with a service, use `assay context` to find the right module:

--- a/crates/assay/Cargo.toml
+++ b/crates/assay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-lua"
-version = "0.16.9"
+version = "0.16.10"
 categories = ["command-line-utilities", "development-tools::testing"]
 edition = "2024"
 homepage = "https://assay.rs"

--- a/crates/assay/src/checks/mod.rs
+++ b/crates/assay/src/checks/mod.rs
@@ -3,13 +3,14 @@ pub mod prometheus;
 pub mod script;
 
 use crate::config::CheckConfig;
+use crate::lua::ExecMode;
 use crate::output::CheckResult;
 use std::time::Instant;
 
 pub async fn run_check(
     config: &CheckConfig,
     client: &reqwest::Client,
-    readonly: bool,
+    exec_mode: ExecMode,
 ) -> CheckResult {
     let start = Instant::now();
     let result = match config.check_type {
@@ -18,7 +19,7 @@ pub async fn run_check(
             prometheus::PrometheusCheck.execute(config, client).await
         }
         crate::config::CheckType::Script => {
-            script::ScriptCheck.execute(config, client, readonly).await
+            script::ScriptCheck.execute(config, client, exec_mode).await
         }
     };
 

--- a/crates/assay/src/checks/script.rs
+++ b/crates/assay/src/checks/script.rs
@@ -1,5 +1,6 @@
 use crate::config::CheckConfig;
 use crate::lua;
+use crate::lua::ExecMode;
 use crate::output::CheckResult;
 use anyhow::{Context, Result};
 
@@ -10,7 +11,7 @@ impl ScriptCheck {
         &self,
         config: &CheckConfig,
         client: &reqwest::Client,
-        readonly: bool,
+        exec_mode: ExecMode,
     ) -> Result<CheckResult> {
         let file_path = config
             .file
@@ -18,8 +19,15 @@ impl ScriptCheck {
             .context("script check requires a 'file' field")?;
 
         // Create a fresh Lua VM for each script check (isolation)
-        let vm =
-            lua::create_vm_configured(client.clone(), None, readonly).context("creating Lua VM")?;
+        let vm = lua::create_vm_with_options(
+            client.clone(),
+            lua::VmOptions {
+                global_modules_path: None,
+                mode: exec_mode,
+                approval: lua::ApprovalConfig::default(),
+            },
+        )
+        .context("creating Lua VM")?;
 
         // Inject check-specific environment variables
         lua::inject_env(&vm, &config.env)?;

--- a/crates/assay/src/lua/builtins/approval.rs
+++ b/crates/assay/src/lua/builtins/approval.rs
@@ -1,0 +1,217 @@
+//! Approval-mode guards, applied after `register_all` when the VM is
+//! created with `ExecMode::Approval`. Mutating builtins stay registered
+//! but each call is gated by its sequence index: an operation whose index
+//! is in the approved set runs against the original inner function;
+//! otherwise the call raises an approval request carrying the operation
+//! descriptor so the tool-mode resume machinery can suspend and collect a
+//! decision. A per-VM counter assigns the index and advances on every
+//! gated call, so successive resumes admit one more operation each.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use mlua::{Lua, MultiValue, Table, Value};
+
+use super::gated::{BLOCKED_FUNCTIONS, BLOCKED_TABLES, is_gated_http_verb};
+use crate::lua::{APPROVAL_REQUEST_PREFIX, ApprovalConfig};
+
+const SUMMARY_CAP: usize = 200;
+
+struct GateState {
+    counter: AtomicU64,
+    approved: HashSet<u64>,
+    denied: Option<u64>,
+}
+
+pub fn apply(lua: &Lua, config: &ApprovalConfig) -> mlua::Result<()> {
+    let state = Arc::new(GateState {
+        counter: AtomicU64::new(0),
+        approved: config.approved_indices.iter().copied().collect(),
+        denied: config.denied_index,
+    });
+    for path in BLOCKED_FUNCTIONS {
+        gate_function(lua, path, &state)?;
+    }
+    for name in BLOCKED_TABLES {
+        gate_table(lua, name, &state)?;
+    }
+    gate_http_client_request(lua, &state)?;
+    gate_io_open(lua, &state)?;
+    gate_io_output(lua, &state)?;
+    Ok(())
+}
+
+/// Advance the counter and decide the fate of this call. `Ok(())` admits
+/// the operation; an error either denies it terminally or raises the
+/// approval request that suspends the run.
+fn gate_decision(state: &GateState, op: &str, summary: &str) -> mlua::Result<()> {
+    let index = state.counter.fetch_add(1, Ordering::SeqCst);
+    if state.denied == Some(index) {
+        return Err(mlua::Error::runtime(format!("approval: {op} denied")));
+    }
+    if state.approved.contains(&index) {
+        return Ok(());
+    }
+    Err(approval_request(op, summary, index))
+}
+
+fn approval_request(op: &str, summary: &str, index: u64) -> mlua::Error {
+    let payload = serde_json::json!({
+        "prompt": format!("Approve {op}?"),
+        "op": op,
+        "summary": summary,
+        "index": index,
+    });
+    mlua::Error::runtime(format!("{APPROVAL_REQUEST_PREFIX}{payload}"))
+}
+
+fn truncate(value: &str) -> String {
+    if value.chars().count() > SUMMARY_CAP {
+        let head: String = value.chars().take(SUMMARY_CAP).collect();
+        format!("{head}...")
+    } else {
+        value.to_string()
+    }
+}
+
+/// The salient argument for the descriptor: the first string argument
+/// (url for http, path for fs, command for shell, sql for db.execute).
+fn first_string_arg(args: &MultiValue) -> String {
+    for value in args.iter() {
+        if let Value::String(s) = value
+            && let Ok(text) = s.to_str()
+        {
+            return truncate(&text);
+        }
+    }
+    String::new()
+}
+
+fn gate_function(lua: &Lua, path: &str, state: &Arc<GateState>) -> mlua::Result<()> {
+    let Some((table_name, fn_name)) = path.split_once('.') else {
+        return Ok(());
+    };
+    let Some(table) = lua.globals().get::<Option<Table>>(table_name)? else {
+        return Ok(());
+    };
+    let Value::Function(inner) = table.get::<Value>(fn_name)? else {
+        return Ok(());
+    };
+    let op = path.to_string();
+    let state = Arc::clone(state);
+    let wrapper = lua.create_async_function(move |_, args: MultiValue| {
+        let inner = inner.clone();
+        let state = Arc::clone(&state);
+        let op = op.clone();
+        async move {
+            let summary = first_string_arg(&args);
+            gate_decision(&state, &op, &summary)?;
+            inner.call_async::<MultiValue>(args).await
+        }
+    })?;
+    table.set(fn_name, wrapper)?;
+    Ok(())
+}
+
+fn gate_table(lua: &Lua, name: &str, state: &Arc<GateState>) -> mlua::Result<()> {
+    let Some(table) = lua.globals().get::<Option<Table>>(name)? else {
+        return Ok(());
+    };
+    for pair in table.clone().pairs::<Value, Value>() {
+        let (key, value) = pair?;
+        let (Value::String(key_str), Value::Function(inner)) = (&key, &value) else {
+            continue;
+        };
+        let op = format!("{name}.{}", key_str.to_str()?);
+        let inner = inner.clone();
+        let state = Arc::clone(state);
+        let wrapper = lua.create_async_function(move |_, args: MultiValue| {
+            let inner = inner.clone();
+            let state = Arc::clone(&state);
+            let op = op.clone();
+            async move {
+                let summary = first_string_arg(&args);
+                gate_decision(&state, &op, &summary)?;
+                inner.call_async::<MultiValue>(args).await
+            }
+        })?;
+        table.set(key.clone(), wrapper)?;
+    }
+    Ok(())
+}
+
+fn gate_http_client_request(lua: &Lua, state: &Arc<GateState>) -> mlua::Result<()> {
+    let Some(http) = lua.globals().get::<Option<Table>>("http")? else {
+        return Ok(());
+    };
+    let Some(inner) = http.get::<Option<mlua::Function>>("_client_request")? else {
+        return Ok(());
+    };
+    let state = Arc::clone(state);
+    let wrapper = lua.create_async_function(move |_, args: MultiValue| {
+        let inner = inner.clone();
+        let state = Arc::clone(&state);
+        async move {
+            let method = match args.iter().nth(1) {
+                Some(Value::String(s)) => Some(s.to_str()?.to_string()),
+                _ => None,
+            };
+            if let Some(method) = method
+                && is_gated_http_verb(&method)
+            {
+                let op = format!("http.{method}");
+                let summary = match args.iter().nth(2) {
+                    Some(Value::String(s)) => truncate(&s.to_str()?),
+                    _ => String::new(),
+                };
+                gate_decision(&state, &op, &summary)?;
+            }
+            inner.call_async::<MultiValue>(args).await
+        }
+    })?;
+    http.set("_client_request", wrapper)?;
+    Ok(())
+}
+
+fn gate_io_open(lua: &Lua, state: &Arc<GateState>) -> mlua::Result<()> {
+    let Some(io_table) = lua.globals().get::<Option<Table>>("io")? else {
+        return Ok(());
+    };
+    let Some(inner) = io_table.get::<Option<mlua::Function>>("open")? else {
+        return Ok(());
+    };
+    let state = Arc::clone(state);
+    let wrapper = lua.create_function(move |_, args: MultiValue| {
+        let mode = match args.iter().nth(1) {
+            Some(Value::String(s)) => s.to_str()?.to_string(),
+            _ => "r".to_string(),
+        };
+        if mode.contains('w') || mode.contains('a') || mode.contains('+') {
+            let summary = first_string_arg(&args);
+            gate_decision(&state, "io.open", &summary)?;
+        }
+        inner.call::<MultiValue>(args)
+    })?;
+    io_table.set("open", wrapper)?;
+    Ok(())
+}
+
+fn gate_io_output(lua: &Lua, state: &Arc<GateState>) -> mlua::Result<()> {
+    let Some(io_table) = lua.globals().get::<Option<Table>>("io")? else {
+        return Ok(());
+    };
+    let Some(inner) = io_table.get::<Option<mlua::Function>>("output")? else {
+        return Ok(());
+    };
+    let state = Arc::clone(state);
+    let wrapper = lua.create_function(move |_, args: MultiValue| {
+        if !args.is_empty() {
+            let summary = first_string_arg(&args);
+            gate_decision(&state, "io.output", &summary)?;
+        }
+        inner.call::<MultiValue>(args)
+    })?;
+    io_table.set("output", wrapper)?;
+    Ok(())
+}

--- a/crates/assay/src/lua/builtins/gated.rs
+++ b/crates/assay/src/lua/builtins/gated.rs
@@ -1,0 +1,57 @@
+//! Shared catalog of assay's mutating builtin surface. Both the read-only
+//! gate (`readonly.rs`) and the approval gate (`approval.rs`) consume this
+//! one list so the two modes classify the same operations as mutating.
+
+/// Tables whose entire function surface is gated.
+pub(crate) const BLOCKED_TABLES: &[&str] = &["shell", "process", "machinectl"];
+
+/// Individual functions gated inside otherwise-usable tables.
+pub(crate) const BLOCKED_FUNCTIONS: &[&str] = &[
+    "http.post",
+    "http.put",
+    "http.patch",
+    "http.delete",
+    "http.serve",
+    "http.serve_with_extra",
+    "http.download",
+    "ws.connect",
+    "fs.write",
+    "fs.write_bytes",
+    "fs.remove",
+    "fs.rename",
+    "fs.copy",
+    "fs.chmod",
+    "fs.mkdir",
+    "fs.tempdir",
+    "fs.sub_in_file",
+    "env.set",
+    "db.execute",
+    "oci.copy",
+    "oci.tag",
+    "oci.mutate",
+    "systemd.start",
+    "systemd.stop",
+    "systemd.restart",
+    "systemd.reload",
+    "systemd.unit_action",
+    "systemd.machine_start",
+    "systemd.machine_poweroff",
+    "systemd.machine_reboot",
+    "systemd.machine_terminate",
+    "systemd.machine_exec",
+    "apt.update",
+    "apt.install",
+    "apt.remove",
+    "apt.add_source",
+    "compress.untar",
+    "tar.create",
+    "tar.extract",
+    "io.popen",
+];
+
+/// `http.client(...)` wrappers route every verb through
+/// `http._client_request(ud, method, ...)`. Only `get` is a read; every
+/// other verb is a mutating (gated) request.
+pub(crate) fn is_gated_http_verb(method: &str) -> bool {
+    method != "get"
+}

--- a/crates/assay/src/lua/builtins/mod.rs
+++ b/crates/assay/src/lua/builtins/mod.rs
@@ -1,3 +1,4 @@
+pub mod approval;
 mod apt;
 mod assert;
 mod cgroup;
@@ -7,6 +8,7 @@ mod crypto;
 #[cfg(feature = "db")]
 mod db;
 mod disk;
+pub(crate) mod gated;
 pub mod http;
 mod json;
 mod linux;

--- a/crates/assay/src/lua/builtins/readonly.rs
+++ b/crates/assay/src/lua/builtins/readonly.rs
@@ -8,52 +8,7 @@
 
 use mlua::{Lua, MultiValue, Table, Value};
 
-/// Tables whose entire function surface is blocked.
-const BLOCKED_TABLES: &[&str] = &["shell", "process", "machinectl"];
-
-/// Individual functions blocked inside otherwise-usable tables.
-const BLOCKED_FUNCTIONS: &[&str] = &[
-    "http.post",
-    "http.put",
-    "http.patch",
-    "http.delete",
-    "http.serve",
-    "http.serve_with_extra",
-    "http.download",
-    "ws.connect",
-    "fs.write",
-    "fs.write_bytes",
-    "fs.remove",
-    "fs.rename",
-    "fs.copy",
-    "fs.chmod",
-    "fs.mkdir",
-    "fs.tempdir",
-    "fs.sub_in_file",
-    "env.set",
-    "db.execute",
-    "oci.copy",
-    "oci.tag",
-    "oci.mutate",
-    "systemd.start",
-    "systemd.stop",
-    "systemd.restart",
-    "systemd.reload",
-    "systemd.unit_action",
-    "systemd.machine_start",
-    "systemd.machine_poweroff",
-    "systemd.machine_reboot",
-    "systemd.machine_terminate",
-    "systemd.machine_exec",
-    "apt.update",
-    "apt.install",
-    "apt.remove",
-    "apt.add_source",
-    "compress.untar",
-    "tar.create",
-    "tar.extract",
-    "io.popen",
-];
+use super::gated::{BLOCKED_FUNCTIONS, BLOCKED_TABLES, is_gated_http_verb};
 
 pub fn apply(lua: &Lua) -> mlua::Result<()> {
     for path in BLOCKED_FUNCTIONS {
@@ -129,7 +84,7 @@ fn guard_http_client_request(lua: &Lua) -> mlua::Result<()> {
                 _ => None,
             };
             if let Some(method) = method
-                && method != "get"
+                && is_gated_http_verb(&method)
             {
                 return Err(blocked(&format!("http.{method}")));
             }

--- a/crates/assay/src/lua/mod.rs
+++ b/crates/assay/src/lua/mod.rs
@@ -34,6 +34,100 @@ pub fn readonly_from_env() -> bool {
     )
 }
 
+/// Set to `1` or `true` to activate approval mode for every VM the process
+/// creates. Mutating builtins stay registered but suspend for
+/// per-operation approval via the resume flow instead of executing. The
+/// `--approval-mode` CLI flag activates the same mode per invocation and
+/// takes precedence over read-only mode.
+pub const APPROVAL_ENV: &str = "ASSAY_APPROVAL";
+
+/// Comma-separated set of already-approved operation indices for an
+/// approval-mode re-run (set by the resume machinery).
+pub(crate) const APPROVED_INDICES_ENV: &str = "ASSAY_APPROVED_INDICES";
+
+/// The single operation index to fail terminally on an approval-mode
+/// re-run (set by the resume machinery when a decision is `no`).
+pub(crate) const DENIED_INDEX_ENV: &str = "ASSAY_DENIED_INDEX";
+
+/// Prefix that marks a runtime error as an approval request. The tool-mode
+/// runner extracts the JSON payload that follows it to suspend the run.
+pub(crate) const APPROVAL_REQUEST_PREFIX: &str = "__assay_approval_request__:";
+
+pub fn approval_from_env() -> bool {
+    matches!(
+        std::env::var(APPROVAL_ENV).ok().as_deref().map(str::trim),
+        Some("1") | Some("true")
+    )
+}
+
+/// Execution mode selecting which post-registration gate (if any) is
+/// applied to a VM.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum ExecMode {
+    #[default]
+    Unrestricted,
+    ReadOnly,
+    Approval,
+}
+
+impl ExecMode {
+    pub fn is_readonly(self) -> bool {
+        matches!(self, ExecMode::ReadOnly)
+    }
+
+    pub fn is_approval(self) -> bool {
+        matches!(self, ExecMode::Approval)
+    }
+}
+
+/// Per-run approval state consumed by the approval gate: which operation
+/// indices are pre-approved for this run and which single index (if any)
+/// must fail terminally.
+#[derive(Clone, Debug, Default)]
+pub struct ApprovalConfig {
+    pub approved_indices: Vec<u64>,
+    pub denied_index: Option<u64>,
+}
+
+/// Resolve the approval set + denied index from the environment. Empty
+/// when the vars are absent, which is the first-run (nothing approved
+/// yet) case.
+pub fn approval_config_from_env() -> ApprovalConfig {
+    let approved_indices = std::env::var(APPROVED_INDICES_ENV)
+        .ok()
+        .map(|raw| parse_indices(&raw))
+        .unwrap_or_default();
+    let denied_index = std::env::var(DENIED_INDEX_ENV)
+        .ok()
+        .and_then(|raw| raw.trim().parse::<u64>().ok());
+    ApprovalConfig {
+        approved_indices,
+        denied_index,
+    }
+}
+
+fn parse_indices(raw: &str) -> Vec<u64> {
+    raw.split(',')
+        .filter_map(|part| {
+            let trimmed = part.trim();
+            if trimmed.is_empty() {
+                None
+            } else {
+                trimmed.parse::<u64>().ok()
+            }
+        })
+        .collect()
+}
+
+/// Full VM configuration. New knobs are added here rather than by widening
+/// `create_vm_configured`, keeping the older factory signatures stable.
+#[derive(Clone, Debug, Default)]
+pub struct VmOptions {
+    pub global_modules_path: Option<String>,
+    pub mode: ExecMode,
+    pub approval: ApprovalConfig,
+}
+
 fn lua_err(e: mlua::Error) -> anyhow::Error {
     anyhow::anyhow!("{e}")
 }
@@ -61,6 +155,27 @@ pub fn create_vm_configured(
     global_modules_path: Option<String>,
     readonly: bool,
 ) -> Result<Lua> {
+    let mode = if readonly {
+        ExecMode::ReadOnly
+    } else {
+        ExecMode::Unrestricted
+    };
+    create_vm_with_options(
+        client,
+        VmOptions {
+            global_modules_path,
+            mode,
+            approval: ApprovalConfig::default(),
+        },
+    )
+}
+
+pub fn create_vm_with_options(client: reqwest::Client, options: VmOptions) -> Result<Lua> {
+    let VmOptions {
+        global_modules_path,
+        mode,
+        approval,
+    } = options;
     let libs = StdLib::ALL_SAFE;
     let lua = Lua::new_with(libs, LuaOptions::default()).map_err(lua_err)?;
     lua.set_memory_limit(64 * 1024 * 1024).map_err(lua_err)?;
@@ -68,8 +183,10 @@ pub fn create_vm_configured(
     register_fs_loader(&lua, global_modules_path).map_err(lua_err)?;
     register_stdlib_loader(&lua).map_err(lua_err)?;
     builtins::register_all(&lua, client).map_err(lua_err)?;
-    if readonly {
-        builtins::readonly::apply(&lua).map_err(lua_err)?;
+    match mode {
+        ExecMode::ReadOnly => builtins::readonly::apply(&lua).map_err(lua_err)?,
+        ExecMode::Approval => builtins::approval::apply(&lua, &approval).map_err(lua_err)?,
+        ExecMode::Unrestricted => {}
     }
     Ok(lua)
 }

--- a/crates/assay/src/main.rs
+++ b/crates/assay/src/main.rs
@@ -55,6 +55,13 @@ struct Cli {
     /// ASSAY_READONLY=1 activates the same mode.
     #[arg(long, global = true)]
     readonly: bool,
+
+    /// Approval mode: mutating builtins suspend for per-operation human
+    /// approval via the resume flow instead of executing.
+    /// ASSAY_APPROVAL=1 activates the same mode. Takes precedence over
+    /// --readonly.
+    #[arg(long, global = true)]
+    approval_mode: bool,
 }
 
 #[derive(Subcommand, Debug)]
@@ -395,11 +402,12 @@ enum ScriptMode {
     Tool,
 }
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 struct RunOptions {
     mode: ScriptMode,
     timeout_secs: u64,
-    readonly: bool,
+    exec_mode: lua::ExecMode,
+    approval: lua::ApprovalConfig,
 }
 
 impl Default for RunOptions {
@@ -407,8 +415,21 @@ impl Default for RunOptions {
         Self {
             mode: resolve_script_mode(None),
             timeout_secs: DEFAULT_TOOL_TIMEOUT_SECS,
-            readonly: lua::readonly_from_env(),
+            exec_mode: resolve_exec_mode(false, false),
+            approval: lua::approval_config_from_env(),
         }
+    }
+}
+
+/// Resolve the execution mode from CLI flags and environment. Approval
+/// mode wins over read-only when both are requested.
+fn resolve_exec_mode(cli_readonly: bool, cli_approval: bool) -> lua::ExecMode {
+    if cli_approval || lua::approval_from_env() {
+        lua::ExecMode::Approval
+    } else if cli_readonly || lua::readonly_from_env() {
+        lua::ExecMode::ReadOnly
+    } else {
+        lua::ExecMode::Unrestricted
     }
 }
 
@@ -443,6 +464,12 @@ struct ApprovalRequestPayload {
     prompt: String,
     #[serde(default)]
     context: JsonValue,
+    #[serde(default)]
+    op: Option<String>,
+    #[serde(default)]
+    summary: Option<String>,
+    #[serde(default)]
+    index: Option<u64>,
 }
 
 #[derive(Deserialize, Serialize)]
@@ -452,12 +479,30 @@ struct ResumeState {
     approval_context: JsonValue,
     created_at: u64,
     ttl_secs: u64,
+    #[serde(default)]
+    mode: Option<String>,
+    #[serde(default)]
+    approved_indices: Vec<u64>,
+    #[serde(default)]
+    pending_index: Option<u64>,
+    #[serde(default)]
+    op: Option<String>,
+    #[serde(default)]
+    summary: Option<String>,
+    #[serde(default)]
+    script_args: Vec<String>,
 }
 
 #[tokio::main]
 async fn main() -> ExitCode {
     let cli = Cli::parse();
-    let readonly = cli.readonly || lua::readonly_from_env();
+    let exec_mode = resolve_exec_mode(cli.readonly, cli.approval_mode);
+    let readonly = exec_mode.is_readonly();
+    let approval = if exec_mode.is_approval() {
+        lua::approval_config_from_env()
+    } else {
+        lua::ApprovalConfig::default()
+    };
 
     let filter = if cli.verbose {
         EnvFilter::new("debug")
@@ -475,10 +520,11 @@ async fn main() -> ExitCode {
         Some(Commands::Context { query, limit }) => run_context(&query, limit),
         Some(Commands::Exec { eval, file }) => {
             if let Some(code) = eval {
-                run_lua_inline(&code, readonly).await
+                run_lua_inline(&code, exec_mode, &approval).await
             } else if let Some(path) = file {
                 let options = RunOptions {
-                    readonly,
+                    exec_mode,
+                    approval: approval.clone(),
                     ..RunOptions::default()
                 };
                 run_lua_script(&path, options, Vec::new()).await
@@ -487,7 +533,7 @@ async fn main() -> ExitCode {
                 ExitCode::from(1)
             }
         }
-        Some(Commands::Modules) => run_modules(readonly),
+        Some(Commands::Modules) => run_modules(exec_mode),
         Some(Commands::Run {
             file,
             mode,
@@ -497,7 +543,8 @@ async fn main() -> ExitCode {
             let options = RunOptions {
                 mode: resolve_script_mode(mode.as_deref()),
                 timeout_secs: timeout.unwrap_or(DEFAULT_TOOL_TIMEOUT_SECS),
-                readonly,
+                exec_mode,
+                approval: approval.clone(),
             };
             dispatch_file(&file, options, script_args).await
         }
@@ -678,7 +725,8 @@ async fn main() -> ExitCode {
         None => {
             if let Some(ref file) = cli.file {
                 let options = RunOptions {
-                    readonly,
+                    exec_mode,
+                    approval: approval.clone(),
                     ..RunOptions::default()
                 };
                 dispatch_file(file, options, Vec::new()).await
@@ -711,7 +759,7 @@ async fn dispatch_file(
     let ext = file.extension().and_then(|e| e.to_str()).unwrap_or("");
 
     match ext {
-        "yaml" | "yml" => run_yaml_checks(file, options.readonly).await,
+        "yaml" | "yml" => run_yaml_checks(file, options.exec_mode).await,
         "lua" => run_lua_script(file, options, script_args).await,
         other => {
             eprintln!(
@@ -722,7 +770,8 @@ async fn dispatch_file(
     }
 }
 
-async fn run_yaml_checks(path: &std::path::Path, readonly: bool) -> ExitCode {
+async fn run_yaml_checks(path: &std::path::Path, exec_mode: lua::ExecMode) -> ExitCode {
+    let readonly = exec_mode.is_readonly();
     info!(config = %path.display(), readonly, "starting assay (check mode)");
 
     let cfg = match config::load(path) {
@@ -740,7 +789,7 @@ async fn run_yaml_checks(path: &std::path::Path, readonly: bool) -> ExitCode {
         "configuration loaded"
     );
 
-    let result = runner::run(&cfg, readonly).await;
+    let result = runner::run(&cfg, exec_mode).await;
     result.print()
 }
 
@@ -760,14 +809,24 @@ async fn run_lua_script(
     let script = lua::async_bridge::strip_shebang(&script);
 
     match options.mode {
-        ScriptMode::Script => run_lua_script_mode(path, script, script_args, options.readonly).await,
+        ScriptMode::Script => {
+            run_lua_script_mode(
+                path,
+                script,
+                script_args,
+                options.exec_mode,
+                &options.approval,
+            )
+            .await
+        }
         ScriptMode::Tool => {
             run_lua_tool_mode(
                 path,
                 script,
                 options.timeout_secs,
                 script_args,
-                options.readonly,
+                options.exec_mode,
+                &options.approval,
             )
             .await
         }
@@ -794,13 +853,22 @@ async fn run_lua_script_mode(
     path: &std::path::Path,
     script: &str,
     script_args: Vec<String>,
-    readonly: bool,
+    exec_mode: lua::ExecMode,
+    approval: &lua::ApprovalConfig,
 ) -> ExitCode {
+    let readonly = exec_mode.is_readonly();
     info!(script = %path.display(), readonly, "starting assay (script mode)");
 
     let client = build_http_client();
 
-    let vm = match lua::create_vm_configured(client, None, readonly) {
+    let vm = match lua::create_vm_with_options(
+        client,
+        lua::VmOptions {
+            global_modules_path: None,
+            mode: exec_mode,
+            approval: approval.clone(),
+        },
+    ) {
         Ok(vm) => vm,
         Err(e) => {
             eprintln!("error: creating Lua VM: {e:#}");
@@ -837,12 +905,16 @@ async fn run_lua_tool_mode(
     script: &str,
     timeout_secs: u64,
     script_args: Vec<String>,
-    readonly: bool,
+    exec_mode: lua::ExecMode,
+    approval: &lua::ApprovalConfig,
 ) -> ExitCode {
+    let readonly = exec_mode.is_readonly();
+    // Under a gate (read-only or approval) `env.set` is itself gated, so
+    // the mode marker is injected through the check-env table rather than a
+    // script prefix that would trip the gate.
+    let gated = exec_mode.is_readonly() || exec_mode.is_approval();
     info!(script = %path.display(), timeout_secs, readonly, "starting assay (tool mode)");
-    // In read-only mode `env.set` raises, so the mode marker is injected
-    // through the check-env table instead of the script prefix.
-    let tool_script = if readonly {
+    let tool_script = if gated {
         script.to_string()
     } else {
         format!("env.set(\"ASSAY_MODE\", \"tool\")\n{script}")
@@ -850,7 +922,14 @@ async fn run_lua_tool_mode(
 
     let client = build_http_client();
 
-    let vm = match lua::create_vm_configured(client, None, readonly) {
+    let vm = match lua::create_vm_with_options(
+        client,
+        lua::VmOptions {
+            global_modules_path: None,
+            mode: exec_mode,
+            approval: approval.clone(),
+        },
+    ) {
         Ok(vm) => vm,
         Err(e) => {
             emit_tool_error("error", format!("creating Lua VM: {e:#}"), readonly);
@@ -858,7 +937,7 @@ async fn run_lua_tool_mode(
         }
     };
 
-    if readonly {
+    if gated {
         let mode_env =
             std::collections::HashMap::from([("ASSAY_MODE".to_string(), "tool".to_string())]);
         if let Err(e) = lua::inject_env(&vm, &mode_env) {
@@ -895,7 +974,13 @@ async fn run_lua_tool_mode(
         },
         Ok(Err(e)) => {
             if let Some(request) = extract_approval_request(&e) {
-                match persist_resume_state(path, request) {
+                match persist_resume_state(
+                    path,
+                    request,
+                    exec_mode,
+                    &approval.approved_indices,
+                    &script_args,
+                ) {
                     Ok(requires_approval) => emit_tool_needs_approval(requires_approval, readonly),
                     Err(err) => emit_tool_error("error", err, readonly),
                 }
@@ -965,17 +1050,47 @@ async fn resume_tool_execution(
     };
 
     let mut command = Command::new(current_exe);
+    command.args([
+        "run",
+        "--mode",
+        "tool",
+        state.script_path.to_string_lossy().as_ref(),
+    ]);
+    // Re-run with the original positional arguments so the `arg` global —
+    // and any control flow that depends on it — is identical across runs.
+    if !state.script_args.is_empty() {
+        command.arg("--");
+        command.args(&state.script_args);
+    }
     command
-        .args([
-            "run",
-            "--mode",
-            "tool",
-            state.script_path.to_string_lossy().as_ref(),
-        ])
         .env("ASSAY_MODE", "tool")
         .env("ASSAY_APPROVAL_RESULT", approve)
         .env("ASSAY_STATE_DIR", &state_dir);
-    if readonly {
+
+    if state.mode.as_deref() == Some("approval") {
+        command.env(lua::APPROVAL_ENV, "1");
+        let mut approved = state.approved_indices.clone();
+        match approve {
+            "yes" => {
+                if let Some(idx) = state.pending_index
+                    && !approved.contains(&idx)
+                {
+                    approved.push(idx);
+                }
+            }
+            _ => {
+                if let Some(idx) = state.pending_index {
+                    command.env(lua::DENIED_INDEX_ENV, idx.to_string());
+                }
+            }
+        }
+        let joined = approved
+            .iter()
+            .map(u64::to_string)
+            .collect::<Vec<_>>()
+            .join(",");
+        command.env(lua::APPROVED_INDICES_ENV, joined);
+    } else if readonly {
         command.env(lua::READONLY_ENV, "1");
     }
 
@@ -1006,19 +1121,35 @@ async fn resume_tool_execution(
         output.status.success() && resumed_status.as_deref() != Some("needs_approval");
 
     if should_cleanup && let Err(err) = fs::remove_file(&state_path) {
-        emit_tool_error("error", format!("cleaning up resume state: {err}"), readonly);
+        emit_tool_error(
+            "error",
+            format!("cleaning up resume state: {err}"),
+            readonly,
+        );
         return ExitCode::SUCCESS;
     }
 
     ExitCode::SUCCESS
 }
 
-async fn run_lua_inline(code: &str, readonly: bool) -> ExitCode {
+async fn run_lua_inline(
+    code: &str,
+    exec_mode: lua::ExecMode,
+    approval: &lua::ApprovalConfig,
+) -> ExitCode {
+    let readonly = exec_mode.is_readonly();
     info!(readonly, "starting assay (inline eval mode)");
 
     let client = build_http_client();
 
-    let vm = match lua::create_vm_configured(client, None, readonly) {
+    let vm = match lua::create_vm_with_options(
+        client,
+        lua::VmOptions {
+            global_modules_path: None,
+            mode: exec_mode,
+            approval: approval.clone(),
+        },
+    ) {
         Ok(vm) => vm,
         Err(e) => {
             eprintln!("error: creating Lua VM: {e:#}");
@@ -1075,6 +1206,9 @@ fn extract_approval_request(err: &mlua::Error) -> Option<ApprovalRequestPayload>
 fn persist_resume_state(
     script_path: &std::path::Path,
     request: ApprovalRequestPayload,
+    mode: lua::ExecMode,
+    approved_indices: &[u64],
+    script_args: &[String],
 ) -> Result<JsonValue, String> {
     let state_dir = resolve_state_dir()?;
     let resume_dir = state_dir.join("resume");
@@ -1090,12 +1224,19 @@ fn persist_resume_state(
             Err(_) => script_path.to_path_buf(),
         }
     };
+    let mode_label = mode.is_approval().then(|| "approval".to_string());
     let state = ResumeState {
         script_path: resolved_script_path,
         approval_prompt: request.prompt.clone(),
         approval_context: request.context.clone(),
         created_at: unix_timestamp_now(),
         ttl_secs: DEFAULT_RESUME_TTL_SECS,
+        mode: mode_label,
+        approved_indices: approved_indices.to_vec(),
+        pending_index: request.index,
+        op: request.op.clone(),
+        summary: request.summary.clone(),
+        script_args: script_args.to_vec(),
     };
 
     let serialized =
@@ -1103,11 +1244,20 @@ fn persist_resume_state(
     fs::write(resume_dir.join(format!("{token}.json")), serialized)
         .map_err(|err| format!("writing resume state: {err}"))?;
 
-    Ok(serde_json::json!({
-        "prompt": request.prompt,
-        "context": request.context,
-        "resumeToken": token,
-    }))
+    let mut requires = serde_json::Map::new();
+    requires.insert("prompt".to_string(), JsonValue::String(request.prompt));
+    requires.insert("context".to_string(), request.context);
+    requires.insert("resumeToken".to_string(), JsonValue::String(token));
+    if let Some(op) = request.op {
+        requires.insert("op".to_string(), JsonValue::String(op));
+    }
+    if let Some(summary) = request.summary {
+        requires.insert("summary".to_string(), JsonValue::String(summary));
+    }
+    if let Some(index) = request.index {
+        requires.insert("index".to_string(), JsonValue::from(index));
+    }
+    Ok(JsonValue::Object(requires))
 }
 
 fn resolve_state_dir() -> Result<PathBuf, String> {
@@ -1232,7 +1382,7 @@ fn truncate_tool_envelope(mut envelope: ToolSuccessEnvelope) -> ToolSuccessEnvel
     envelope
 }
 
-fn run_modules(readonly: bool) -> ExitCode {
+fn run_modules(exec_mode: lua::ExecMode) -> ExitCode {
     use assay::discovery::{ModuleSource, discover_modules};
 
     let modules = discover_modules();
@@ -1263,11 +1413,14 @@ fn run_modules(readonly: bool) -> ExitCode {
         );
     }
 
-    if readonly {
+    if exec_mode.is_readonly() {
         println!();
         println!(
             "read-only mode active: mutating builtins raise 'readonly: <name> blocked' errors"
         );
+    } else if exec_mode.is_approval() {
+        println!();
+        println!("approval mode active: mutating builtins pause for per-operation approval");
     }
 
     ExitCode::SUCCESS

--- a/crates/assay/src/runner.rs
+++ b/crates/assay/src/runner.rs
@@ -1,6 +1,7 @@
 use crate::build_http_client;
 use crate::checks;
 use crate::config::Config;
+use crate::lua::ExecMode;
 use crate::output::{CheckResult, RunResult};
 use std::sync::Arc;
 use std::time::Instant;
@@ -8,7 +9,7 @@ use tokio::sync::Mutex;
 use tokio::time::timeout;
 use tracing::{error, info, warn};
 
-pub async fn run(config: &Config, readonly: bool) -> RunResult {
+pub async fn run(config: &Config, exec_mode: ExecMode) -> RunResult {
     if config.parallel {
         warn!("parallel execution not yet implemented, running sequentially");
     }
@@ -17,7 +18,7 @@ pub async fn run(config: &Config, readonly: bool) -> RunResult {
     let client = build_http_client();
     let results = Arc::new(Mutex::new(Vec::with_capacity(config.checks.len())));
 
-    let run_future = run_all_checks(config, &client, Arc::clone(&results), readonly);
+    let run_future = run_all_checks(config, &client, Arc::clone(&results), exec_mode);
 
     match timeout(config.timeout, run_future).await {
         Ok(()) => {}
@@ -59,10 +60,10 @@ async fn run_all_checks(
     config: &Config,
     client: &reqwest::Client,
     results: Arc<Mutex<Vec<CheckResult>>>,
-    readonly: bool,
+    exec_mode: ExecMode,
 ) {
     for check_config in &config.checks {
-        let result = run_check_with_retries(config, check_config, client, readonly).await;
+        let result = run_check_with_retries(config, check_config, client, exec_mode).await;
         let passed_str = if result.passed { "PASS" } else { "FAIL" };
         info!(
             check = check_config.name,
@@ -78,12 +79,12 @@ async fn run_check_with_retries(
     config: &Config,
     check_config: &crate::config::CheckConfig,
     client: &reqwest::Client,
-    readonly: bool,
+    exec_mode: ExecMode,
 ) -> CheckResult {
     let max_attempts = config.retries + 1;
 
     for attempt in 1..=max_attempts {
-        let result = checks::run_check(check_config, client, readonly).await;
+        let result = checks::run_check(check_config, client, exec_mode).await;
 
         if result.passed {
             return result;

--- a/crates/assay/tests/approval_mode.rs
+++ b/crates/assay/tests/approval_mode.rs
@@ -1,0 +1,365 @@
+// Approval execution mode: mutating builtins suspend for per-operation
+// approval via the resume flow instead of executing. Activated per-VM via
+// `ExecMode::Approval`, process-wide via ASSAY_APPROVAL=1|true, or
+// per-invocation via the global `--approval-mode` flag. These tests drive
+// the spawned binary so the full suspend → resume → re-run loop is
+// exercised end to end.
+
+use serde_json::Value;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+static DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn assay_binary() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_assay"))
+}
+
+fn unique_dir(prefix: &str) -> PathBuf {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let seq = DIR_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!("{prefix}-{nonce}-{seq}"));
+    std::fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn write_script(dir: &Path, name: &str, content: &str) -> PathBuf {
+    let path = dir.join(name);
+    std::fs::write(&path, content).unwrap();
+    path
+}
+
+fn resume_state_path(state_dir: &Path, token: &str) -> PathBuf {
+    state_dir.join("resume").join(format!("{token}.json"))
+}
+
+fn stdout_json(output: &std::process::Output) -> Value {
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+        panic!(
+            "stdout not JSON ({e}): {}",
+            String::from_utf8_lossy(&output.stdout)
+        )
+    })
+}
+
+// Spawned children must not inherit approval/readonly env from the test
+// process; each test adds back exactly what it needs.
+fn scrub(cmd: &mut Command) {
+    for key in [
+        "ASSAY_APPROVAL",
+        "ASSAY_APPROVED_INDICES",
+        "ASSAY_DENIED_INDEX",
+        "ASSAY_READONLY",
+        "ASSAY_MODE",
+        "ASSAY_APPROVAL_RESULT",
+    ] {
+        cmd.env_remove(key);
+    }
+}
+
+fn tool_cmd(script: &Path, flags: &[&str], state_dir: &Path) -> Command {
+    let mut cmd = Command::new(assay_binary());
+    cmd.arg("run").arg("--mode").arg("tool");
+    for flag in flags {
+        cmd.arg(flag);
+    }
+    cmd.arg(script);
+    scrub(&mut cmd);
+    cmd.env("ASSAY_STATE_DIR", state_dir);
+    cmd
+}
+
+fn resume_cmd(token: &str, approve: &str, state_dir: &Path) -> Command {
+    let mut cmd = Command::new(assay_binary());
+    cmd.arg("resume")
+        .arg("--token")
+        .arg(token)
+        .arg("--approve")
+        .arg(approve);
+    scrub(&mut cmd);
+    cmd.env("ASSAY_STATE_DIR", state_dir);
+    cmd
+}
+
+// Run a blocking spawn off the async runtime so an in-process wiremock
+// server stays responsive to the child's requests.
+async fn run_blocking(mut cmd: Command) -> std::process::Output {
+    tokio::task::spawn_blocking(move || cmd.output().unwrap())
+        .await
+        .unwrap()
+}
+
+fn post_script(dir: &Path, name: &str, url: &str) -> PathBuf {
+    write_script(
+        dir,
+        name,
+        &format!("local r = http.post(\"{url}/submit\", \"{{}}\")\nreturn {{ status = r.status }}"),
+    )
+}
+
+// ── (a) a mutation halts with a descriptor, without executing ──────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn mutation_halts_with_descriptor_and_no_request() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/submit"))
+        .respond_with(ResponseTemplate::new(201))
+        .mount(&server)
+        .await;
+
+    let dir = unique_dir("assay-approval-halt");
+    let state_dir = dir.join("state");
+    let script = post_script(&dir, "post.lua", &server.uri());
+
+    let out = run_blocking(tool_cmd(&script, &["--approval-mode"], &state_dir)).await;
+    let json = stdout_json(&out);
+    assert_eq!(json["ok"], Value::Bool(true));
+    assert_eq!(json["status"], "needs_approval");
+    assert_eq!(json["output"], Value::Null);
+
+    let ra = &json["requiresApproval"];
+    assert_eq!(ra["op"], "http.post");
+    assert_eq!(ra["index"], 0);
+    assert!(
+        ra["summary"].as_str().unwrap().contains("/submit"),
+        "summary: {}",
+        ra["summary"]
+    );
+    let token = ra["resumeToken"].as_str().unwrap();
+    assert_eq!(token.len(), 32);
+    assert!(token.chars().all(|c| c.is_ascii_hexdigit()));
+    assert!(resume_state_path(&state_dir, token).exists());
+
+    // The POST never reached the mock.
+    assert!(server.received_requests().await.unwrap().is_empty());
+}
+
+// ── (b) each resume admits exactly one more operation ──────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn resume_cycle_admits_one_op_per_approval() {
+    let server_one = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(201))
+        .mount(&server_one)
+        .await;
+    let server_two = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(202))
+        .mount(&server_two)
+        .await;
+
+    let dir = unique_dir("assay-approval-cycle");
+    let state_dir = dir.join("state");
+    let script = write_script(
+        &dir,
+        "two_ops.lua",
+        &format!(
+            "local a = http.post(\"{one}/x\", \"{{}}\")\n\
+             local b = http.post(\"{two}/x\", \"{{}}\")\n\
+             return {{ one = a.status, two = b.status }}",
+            one = server_one.uri(),
+            two = server_two.uri(),
+        ),
+    );
+
+    // Run 1: suspends at op 0.
+    let first = run_blocking(tool_cmd(&script, &["--approval-mode"], &state_dir)).await;
+    let first_json = stdout_json(&first);
+    assert_eq!(first_json["status"], "needs_approval");
+    assert_eq!(first_json["requiresApproval"]["index"], 0);
+    let token_a = first_json["requiresApproval"]["resumeToken"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    assert!(server_one.received_requests().await.unwrap().is_empty());
+    assert!(server_two.received_requests().await.unwrap().is_empty());
+
+    // Resume yes: op 0 runs, run re-suspends at op 1.
+    let second = run_blocking(resume_cmd(&token_a, "yes", &state_dir)).await;
+    let second_json = stdout_json(&second);
+    assert_eq!(second_json["status"], "needs_approval");
+    assert_eq!(second_json["requiresApproval"]["index"], 1);
+    let token_b = second_json["requiresApproval"]["resumeToken"]
+        .as_str()
+        .unwrap()
+        .to_string();
+    assert!(!server_one.received_requests().await.unwrap().is_empty());
+    assert!(
+        server_two.received_requests().await.unwrap().is_empty(),
+        "op 1 must not run until approved"
+    );
+
+    // Resume yes again: both ops run, script completes.
+    let third = run_blocking(resume_cmd(&token_b, "yes", &state_dir)).await;
+    let third_json = stdout_json(&third);
+    assert_eq!(third_json["status"], "ok");
+    assert_eq!(third_json["output"]["one"], 201);
+    assert_eq!(third_json["output"]["two"], 202);
+    assert!(!server_two.received_requests().await.unwrap().is_empty());
+}
+
+// ── (c) deny fails the operation without executing it ──────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn deny_fails_operation_and_skips_request() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/submit"))
+        .respond_with(ResponseTemplate::new(201))
+        .mount(&server)
+        .await;
+
+    let dir = unique_dir("assay-approval-deny");
+    let state_dir = dir.join("state");
+    let script = post_script(&dir, "post.lua", &server.uri());
+
+    let first = run_blocking(tool_cmd(&script, &["--approval-mode"], &state_dir)).await;
+    let token = stdout_json(&first)["requiresApproval"]["resumeToken"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let denied = run_blocking(resume_cmd(&token, "no", &state_dir)).await;
+    let json = stdout_json(&denied);
+    assert_eq!(json["ok"], Value::Bool(false));
+    assert_eq!(json["status"], "error");
+    assert!(
+        json["error"]
+            .as_str()
+            .unwrap()
+            .contains("approval: http.post denied"),
+        "error: {}",
+        json["error"]
+    );
+
+    assert!(server.received_requests().await.unwrap().is_empty());
+}
+
+// ── (d) read paths run freely without prompting ────────────────────────
+
+#[test]
+fn read_only_op_runs_freely_in_approval_mode() {
+    let dir = unique_dir("assay-approval-read");
+    let state_dir = dir.join("state");
+    let data = dir.join("data.txt");
+    std::fs::write(&data, "readable payload").unwrap();
+    let script = write_script(
+        &dir,
+        "read.lua",
+        &format!("return {{ content = fs.read(\"{}\") }}", data.display()),
+    );
+
+    let out = tool_cmd(&script, &["--approval-mode"], &state_dir)
+        .output()
+        .unwrap();
+    let json = stdout_json(&out);
+    assert_eq!(json["status"], "ok");
+    assert_eq!(json["output"]["content"], "readable payload");
+}
+
+// ── (e) flag and env both activate approval mode ───────────────────────
+
+#[test]
+fn flag_and_env_activate_approval() {
+    let dir = unique_dir("assay-approval-activate");
+    let target = dir.join("out.txt");
+    let script = write_script(
+        &dir,
+        "write.lua",
+        &format!(
+            "fs.write(\"{}\", \"data\")\nreturn {{ done = true }}",
+            target.display()
+        ),
+    );
+
+    // Flag activation.
+    let flag_out = tool_cmd(&script, &["--approval-mode"], &dir.join("state-flag"))
+        .output()
+        .unwrap();
+    let flag_json = stdout_json(&flag_out);
+    assert_eq!(flag_json["status"], "needs_approval");
+    assert_eq!(flag_json["requiresApproval"]["op"], "fs.write");
+    assert!(!target.exists(), "fs.write must not run before approval");
+
+    // Env activation.
+    let mut env_cmd = tool_cmd(&script, &[], &dir.join("state-env"));
+    env_cmd.env("ASSAY_APPROVAL", "1");
+    let env_json = stdout_json(&env_cmd.output().unwrap());
+    assert_eq!(env_json["status"], "needs_approval");
+    assert_eq!(env_json["requiresApproval"]["op"], "fs.write");
+}
+
+// ── (f) approval wins over readonly when both are set ──────────────────
+
+#[test]
+fn approval_mode_wins_over_readonly() {
+    let dir = unique_dir("assay-approval-precedence");
+    let state_dir = dir.join("state");
+    let target = dir.join("out.txt");
+    let script = write_script(
+        &dir,
+        "write.lua",
+        &format!(
+            "fs.write(\"{}\", \"data\")\nreturn {{ done = true }}",
+            target.display()
+        ),
+    );
+
+    let out = tool_cmd(&script, &["--readonly", "--approval-mode"], &state_dir)
+        .output()
+        .unwrap();
+    let json = stdout_json(&out);
+    assert_eq!(
+        json["status"], "needs_approval",
+        "approval must win: {json}"
+    );
+    assert_eq!(json["requiresApproval"]["op"], "fs.write");
+    // Not a read-only hard block, and the readonly signal is absent.
+    assert!(json.get("error").is_none());
+    assert!(json.get("readonly").is_none(), "envelope: {json}");
+}
+
+// ── (g) the tool-mode marker does not self-trip the gate ───────────────
+
+#[test]
+fn env_marker_does_not_self_trip_in_approval_mode() {
+    let dir = unique_dir("assay-approval-marker");
+    let state_dir = dir.join("state");
+    let script = write_script(
+        &dir,
+        "marker.lua",
+        "return { mode = env.get(\"ASSAY_MODE\") }",
+    );
+
+    let out = tool_cmd(&script, &["--approval-mode"], &state_dir)
+        .output()
+        .unwrap();
+    let json = stdout_json(&out);
+    assert_eq!(
+        json["status"], "ok",
+        "marker must not trip the gate: {json}"
+    );
+    assert_eq!(json["output"]["mode"], "tool");
+}
+
+// ── reporting ──────────────────────────────────────────────────────────
+
+#[test]
+fn modules_reports_approval_mode() {
+    let mut cmd = Command::new(assay_binary());
+    cmd.args(["modules", "--approval-mode"]);
+    scrub(&mut cmd);
+    let out = cmd.output().unwrap();
+    assert!(out.status.success());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("approval mode active"), "stdout: {stdout}");
+}


### PR DESCRIPTION
Closes #176.

## What

An enforced approval mode for supervised script contexts, building on the read-only mode (#180). Activated by `--approval-mode` / `ASSAY_APPROVAL=1`. A mutating operation does not execute — it **suspends for per-operation approval** via the existing resume-token machinery, carrying a descriptor the supervisor inspects. Iterative: each `assay resume --approve yes` admits one more operation and the script re-runs, previously-approved writes execute, and it re-suspends at the next unapproved one until it completes. `--approve no` fails just that operation (`approval: <op> denied`).

## Design

- **Shared catalog**: `BLOCKED_TABLES`/`BLOCKED_FUNCTIONS` + the http write-verb predicate extracted to a new `builtins/gated.rs` (`pub(crate)`); both the read-only gate and the approval gate consume the one list. `readonly.rs` refactored to import it — behavior unchanged, its 20 tests still pass.
- **Descriptor + sequence-index matching** (`builtins/approval.rs`): each gated call gets `{op, summary (first string arg, capped 200), index}`; a per-VM `AtomicU64` advances on every gated call. Approved index → run the captured inner; denied → terminal error; otherwise raise `__assay_approval_request__` reusing the existing extract/persist/emit path. Sequence-index (not arg-hashing) is robust to timestamp/nonce args; documented caveat: a read that changes control flow across re-runs can shift indices (same class as workflow replay).
- **Mode precedence**: `ExecMode` enum (Unrestricted | ReadOnly | Approval); approval wins if both flags/envs are set.
- **Re-run identity**: `ResumeState` persists `mode`, `approved_indices`, `pending_index`, `op`, `summary`, and `script_args`; resume replays `run --mode tool <script> -- <args>` with the accumulated approved set + same state dir, so the `arg` global and control flow are identical across runs (also fixes a gap in the prior resume path).
- **Tool-mode marker fix**: the `ASSAY_MODE` marker moves to `inject_env` so `env.set` gating never self-trips.
- New library API is purely additive (`ExecMode`, `VmOptions`, `ApprovalConfig`, `create_vm_with_options`, `APPROVAL_ENV`, …) — existing `create_vm*` signatures untouched, so semver-checks stays a clean patch bump.

## Testing

- `cargo test -p assay-lua` full crate: **1262 passed / 0 failed**. New `approval_mode.rs`: 8 (suspend-not-execute with wiremock, two-op approve cycle, deny, read runs freely, flag+env activation, precedence, env.set marker). `readonly_mode.rs` 20 and `tool_mode.rs` 16 unchanged. Clippy `-D warnings` clean; dprint clean.

## Known limitations (documented)

Approved ops re-execute each cycle (inherent to iterative replay); full suspend/resume UX is tool-mode only (script/inline/YAML install the gate but surface the raw request as a fail-closed error); resume-file perms tightening left as the follow-up the issue's Notes mention.