### PR TITLE
release: assay-lua 0.17.1 — publish modules + plugin stranded by the 0.17.0 tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to Assay are documented here.
 
-## assay 0.17.0 — 2026-07-05
+## assay 0.17.1 — 2026-07-05
 
 ### Added
 
@@ -13,6 +13,30 @@ All notable changes to Assay are documented here.
 - build: track the embedded `stdlib/` tree via `build.rs` `rerun-if-changed` so a stdlib-only change
   is never served from a stale build cache (persistent CI caches previously missed newly added
   modules).
+- Five API-client stdlib modules over the existing `http` and `aws.sigv4` builtins, extending the
+  batteries-included set to more infrastructure and cloud HTTP APIs:
+  - `assay.sonarqube` — SonarQube web API reads: quality-gate project status, issue and hotspot
+    search, component measures, project search. Bearer or basic auth. Read-only.
+  - `assay.servicenow` — ServiceNow Table API (`list` / `get` / `create` / `update`) plus a
+    `cmdb:query` helper. Basic or bearer auth. `create` / `update` mutate; `cmdb:query` is a lookup
+    that uses `POST` by API contract.
+  - `assay.infoblox` — Infoblox WAPI: DNS record / network / range reads and grid status, plus
+    record create / update / delete. Basic auth. Documents that the Grid CA must be trusted by the
+    runtime because the `http` builtin exposes no TLS-skip option.
+  - `assay.aws.ec2` — EC2 Query API reads over Signature V4: `describe_instances`,
+    `describe_volumes`, `describe_security_groups`. Read-only.
+  - `assay.aws.s3` — S3 reads over Signature V4: `list_buckets`, `list_objects`, `head_object`.
+    Read-only.
+
+  Every mutating method routes exclusively through the already-gated `http.post` / `put` / `patch` /
+  `delete` verbs, so read-only and approval modes classify them as mutations with no change to the
+  shared mutation catalog. Because that gate is verb-based, `servicenow.cmdb:query` (a `POST` that
+  reads) is also suspended in gated modes.
+
+## assay 0.17.0 — 2026-07-05
+
+### Added
+
 - `assay mcp-serve` — a Model Context Protocol server over stdio so AI coding agents (Claude Code,
   Cursor, Windsurf, Cline, and any MCP client) can drive the runtime directly. It speaks JSON-RPC
   2.0 over stdin/stdout with newline-delimited framing per the MCP stdio transport, implementing
@@ -33,25 +57,6 @@ All notable changes to Assay are documented here.
     error); malformed JSON-RPC returns a transport-level error response. Transport is hand-rolled on
     `serde_json` + `tokio` (both already dependencies) to keep the static binary size flat — no MCP
     SDK is pulled in.
-- Five API-client stdlib modules over the existing `http` and `aws.sigv4` builtins, extending the
-  batteries-included set to more infrastructure and cloud HTTP APIs:
-  - `assay.sonarqube` — SonarQube web API reads: quality-gate project status, issue and hotspot
-    search, component measures, project search. Bearer or basic auth. Read-only.
-  - `assay.servicenow` — ServiceNow Table API (`list` / `get` / `create` / `update`) plus a
-    `cmdb:query` helper. Basic or bearer auth. `create` / `update` mutate; `cmdb:query` is a lookup
-    that uses `POST` by API contract.
-  - `assay.infoblox` — Infoblox WAPI: DNS record / network / range reads and grid status, plus
-    record create / update / delete. Basic auth. Documents that the Grid CA must be trusted by the
-    runtime because the `http` builtin exposes no TLS-skip option.
-  - `assay.aws.ec2` — EC2 Query API reads over Signature V4: `describe_instances`,
-    `describe_volumes`, `describe_security_groups`. Read-only.
-  - `assay.aws.s3` — S3 reads over Signature V4: `list_buckets`, `list_objects`, `head_object`.
-    Read-only.
-
-  Every mutating method routes exclusively through the already-gated `http.post` / `put` / `patch` /
-  `delete` verbs, so read-only and approval modes classify them as mutations with no change to the
-  shared mutation catalog. Because that gate is verb-based, `servicenow.cmdb:query` (a `POST` that
-  reads) is also suspended in gated modes.
 
 ## assay 0.16.10 — 2026-07-05
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,7 +338,7 @@ dependencies = [
 
 [[package]]
 name = "assay-lua"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/assay/Cargo.toml
+++ b/crates/assay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-lua"
-version = "0.17.0"
+version = "0.17.1"
 categories = ["command-line-utilities", "development-tools::testing"]
 edition = "2024"
 homepage = "https://assay.rs"


### PR DESCRIPTION
`assay-lua 0.17.0` auto-released at the mcp-serve merge (#184, 16:00) — before the API-client modules (#185) and Claude plugin (#186) landed. Those added to the 0.17.0 changelog section without bumping the version string, so the release job saw 0.17.0 already published and no-op'd. **The modules are on main but in no published crate/binary/image.**

Bump to **0.17.1** to ship them. Changelog split to match reality:
- **0.17.0** (as published): `assay mcp-serve`.
- **0.17.1** (this): sonarqube / servicenow / infoblox / aws ec2·s3 modules, the stdlib build-cache fix (`build.rs rerun-if-changed`), and the Claude Code plugin.

Merging triggers the 0.17.1 release (crates.io + GHCR + GH release) with the modules embedded. Builds clean; additive-only, so semver-checks stays a clean patch bump.