### PR TITLE
feat(assay): mcp-serve — MCP server exposing assay_run + assay_context (0.17.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to Assay are documented here.
 
+## assay 0.17.0 — 2026-07-05
+
+### Added
+
+- `assay mcp-serve` — a Model Context Protocol server over stdio so AI coding agents (Claude Code,
+  Cursor, Windsurf, Cline, and any MCP client) can drive the runtime directly. It speaks JSON-RPC
+  2.0 over stdin/stdout with newline-delimited framing per the MCP stdio transport, implementing
+  `initialize`, `tools/list`, `tools/call`, `ping`, and clean shutdown on EOF. Rather than exposing
+  one tool per module, it presents exactly two tools and lets Lua compose the modules — the
+  advertised schema stays tiny no matter how many modules ship:
+  - `assay_run` — execute a Lua script and return the tool-mode JSON envelope (`status` ok /
+    needs_approval / error, `output`, `requiresApproval` + resume token, `truncated`, `readonly`).
+    Reuses the existing tool-mode execution path, so approval gates suspend and return a resume
+    token exactly as `assay run --mode tool` does. Execution is **always gated**: the `mode`
+    argument accepts only `readonly` (default) or `approval`; an unrestricted mode is intentionally
+    not offered and any other value is rejected, so a caller can never opt out of the gate. A
+    blocked write in read-only mode surfaces as an `error` envelope rather than crashing the server.
+  - `assay_context` — search the embedded modules and return prompt-ready Markdown (method
+    signatures, env vars, builtins), the same output as the `assay context` CLI, so an agent can
+    discover module APIs before composing a script.
+  - Tool-execution failures return an MCP result with `isError: true` (`needs_approval` is not an
+    error); malformed JSON-RPC returns a transport-level error response. Transport is hand-rolled on
+    `serde_json` + `tokio` (both already dependencies) to keep the static binary size flat — no MCP
+    SDK is pulled in.
+
 ## assay 0.16.10 — 2026-07-05
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,7 +338,7 @@ dependencies = [
 
 [[package]]
 name = "assay-lua"
-version = "0.16.9"
+version = "0.17.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/README.md
+++ b/README.md
@@ -173,6 +173,35 @@ Because approvals are matched by the sequence index of mutating operations, a re
 control flow between operations across re-runs can shift indices — the same replay limitation
 workflow engines have; suitable for supervised single-writer scripts.
 
+## MCP server
+
+`assay mcp-serve` runs a Model Context Protocol server over stdio so AI coding agents (Claude Code,
+Cursor, Windsurf, Cline, and any MCP client) can drive the runtime directly. It speaks JSON-RPC 2.0
+with newline-delimited messages per the MCP stdio transport. Point the client at the binary:
+
+```json
+{
+  "mcpServers": {
+    "assay": { "command": "assay", "args": ["mcp-serve"] }
+  }
+}
+```
+
+Rather than one tool per module — which would balloon the advertised schema as modules are added —
+the server exposes exactly **two tools** and lets Lua compose the modules:
+
+- **`assay_run`** — run a Lua script (all embedded modules and builtins available) and return the
+  tool-mode JSON envelope. Every run is **gated**: `mode` accepts only `readonly` (default) or
+  `approval` — unrestricted execution is not offered, so a caller can never opt out of the gate.
+  Optional `timeout_secs` and `args`. Approval gates suspend and return a `requiresApproval` resume
+  token, resumable with `assay resume`.
+- **`assay_context`** — search the embedded modules and return prompt-ready Markdown docs (method
+  signatures, env vars, builtins), the same output as `assay context`.
+
+A script that errors — including a write blocked by read-only mode — comes back as an MCP result
+with `isError: true`; `needs_approval` is not an error. The server implements `initialize`,
+`tools/list`, `tools/call`, and `ping`, and shuts down cleanly on EOF.
+
 ## Auth + IdP quick-start
 
 Once `assay-engine` is running with the auth module enabled, every IdP capability is reachable over

--- a/SKILL.md
+++ b/SKILL.md
@@ -657,12 +657,12 @@ Run `assay context "grafana"` to get prompt-ready method signatures for any modu
 
 ## AI Agent Integration
 
-Assay integrates with all major AI coding agents via `assay context <query>` (today) or
-`assay mcp-serve` (v0.6.0).
+Assay integrates with all major AI coding agents via `assay context <query>` or the
+`assay mcp-serve` Model Context Protocol server (v0.17.0+).
 
 ### Claude Code
 
-Add to `.mcp.json` (Coming Soon — v0.6.0):
+Add to `.mcp.json`:
 
 ```json
 {
@@ -684,7 +684,7 @@ Example: `assay context "grafana"` returns all grafana client methods with types
 
 ### Cursor
 
-Add to `.cursor/mcp.json` (Coming Soon — v0.6.0):
+Add to `.cursor/mcp.json`:
 
 ```json
 {
@@ -696,7 +696,7 @@ Add to `.cursor/mcp.json` (Coming Soon — v0.6.0):
 
 ### Windsurf
 
-Add to `~/.codeium/windsurf/mcp_config.json` (Coming Soon — v0.6.0):
+Add to `~/.codeium/windsurf/mcp_config.json`:
 
 ```json
 {
@@ -708,19 +708,38 @@ Add to `~/.codeium/windsurf/mcp_config.json` (Coming Soon — v0.6.0):
 
 ### Cline / OpenCode
 
-Same pattern — `assay mcp-serve` exposes all modules as MCP tools (v0.6.0).
+Same pattern — point the client at `assay mcp-serve`.
 
-Today: use `assay context <query>` from terminal and paste output into agent context.
+Alternatively, use `assay context <query>` from the terminal and paste the output into the agent
+context.
 
-## MCP-Serve Vision (v0.6.0)
+## MCP Server (`assay mcp-serve`)
 
-`assay mcp-serve` will expose all 65 modules (45 stdlib + 20 builtins) as MCP tools over stdio/SSE
-transport:
+`assay mcp-serve` runs a Model Context Protocol server over stdio (JSON-RPC 2.0, newline-delimited
+messages). Instead of exposing one tool per module — which would balloon the advertised schema as
+modules are added — it presents exactly **two tools** and lets Lua compose the modules:
 
-- Each stdlib module becomes an MCP tool (e.g., `grafana_health`, `k8s_pods`)
-- Each builtin becomes an MCP tool (e.g., `http_get`, `crypto_jwt_sign`)
-- Agents call tools directly — no Lua scripting required for simple queries
-- Lua scripting still available for complex multi-step workflows
+| Tool            | Purpose                                                                               |
+| --------------- | ------------------------------------------------------------------------------------- |
+| `assay_run`     | Run a Lua script; returns the tool-mode JSON envelope. All modules + builtins usable. |
+| `assay_context` | Search modules; returns prompt-ready Markdown docs (same as `assay context`).         |
 
-Until v0.6.0: use `assay context <query>` + paste into agent context window. See
-https://assay.rs/agent-guides.html for complete integration examples.
+`assay_run` input schema:
+
+| Field          | Type                         | Notes                                                                                  |
+| -------------- | ---------------------------- | -------------------------------------------------------------------------------------- |
+| `script`       | string (required)            | Lua source. `return` a value to surface it as the tool output.                         |
+| `mode`         | `"readonly"` \| `"approval"` | Required, default `readonly`. **`unrestricted` is not accepted** — every run is gated. |
+| `timeout_secs` | number (optional)            | Max execution seconds (default 20).                                                    |
+| `args`         | string[] (optional)          | Positional args exposed to the script as the 1-indexed `arg` global.                   |
+
+`assay_run` returns the same envelope as `assay run --mode tool`: `status` is `ok`, `needs_approval`
+(with a `requiresApproval` resume token when an approval gate is hit), or `error`. A tool call whose
+script errors — including a write blocked by read-only mode — returns an MCP result with
+`isError: true`; `needs_approval` is not an error. Resume an approval gate out of band with
+`assay resume --token <token> --approve yes|no`.
+
+`assay_context` input schema: `query` (string, required) and `limit` (number, optional, default 5).
+
+The server implements `initialize`, `tools/list`, `tools/call`, and `ping`, and shuts down cleanly
+when stdin closes. See https://assay.rs/agent-guides.html for complete integration examples.

--- a/crates/assay/Cargo.toml
+++ b/crates/assay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-lua"
-version = "0.16.10"
+version = "0.17.0"
 categories = ["command-line-utilities", "development-tools::testing"]
 edition = "2024"
 homepage = "https://assay.rs"

--- a/crates/assay/src/main.rs
+++ b/crates/assay/src/main.rs
@@ -2,6 +2,7 @@ mod checks;
 mod cli;
 mod config;
 mod lua;
+mod mcp;
 mod output;
 mod runner;
 
@@ -159,6 +160,15 @@ enum Commands {
         /// Target shell.
         shell: clap_complete::Shell,
     },
+    /// Run a Model Context Protocol server over stdio.
+    ///
+    /// Speaks JSON-RPC 2.0 over stdin/stdout and exposes two tools:
+    ///   assay_run     — execute a gated Lua script (readonly | approval)
+    ///   assay_context — prompt-ready module docs for discovery
+    ///
+    /// The single `assay_run` tool composes all embedded modules through
+    /// Lua, so the exposed schema stays tiny regardless of module count.
+    McpServe,
 }
 
 /// Global flags shared by `workflow` / `schedule` / `namespace` / `worker` /
@@ -704,6 +714,7 @@ async fn main() -> ExitCode {
             }
         }
         Some(Commands::Install(args)) => install::run(args).await,
+        Some(Commands::McpServe) => mcp::serve().await,
         Some(Commands::Completion { shell }) => {
             use clap::CommandFactory;
             let mut cmd = Cli::command();
@@ -908,6 +919,31 @@ async fn run_lua_tool_mode(
     exec_mode: lua::ExecMode,
     approval: &lua::ApprovalConfig,
 ) -> ExitCode {
+    let outcome =
+        execute_tool_mode(path, script, timeout_secs, script_args, exec_mode, approval).await;
+    print!("{}", outcome.envelope);
+    ExitCode::SUCCESS
+}
+
+/// Result of a tool-mode run: the serialized JSON envelope plus its
+/// `status` field. Shared by the CLI (prints `envelope`) and the MCP
+/// server (surfaces `envelope` as tool content, maps `status` to isError).
+pub struct ToolModeOutcome {
+    pub envelope: String,
+    pub status: &'static str,
+}
+
+/// Execute a Lua script in tool mode and return the JSON envelope without
+/// emitting it. `status` mirrors the envelope's own field: "ok",
+/// "needs_approval", "error", or "timeout".
+async fn execute_tool_mode(
+    path: &std::path::Path,
+    script: &str,
+    timeout_secs: u64,
+    script_args: Vec<String>,
+    exec_mode: lua::ExecMode,
+    approval: &lua::ApprovalConfig,
+) -> ToolModeOutcome {
     let readonly = exec_mode.is_readonly();
     // Under a gate (read-only or approval) `env.set` is itself gated, so
     // the mode marker is injected through the check-env table rather than a
@@ -932,8 +968,10 @@ async fn run_lua_tool_mode(
     ) {
         Ok(vm) => vm,
         Err(e) => {
-            emit_tool_error("error", format!("creating Lua VM: {e:#}"), readonly);
-            return ExitCode::SUCCESS;
+            return ToolModeOutcome {
+                envelope: build_tool_error("error", format!("creating Lua VM: {e:#}"), readonly),
+                status: "error",
+            };
         }
     };
 
@@ -941,14 +979,22 @@ async fn run_lua_tool_mode(
         let mode_env =
             std::collections::HashMap::from([("ASSAY_MODE".to_string(), "tool".to_string())]);
         if let Err(e) = lua::inject_env(&vm, &mode_env) {
-            emit_tool_error("error", format!("injecting ASSAY_MODE: {e:#}"), readonly);
-            return ExitCode::SUCCESS;
+            return ToolModeOutcome {
+                envelope: build_tool_error(
+                    "error",
+                    format!("injecting ASSAY_MODE: {e:#}"),
+                    readonly,
+                ),
+                status: "error",
+            };
         }
     }
 
     if let Err(e) = install_script_args(&vm, path, &script_args) {
-        emit_tool_error("error", format!("installing arg global: {e}"), readonly);
-        return ExitCode::SUCCESS;
+        return ToolModeOutcome {
+            envelope: build_tool_error("error", format!("installing arg global: {e}"), readonly),
+            status: "error",
+        };
     }
 
     let local = tokio::task::LocalSet::new();
@@ -963,14 +1009,18 @@ async fn run_lua_tool_mode(
 
     match result {
         Ok(Ok(value)) => match lua_value_to_json(&vm, value) {
-            Ok(output) => {
-                emit_tool_success(output, readonly);
-                ExitCode::SUCCESS
-            }
-            Err(e) => {
-                emit_tool_error("error", format!("serializing Lua result: {e}"), readonly);
-                ExitCode::SUCCESS
-            }
+            Ok(output) => ToolModeOutcome {
+                envelope: build_tool_success(output, readonly),
+                status: "ok",
+            },
+            Err(e) => ToolModeOutcome {
+                envelope: build_tool_error(
+                    "error",
+                    format!("serializing Lua result: {e}"),
+                    readonly,
+                ),
+                status: "error",
+            },
         },
         Ok(Err(e)) => {
             if let Some(request) = extract_approval_request(&e) {
@@ -981,22 +1031,30 @@ async fn run_lua_tool_mode(
                     &approval.approved_indices,
                     &script_args,
                 ) {
-                    Ok(requires_approval) => emit_tool_needs_approval(requires_approval, readonly),
-                    Err(err) => emit_tool_error("error", err, readonly),
+                    Ok(requires_approval) => ToolModeOutcome {
+                        envelope: build_tool_needs_approval(requires_approval, readonly),
+                        status: "needs_approval",
+                    },
+                    Err(err) => ToolModeOutcome {
+                        envelope: build_tool_error("error", err, readonly),
+                        status: "error",
+                    },
                 }
             } else {
-                emit_tool_error("error", format_lua_error(&e), readonly);
+                ToolModeOutcome {
+                    envelope: build_tool_error("error", format_lua_error(&e), readonly),
+                    status: "error",
+                }
             }
-            ExitCode::SUCCESS
         }
-        Err(_) => {
-            emit_tool_error(
+        Err(_) => ToolModeOutcome {
+            envelope: build_tool_error(
                 "timeout",
                 format!("execution timed out after {timeout_secs}s"),
                 readonly,
-            );
-            ExitCode::SUCCESS
-        }
+            ),
+            status: "timeout",
+        },
     }
 }
 
@@ -1281,7 +1339,7 @@ fn unix_timestamp_now() -> u64 {
         .as_secs()
 }
 
-fn emit_tool_success(output: JsonValue, readonly: bool) {
+fn build_tool_success(output: JsonValue, readonly: bool) -> String {
     let mut envelope = ToolSuccessEnvelope {
         ok: true,
         status: "ok",
@@ -1298,12 +1356,12 @@ fn emit_tool_success(output: JsonValue, readonly: bool) {
     }
 
     match serde_json::to_string(&envelope) {
-        Ok(serialized) => print!("{serialized}"),
-        Err(e) => emit_tool_error("error", format!("serializing tool envelope: {e}"), readonly),
+        Ok(serialized) => serialized,
+        Err(e) => build_tool_error("error", format!("serializing tool envelope: {e}"), readonly),
     }
 }
 
-fn emit_tool_needs_approval(requires_approval: JsonValue, readonly: bool) {
+fn build_tool_needs_approval(requires_approval: JsonValue, readonly: bool) -> String {
     let envelope = ToolSuccessEnvelope {
         ok: true,
         status: "needs_approval",
@@ -1314,8 +1372,8 @@ fn emit_tool_needs_approval(requires_approval: JsonValue, readonly: bool) {
     };
 
     match serde_json::to_string(&envelope) {
-        Ok(serialized) => print!("{serialized}"),
-        Err(err) => emit_tool_error(
+        Ok(serialized) => serialized,
+        Err(err) => build_tool_error(
             "error",
             format!("serializing tool envelope: {err}"),
             readonly,
@@ -1323,7 +1381,7 @@ fn emit_tool_needs_approval(requires_approval: JsonValue, readonly: bool) {
     }
 }
 
-fn emit_tool_error(status: &'static str, error_message: String, readonly: bool) {
+fn build_tool_error(status: &'static str, error_message: String, readonly: bool) -> String {
     let envelope = ToolErrorEnvelope {
         ok: false,
         status,
@@ -1331,12 +1389,15 @@ fn emit_tool_error(status: &'static str, error_message: String, readonly: bool) 
         readonly,
     };
 
-    match serde_json::to_string(&envelope) {
-        Ok(serialized) => print!("{serialized}"),
-        Err(e) => print!(
+    serde_json::to_string(&envelope).unwrap_or_else(|e| {
+        format!(
             "{{\"ok\":false,\"status\":\"error\",\"error\":\"serializing tool envelope: {e}\"}}"
-        ),
-    }
+        )
+    })
+}
+
+fn emit_tool_error(status: &'static str, error_message: String, readonly: bool) {
+    print!("{}", build_tool_error(status, error_message, readonly));
 }
 
 fn truncate_tool_envelope(mut envelope: ToolSuccessEnvelope) -> ToolSuccessEnvelope {
@@ -1427,6 +1488,22 @@ fn run_modules(exec_mode: lua::ExecMode) -> ExitCode {
 }
 
 fn run_context(query: &str, limit: usize) -> ExitCode {
+    match render_context(query, limit) {
+        Ok(output) => {
+            print!("{output}");
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            eprintln!("error: {e}");
+            ExitCode::from(1)
+        }
+    }
+}
+
+/// Render prompt-ready module context Markdown for `query`, returning the
+/// same text the `assay context` CLI prints. Shared by the CLI path and
+/// the MCP `assay_context` tool.
+fn render_context(query: &str, limit: usize) -> Result<String, String> {
     use assay::context::{ModuleContextEntry, QuickRefEntry, format_context};
     use assay::discovery::{discover_modules, search_modules};
 
@@ -1465,14 +1542,7 @@ fn run_context(query: &str, limit: usize) -> ExitCode {
         format_context(&entries)
     });
 
-    match handle.join() {
-        Ok(output) => {
-            print!("{output}");
-            ExitCode::SUCCESS
-        }
-        Err(_) => {
-            eprintln!("error: context search failed");
-            ExitCode::from(1)
-        }
-    }
+    handle
+        .join()
+        .map_err(|_| "context search failed".to_string())
 }

--- a/crates/assay/src/mcp.rs
+++ b/crates/assay/src/mcp.rs
@@ -1,0 +1,323 @@
+//! Model Context Protocol server over stdio (JSON-RPC 2.0).
+//!
+//! Exposes two tools — `assay_run` and `assay_context` — so an MCP client
+//! composes every embedded module through a single gated Lua entry point
+//! instead of one tool per module. Transport is newline-delimited JSON per
+//! the MCP stdio spec: one JSON-RPC message per line, no embedded newlines.
+
+use serde_json::{Value as JsonValue, json};
+use std::path::PathBuf;
+use std::process::ExitCode;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+use crate::lua;
+
+const SERVER_NAME: &str = "assay";
+const SERVER_VERSION: &str = env!("CARGO_PKG_VERSION");
+const DEFAULT_PROTOCOL_VERSION: &str = "2024-11-05";
+const DEFAULT_CONTEXT_LIMIT: usize = 5;
+
+static CALL_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+// JSON-RPC 2.0 error codes.
+const PARSE_ERROR: i64 = -32700;
+const INVALID_REQUEST: i64 = -32600;
+const METHOD_NOT_FOUND: i64 = -32601;
+const INVALID_PARAMS: i64 = -32602;
+
+/// Run the MCP server loop until stdin reaches EOF (clean shutdown).
+pub async fn serve() -> ExitCode {
+    let mut reader = BufReader::new(tokio::io::stdin());
+    let mut stdout = tokio::io::stdout();
+    let mut line = String::new();
+
+    loop {
+        line.clear();
+        match reader.read_line(&mut line).await {
+            Ok(0) => break, // Client closed stdin.
+            Ok(_) => {}
+            Err(e) => {
+                eprintln!("mcp: reading stdin: {e}");
+                return ExitCode::from(1);
+            }
+        }
+
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        let response = match serde_json::from_str::<JsonValue>(trimmed) {
+            Ok(request) => handle_message(request).await,
+            Err(_) => Some(error_response(JsonValue::Null, PARSE_ERROR, "parse error")),
+        };
+
+        if let Some(response) = response
+            && let Err(e) = write_message(&mut stdout, &response).await
+        {
+            eprintln!("mcp: writing stdout: {e}");
+            return ExitCode::from(1);
+        }
+    }
+
+    ExitCode::SUCCESS
+}
+
+/// Dispatch a single parsed JSON-RPC message. Returns `None` for
+/// notifications (requests without an `id`), which never get a reply.
+async fn handle_message(request: JsonValue) -> Option<JsonValue> {
+    let Some(id) = request.get("id").cloned() else {
+        return None; // Notification: fire-and-forget, acted on by none.
+    };
+
+    let method = match request.get("method").and_then(JsonValue::as_str) {
+        Some(m) => m,
+        None => return Some(error_response(id, INVALID_REQUEST, "missing method")),
+    };
+
+    let params = request.get("params").cloned().unwrap_or(JsonValue::Null);
+
+    let response = match method {
+        "initialize" => success_response(id, initialize_result(&params)),
+        "ping" => success_response(id, json!({})),
+        "tools/list" => success_response(id, tools_list_result()),
+        "tools/call" => handle_tools_call(id, params).await,
+        other => error_response(id, METHOD_NOT_FOUND, &format!("method not found: {other}")),
+    };
+    Some(response)
+}
+
+fn initialize_result(params: &JsonValue) -> JsonValue {
+    let protocol_version = params
+        .get("protocolVersion")
+        .and_then(JsonValue::as_str)
+        .filter(|v| !v.is_empty())
+        .unwrap_or(DEFAULT_PROTOCOL_VERSION);
+
+    json!({
+        "protocolVersion": protocol_version,
+        "capabilities": { "tools": {} },
+        "serverInfo": { "name": SERVER_NAME, "version": SERVER_VERSION },
+    })
+}
+
+fn tools_list_result() -> JsonValue {
+    json!({ "tools": [assay_run_tool(), assay_context_tool()] })
+}
+
+fn assay_run_tool() -> JsonValue {
+    json!({
+        "name": "assay_run",
+        "description": "Run a Lua script through the assay runtime and return the tool-mode JSON envelope (status ok | needs_approval | error). Every embedded assay module is available via require(\"assay.<module>\") alongside the builtins (http, json, fs, crypto, ...). Execution is always gated: 'readonly' blocks mutating builtins, 'approval' suspends each mutating operation and returns a resume token. Unrestricted execution is intentionally not exposed.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "script": {
+                    "type": "string",
+                    "description": "Lua source to execute. Return a table or value to surface it as the tool output.",
+                },
+                "mode": {
+                    "type": "string",
+                    "enum": ["readonly", "approval"],
+                    "default": "readonly",
+                    "description": "Execution gate. 'readonly' (default) blocks mutating builtins; 'approval' suspends each mutating operation for per-operation approval. 'unrestricted' is not accepted.",
+                },
+                "timeout_secs": {
+                    "type": "number",
+                    "description": "Maximum execution time in seconds (default 20).",
+                },
+                "args": {
+                    "type": "array",
+                    "items": { "type": "string" },
+                    "description": "Positional arguments exposed to the script as the 1-indexed `arg` global.",
+                },
+            },
+            "required": ["script", "mode"],
+        },
+    })
+}
+
+fn assay_context_tool() -> JsonValue {
+    json!({
+        "name": "assay_context",
+        "description": "Search assay's embedded modules and return prompt-ready Markdown docs (method signatures, env vars, builtins) for the matches. Call this before writing an assay_run script to discover the correct module APIs.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "query": {
+                    "type": "string",
+                    "description": "Module search query, e.g. 'grafana', 'kubernetes', 'oauth'.",
+                },
+                "limit": {
+                    "type": "number",
+                    "description": "Maximum number of modules to return (default 5).",
+                },
+            },
+            "required": ["query"],
+        },
+    })
+}
+
+async fn handle_tools_call(id: JsonValue, params: JsonValue) -> JsonValue {
+    let arguments = params
+        .get("arguments")
+        .cloned()
+        .unwrap_or_else(|| json!({}));
+
+    match params.get("name").and_then(JsonValue::as_str) {
+        Some("assay_run") => match call_assay_run(&arguments).await {
+            Ok(result) => success_response(id, result),
+            Err(message) => success_response(id, tool_error_content(message)),
+        },
+        Some("assay_context") => match call_assay_context(&arguments) {
+            Ok(result) => success_response(id, result),
+            Err(message) => success_response(id, tool_error_content(message)),
+        },
+        Some(other) => error_response(id, INVALID_PARAMS, &format!("unknown tool: {other}")),
+        None => error_response(id, INVALID_PARAMS, "missing tool name"),
+    }
+}
+
+async fn call_assay_run(arguments: &JsonValue) -> Result<JsonValue, String> {
+    let script = arguments
+        .get("script")
+        .and_then(JsonValue::as_str)
+        .ok_or_else(|| "assay_run requires a 'script' string argument".to_string())?;
+
+    let exec_mode = resolve_mode(arguments.get("mode"))?;
+
+    let timeout_secs = arguments
+        .get("timeout_secs")
+        .and_then(JsonValue::as_u64)
+        .unwrap_or(crate::DEFAULT_TOOL_TIMEOUT_SECS);
+
+    let script_args = parse_string_array(arguments.get("args"));
+
+    let approval = if exec_mode.is_approval() {
+        lua::approval_config_from_env()
+    } else {
+        lua::ApprovalConfig::default()
+    };
+
+    let script_file = write_temp_script(script).map_err(|e| format!("writing temp script: {e}"))?;
+    let stripped = lua::async_bridge::strip_shebang(script);
+
+    let outcome = crate::execute_tool_mode(
+        &script_file.path,
+        stripped,
+        timeout_secs,
+        script_args,
+        exec_mode,
+        &approval,
+    )
+    .await;
+
+    // Keep the script on disk only while an approval gate still references
+    // it through a resume token; otherwise clean it up eagerly.
+    if outcome.status != "needs_approval" {
+        script_file.cleanup();
+    }
+
+    let is_error = !matches!(outcome.status, "ok" | "needs_approval");
+    Ok(tool_text_content(outcome.envelope, is_error))
+}
+
+fn call_assay_context(arguments: &JsonValue) -> Result<JsonValue, String> {
+    let query = arguments
+        .get("query")
+        .and_then(JsonValue::as_str)
+        .ok_or_else(|| "assay_context requires a 'query' string argument".to_string())?;
+
+    let limit = arguments
+        .get("limit")
+        .and_then(JsonValue::as_u64)
+        .map(|n| n as usize)
+        .filter(|n| *n > 0)
+        .unwrap_or(DEFAULT_CONTEXT_LIMIT);
+
+    let markdown = crate::render_context(query, limit)?;
+    Ok(tool_text_content(markdown, false))
+}
+
+/// Map the requested mode to an `ExecMode`. An absent mode defaults to
+/// read-only so a caller can never fall through to unrestricted execution;
+/// `unrestricted` (or any other value) is rejected.
+fn resolve_mode(value: Option<&JsonValue>) -> Result<lua::ExecMode, String> {
+    match value {
+        None | Some(JsonValue::Null) => Ok(lua::ExecMode::ReadOnly),
+        Some(JsonValue::String(mode)) => match mode.as_str() {
+            "readonly" => Ok(lua::ExecMode::ReadOnly),
+            "approval" => Ok(lua::ExecMode::Approval),
+            other => Err(format!(
+                "mode must be \"readonly\" or \"approval\"; \"{other}\" is not accepted (unrestricted execution is never exposed)"
+            )),
+        },
+        Some(_) => Err("mode must be a string: \"readonly\" or \"approval\"".to_string()),
+    }
+}
+
+fn parse_string_array(value: Option<&JsonValue>) -> Vec<String> {
+    value
+        .and_then(JsonValue::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .filter_map(|v| v.as_str().map(str::to_owned))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn tool_text_content(text: String, is_error: bool) -> JsonValue {
+    json!({
+        "content": [{ "type": "text", "text": text }],
+        "isError": is_error,
+    })
+}
+
+fn tool_error_content(message: String) -> JsonValue {
+    tool_text_content(message, true)
+}
+
+fn success_response(id: JsonValue, result: JsonValue) -> JsonValue {
+    json!({ "jsonrpc": "2.0", "id": id, "result": result })
+}
+
+fn error_response(id: JsonValue, code: i64, message: &str) -> JsonValue {
+    json!({ "jsonrpc": "2.0", "id": id, "error": { "code": code, "message": message } })
+}
+
+async fn write_message(stdout: &mut tokio::io::Stdout, message: &JsonValue) -> std::io::Result<()> {
+    let mut bytes = serde_json::to_vec(message).unwrap_or_else(|_| b"{}".to_vec());
+    bytes.push(b'\n');
+    stdout.write_all(&bytes).await?;
+    stdout.flush().await
+}
+
+/// A Lua script materialised on disk for a single `assay_run` call. The
+/// path feeds the tool-mode runner and any resume token it persists.
+struct TempScript {
+    path: PathBuf,
+    dir: PathBuf,
+}
+
+impl TempScript {
+    fn cleanup(&self) {
+        let _ = std::fs::remove_dir_all(&self.dir);
+    }
+}
+
+fn write_temp_script(script: &str) -> std::io::Result<TempScript> {
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let seq = CALL_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let dir = std::env::temp_dir().join(format!("assay-mcp-{nonce}-{seq}"));
+    std::fs::create_dir_all(&dir)?;
+    let path = dir.join("script.lua");
+    std::fs::write(&path, script)?;
+    Ok(TempScript { path, dir })
+}

--- a/crates/assay/tests/mcp_serve.rs
+++ b/crates/assay/tests/mcp_serve.rs
@@ -1,0 +1,250 @@
+// Exercises `assay mcp-serve`: spawn the binary, speak newline-delimited
+// JSON-RPC 2.0 over its stdio, and assert the MCP handshake, tool listing,
+// and both tools (assay_run + assay_context) behave as specified.
+
+use serde_json::{Value, json};
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
+
+struct McpServer {
+    child: Child,
+    stdin: ChildStdin,
+    stdout: BufReader<ChildStdout>,
+    next_id: i64,
+}
+
+impl McpServer {
+    fn start() -> Self {
+        let mut child = Command::new(env!("CARGO_BIN_EXE_assay"))
+            .arg("mcp-serve")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            // Per-call modes drive the gate; never inherit a process-wide one.
+            .env_remove("ASSAY_READONLY")
+            .env_remove("ASSAY_APPROVAL")
+            .env_remove("ASSAY_MODE")
+            .spawn()
+            .unwrap();
+        let stdin = child.stdin.take().unwrap();
+        let stdout = BufReader::new(child.stdout.take().unwrap());
+        McpServer {
+            child,
+            stdin,
+            stdout,
+            next_id: 0,
+        }
+    }
+
+    fn request(&mut self, method: &str, params: Value) -> Value {
+        self.next_id += 1;
+        let id = self.next_id;
+        let msg = json!({ "jsonrpc": "2.0", "id": id, "method": method, "params": params });
+        writeln!(self.stdin, "{}", serde_json::to_string(&msg).unwrap()).unwrap();
+        self.stdin.flush().unwrap();
+
+        let mut line = String::new();
+        let n = self.stdout.read_line(&mut line).unwrap();
+        assert!(n > 0, "server closed stdout without answering {method}");
+        let resp: Value = serde_json::from_str(line.trim())
+            .unwrap_or_else(|e| panic!("invalid JSON-RPC response to {method}: {e}: {line}"));
+        assert_eq!(resp["jsonrpc"], "2.0", "response: {resp}");
+        assert_eq!(resp["id"], json!(id), "response id mismatch: {resp}");
+        resp
+    }
+
+    fn initialize(&mut self) -> Value {
+        self.request(
+            "initialize",
+            json!({
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": { "name": "test-client", "version": "0.0.0" },
+            }),
+        )
+    }
+
+    fn call_tool(&mut self, name: &str, arguments: Value) -> Value {
+        self.request(
+            "tools/call",
+            json!({ "name": name, "arguments": arguments }),
+        )
+    }
+}
+
+impl Drop for McpServer {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+/// Pull the single text content block out of an MCP tool result.
+fn text_content(result: &Value) -> &str {
+    result["content"][0]["text"]
+        .as_str()
+        .unwrap_or_else(|| panic!("tool result missing text content: {result}"))
+}
+
+#[test]
+fn initialize_handshake() {
+    let mut server = McpServer::start();
+    let resp = server.initialize();
+    let result = &resp["result"];
+
+    assert_eq!(result["serverInfo"]["name"], "assay");
+    let version = result["serverInfo"]["version"].as_str().unwrap();
+    assert!(!version.is_empty(), "serverInfo.version should be set");
+    assert_eq!(result["protocolVersion"], "2024-11-05");
+    assert!(
+        result["capabilities"]["tools"].is_object(),
+        "capabilities.tools should advertise tool support: {result}"
+    );
+}
+
+#[test]
+fn tools_list_advertises_both_tools_with_schemas() {
+    let mut server = McpServer::start();
+    server.initialize();
+
+    let resp = server.request("tools/list", json!({}));
+    let tools = resp["result"]["tools"].as_array().unwrap();
+
+    let names: Vec<&str> = tools.iter().filter_map(|t| t["name"].as_str()).collect();
+    assert!(names.contains(&"assay_run"), "missing assay_run: {names:?}");
+    assert!(
+        names.contains(&"assay_context"),
+        "missing assay_context: {names:?}"
+    );
+
+    let run = tools.iter().find(|t| t["name"] == "assay_run").unwrap();
+    let schema = &run["inputSchema"];
+    assert_eq!(schema["type"], "object");
+    assert!(schema["properties"]["script"].is_object());
+    let modes = schema["properties"]["mode"]["enum"].as_array().unwrap();
+    let modes: Vec<&str> = modes.iter().filter_map(Value::as_str).collect();
+    assert!(modes.contains(&"readonly"), "modes: {modes:?}");
+    assert!(modes.contains(&"approval"), "modes: {modes:?}");
+    assert!(
+        !modes.contains(&"unrestricted"),
+        "unrestricted must never be offered: {modes:?}"
+    );
+
+    let ctx = tools.iter().find(|t| t["name"] == "assay_context").unwrap();
+    assert!(ctx["inputSchema"]["properties"]["query"].is_object());
+    assert_eq!(ctx["inputSchema"]["required"][0], "query");
+}
+
+#[test]
+fn assay_run_readonly_ok_envelope() {
+    let mut server = McpServer::start();
+    server.initialize();
+
+    let resp = server.call_tool(
+        "assay_run",
+        json!({ "script": "return 1 + 1", "mode": "readonly" }),
+    );
+    let result = &resp["result"];
+    assert_eq!(result["isError"], json!(false), "result: {result}");
+
+    let envelope: Value = serde_json::from_str(text_content(result)).unwrap();
+    assert_eq!(envelope["ok"], json!(true), "envelope: {envelope}");
+    assert_eq!(envelope["status"], "ok");
+    assert_eq!(envelope["output"], json!(2));
+    assert_eq!(envelope["readonly"], json!(true));
+}
+
+#[test]
+fn assay_run_rejects_unrestricted_mode() {
+    let mut server = McpServer::start();
+    server.initialize();
+
+    let resp = server.call_tool(
+        "assay_run",
+        json!({ "script": "return 1", "mode": "unrestricted" }),
+    );
+    let result = &resp["result"];
+    assert_eq!(
+        result["isError"],
+        json!(true),
+        "unrestricted mode must be rejected: {result}"
+    );
+    assert!(
+        text_content(result).contains("unrestricted"),
+        "rejection should explain the gate: {result}"
+    );
+}
+
+#[test]
+fn assay_run_readonly_blocks_write_op() {
+    let mut server = McpServer::start();
+    server.initialize();
+
+    let resp = server.call_tool(
+        "assay_run",
+        json!({
+            "script": r#"fs.write("/tmp/assay-mcp-readonly-probe", "x")"#,
+            "mode": "readonly",
+        }),
+    );
+    let result = &resp["result"];
+    assert_eq!(result["isError"], json!(true), "result: {result}");
+
+    let envelope: Value = serde_json::from_str(text_content(result)).unwrap();
+    assert_eq!(envelope["ok"], json!(false), "envelope: {envelope}");
+    assert_eq!(envelope["status"], "error");
+    let error = envelope["error"].as_str().unwrap();
+    assert!(
+        error.contains("readonly: fs.write blocked"),
+        "should surface the read-only block, not crash: {error}"
+    );
+}
+
+#[test]
+fn assay_context_returns_markdown() {
+    let mut server = McpServer::start();
+    server.initialize();
+
+    let resp = server.call_tool("assay_context", json!({ "query": "grafana" }));
+    let result = &resp["result"];
+    assert_eq!(result["isError"], json!(false), "result: {result}");
+
+    let markdown = text_content(result);
+    assert!(
+        markdown.contains("Assay Module Context"),
+        "markdown header missing: {markdown}"
+    );
+    assert!(
+        markdown.to_lowercase().contains("grafana"),
+        "expected the grafana module in the docs: {markdown}"
+    );
+}
+
+#[test]
+fn unknown_method_returns_json_rpc_error() {
+    let mut server = McpServer::start();
+    server.initialize();
+
+    let resp = server.request("does/not/exist", json!({}));
+    assert_eq!(resp["error"]["code"], json!(-32601), "response: {resp}");
+    assert!(resp.get("result").is_none(), "response: {resp}");
+}
+
+#[test]
+fn eof_triggers_clean_shutdown() {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_assay"))
+        .arg("mcp-serve")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap();
+
+    // Close stdin immediately; the server should exit 0 on EOF.
+    drop(child.stdin.take());
+    let status = child.wait().unwrap();
+    assert!(
+        status.success(),
+        "clean shutdown should exit zero: {status}"
+    );
+}


### PR DESCRIPTION
Part of #183; makes the `mcp-serve` claim in SKILL.md real (#179).

## What

`assay mcp-serve` runs a Model Context Protocol server over stdio (JSON-RPC 2.0, newline-delimited — the MCP stdio transport) exposing **two** tools, so a client composes all 57 embedded modules through one gated Lua entry point instead of one tool per module:

- **`assay_run(script, mode, timeout_secs?, args?)`** — runs Lua through the existing tool-mode path and returns the tool-mode JSON envelope (`ok` | `needs_approval` + resume token | `error`). `mode` is `readonly` (default) or `approval`; **`unrestricted` is never exposed or accepted** — an absent/unknown mode can only resolve to read-only, so a caller can't opt out of the gate. `isError` = not (ok | needs_approval).
- **`assay_context(query, limit?)`** — returns prompt-ready module docs (reuses `render_context`) for on-demand API discovery.

## How

- Refactored the tool-mode runner into `execute_tool_mode(...) -> ToolModeOutcome` and the context renderer into `render_context(...) -> String`; the CLI paths are now thin wrappers, so `assay run --mode tool` / `assay context` output is byte-identical (tool_mode + context tests unchanged). No existing `pub` signature changed — additive, clean semver.
- Hand-rolled JSON-RPC on the existing `serde_json` + `tokio` deps rather than pulling `rmcp`. **Binary size: 9,180,656 → 9,213,840 bytes (+33 KB / ~0.4%)** — the point of not adding an SDK.

## Testing

- `cargo test -p assay-lua` full crate: **1270 passed / 0 failed** (exit 0). New `mcp_serve.rs`: 8 (initialize handshake, tools/list schemas without unrestricted, assay_run ok envelope, unrestricted rejected, readonly-write → error envelope not crash, assay_context non-empty, unknown method → -32601, EOF clean shutdown). tool_mode 16 / readonly_mode 20 / approval_mode 16 unchanged. Clippy `-D warnings` clean.
- Docs: 0.16.10 → 0.17.0, CHANGELOG section, SKILL.md `mcp-serve` section made real, README MCP subsection.

Note: release-checklist files (llms.txt, site pages) intentionally deferred to the actual 0.17.0 tag, not this feature branch.