### PR TITLE
feat(assay): Claude Code plugin wrapping the MCP server (0.17.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-marketplace.json",
+  "name": "assay",
+  "owner": {
+    "name": "developerinlondon",
+    "url": "https://github.com/developerinlondon"
+  },
+  "description": "The assay infrastructure toolkit as a Claude Code plugin.",
+  "plugins": [
+    {
+      "name": "assay",
+      "source": "./plugin",
+      "description": "Gated Lua infra toolkit — Kubernetes, ArgoCD, Vault, Prometheus, GitLab, AWS and more through one read-only/approval-gated tool.",
+      "version": "0.17.0"
+    }
+  ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to Assay are documented here.
 
 ### Added
 
+- plugin: ship a Claude Code plugin (`plugin/`) + marketplace (`.claude-plugin/marketplace.json`)
+  that wrap the MCP server — `claude plugin marketplace add developerinlondon/assay` then
+  `claude plugin install assay` gives the gated `assay_run` + `assay_context` tools and a usage
+  skill. Requires the `assay` binary on PATH.
 - build: track the embedded `stdlib/` tree via `build.rs` `rerun-if-changed` so a stdlib-only change
   is never served from a stale build cache (persistent CI caches previously missed newly added
   modules).

--- a/README.md
+++ b/README.md
@@ -202,6 +202,17 @@ A script that errors — including a write blocked by read-only mode — comes b
 with `isError: true`; `needs_approval` is not an error. The server implements `initialize`,
 `tools/list`, `tools/call`, and `ping`, and shuts down cleanly on EOF.
 
+## Claude Code plugin
+
+Install assay as a Claude Code plugin — the `assay_run` + `assay_context` tools plus a usage skill, wrapping the MCP server:
+
+```bash
+claude plugin marketplace add developerinlondon/assay
+claude plugin install assay
+```
+
+The plugin (`plugin/`) declares the MCP server as `assay mcp-serve`, so the `assay` binary must be on `PATH` (install via `cargo install assay-lua` or a release binary). Every run is read-only or approval-gated; unrestricted execution is never exposed.
+
 ## Auth + IdP quick-start
 
 Once `assay-engine` is running with the auth module enabled, every IdP capability is reachable over

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "assay",
+  "version": "0.17.0",
+  "description": "Gated infrastructure toolkit. Run any embedded assay module (Kubernetes, ArgoCD, Vault, Prometheus, GitLab, AWS, and more) through one Lua tool that is always read-only or approval-gated — never unrestricted.",
+  "author": {
+    "name": "developerinlondon",
+    "url": "https://github.com/developerinlondon"
+  },
+  "homepage": "https://github.com/developerinlondon/assay",
+  "repository": "https://github.com/developerinlondon/assay",
+  "license": "Apache-2.0",
+  "keywords": [
+    "assay",
+    "lua",
+    "kubernetes",
+    "argocd",
+    "vault",
+    "prometheus",
+    "aws",
+    "infrastructure",
+    "mcp"
+  ],
+  "mcpServers": "./.mcp.json",
+  "skills": "./skills/"
+}

--- a/plugin/.mcp.json
+++ b/plugin/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "assay": {
+      "command": "assay",
+      "args": ["mcp-serve"]
+    }
+  }
+}

--- a/plugin/skills/assay/SKILL.md
+++ b/plugin/skills/assay/SKILL.md
@@ -1,0 +1,55 @@
+---
+description: Inspect and operate infrastructure — Kubernetes, ArgoCD, Vault, Prometheus, Alertmanager, GitLab, GitHub, AWS, Grafana, Loki, databases, and more — by writing short Lua scripts run through the gated `assay_run` tool. Use whenever a task needs to read or change cloud/cluster/CI state. Discover module APIs first with `assay_context`.
+---
+
+# assay — gated infrastructure toolkit
+
+This plugin exposes two MCP tools backed by the `assay` runtime. Instead of a
+separate tool per CLI, you compose infrastructure operations as small Lua
+scripts, and every run is gated.
+
+## The two tools
+
+- **`assay_context(query)`** — search assay's modules and return prompt-ready
+  docs (method signatures, return shapes, env vars). Call this FIRST to learn a
+  module's API before writing a script. Example queries: `kubernetes`,
+  `argocd`, `vault`, `prometheus`, `sonarqube`, `aws`.
+- **`assay_run(script, mode)`** — run a Lua script and get back a JSON envelope
+  (`status`: `ok` | `needs_approval` | `error`). Every embedded module is
+  available via `require("assay.<module>")` alongside the builtins (`http`,
+  `json`, `fs`, `crypto`, …). Return a value from the script to surface it.
+
+## Gating — always pick a mode
+
+- `mode = "readonly"` (default): mutating operations are blocked. Use this for
+  all investigation and inspection.
+- `mode = "approval"`: each mutating operation suspends and returns a resume
+  token so a human (or your caller) approves it per-operation. Use this only
+  when a change is intended.
+- Unrestricted execution is never available — you cannot bypass the gate.
+
+## How to work
+
+1. `assay_context("<service>")` to find the module and methods.
+2. Write a small Lua script that does the whole step (list → filter → correlate)
+   and `return` the result, so you get structured data in one call instead of
+   many.
+3. Run it with `assay_run(script, "readonly")`. If you intend a change, use
+   `"approval"` and handle the `needs_approval` envelope.
+
+### Example — read-only investigation
+
+```lua
+local k8s = require("assay.k8s")
+local pods = k8s.resources:list("pods", "my-namespace")
+local unhealthy = {}
+for _, p in ipairs(pods.items or {}) do
+  if p.status and p.status.phase ~= "Running" then
+    unhealthy[#unhealthy + 1] = { name = p.metadata.name, phase = p.status.phase }
+  end
+end
+return unhealthy
+```
+
+Prefer one composed script over many round-trips. Read the module docs with
+`assay_context` rather than guessing method names.


### PR DESCRIPTION
Part of #183. Ships assay as an installable Claude Code plugin — a thin wrapper over the `mcp-serve` MCP server (#184).

```
claude plugin marketplace add developerinlondon/assay
claude plugin install assay
```

## Contents
- `plugin/.claude-plugin/plugin.json` — the plugin manifest (name, 0.17.0, references `./.mcp.json` + `./skills/`).
- `plugin/.mcp.json` — declares the MCP server as `assay mcp-serve` (binary on PATH — the plugin is a thin wrapper, not a bundled per-platform binary; install assay via `cargo install assay-lua` or a release).
- `plugin/skills/assay/SKILL.md` — a usage skill: discover module APIs with `assay_context`, compose one gated Lua script with `assay_run`, always pick `readonly`/`approval`.
- `.claude-plugin/marketplace.json` — marketplace entry so the repo is `marketplace add`-able.

## Design
- **No enforcement hook.** The gate is intrinsic to `assay_run` (unrestricted is never exposed, default readonly), so a separate mode-enforcement hook would be redundant. Simpler and more robust.
- Domain-free (references only assay itself) per AGENTS.md.

## Verified
- All three JSON files validate.
- End-to-end smoke: piping `initialize` + `tools/list` into `assay mcp-serve` returns `serverInfo {name: assay, 0.17.0}` and `[assay_run, assay_context]` — the plugin's referenced command works.

Format followed the current Claude Code plugin/marketplace spec (`.claude-plugin/` for manifests, components at plugin root, `${CLAUDE_PLUGIN_ROOT}` not needed since the command is a PATH binary).