### PR TITLE
docs(assay): correct stdlib module count + list new modules in llms.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ with 65 modules for Kubernetes, monitoring, secrets, and AI agents.
 Two binaries, one project. `FROM scratch`-shippable, PG18 + SQLite first-class. Sizes today: `assay`
 ~12 MB, `assay-engine` ~19 MB (the engine grew with the auth + IdP work in v0.2.0).
 
-- **`assay`** — Lua 5.5 runtime with 45 stdlib modules (Kubernetes, Prometheus, Vault, GitHub,
+- **`assay`** — Lua 5.5 runtime with 62 stdlib modules (Kubernetes, Prometheus, Vault, GitHub,
   Gmail, OpenClaw, Tailscale, …). Drop-in replacement for 50-250 MB Python/Node/kubectl scripting
   containers.
 - **`assay-engine`** — durable **workflow engine** (Temporal-replacement: deterministic-replay
@@ -51,7 +51,7 @@ jobs. The runtime talks to a deployed `assay-engine` over HTTP via the `assay.wo
 | `assay-engine` auth Zanzibar  | **Ory Keto / SpiceDB**    | Recursive-CTE walk on PG18 + SQLite                    |
 | `assay-engine` auth biscuit   | (Ory has nothing)         | Datalog-attenuable capability tokens — built-in        |
 | `assay-engine` dashboard      | Ory Console + Temporal UI | Single SPA, auth panes appear when auth is on          |
-| `assay` runtime               | Python / Node + kubectl   | 12 MB, 5 ms cold start, 45 stdlib modules              |
+| `assay` runtime               | Python / Node + kubectl   | 12 MB, 5 ms cold start, 62 stdlib modules              |
 
 ## Two binaries, two use cases
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -44,7 +44,7 @@ assay modules
 | `assay exec -e 'lua code'`  | Evaluate Lua inline                           |
 | `assay exec script.lua`     | Run Lua file via exec subcommand              |
 | `assay context "<keyword>"` | Find modules matching keyword, shows quickref |
-| `assay modules`             | List all 65 modules (45 stdlib + 20 builtins) |
+| `assay modules`             | List all 65 modules (62 stdlib + builtins)    |
 
 **Read-only mode.** The global `--readonly` flag (or `ASSAY_READONLY=1`) disables every mutating
 builtin — HTTP write verbs, `shell.*`, `process.*`, `fs` writes, `env.set`, `db.execute`, and system
@@ -358,7 +358,7 @@ embedding assay inside another admin UI. Full table + theme tokens in
 
 ## Stdlib Modules Quick Reference
 
-All 45 stdlib modules follow `require("assay.<name>")` then `M.client(url, opts)`.
+All 62 stdlib modules follow `require("assay.<name>")` then `M.client(url, opts)`.
 
 | Module               | Description                                                                                                                                                      |
 | -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -627,7 +627,7 @@ hardcode credentials in scripts.
 **Shebang scripts**: Add `#!/usr/bin/assay` as the first line and `chmod +x script.lua` to run
 scripts directly without the `assay` prefix.
 
-**Module not found**: All 45 stdlib modules are embedded in the binary. If `require("assay.foo")`
+**Module not found**: All 62 stdlib modules are embedded in the binary. If `require("assay.foo")`
 fails, run `assay modules` to see the exact module names.
 
 **Lua 5.5 specifics**: Assay uses Lua 5.5 (not LuaJIT). Integer division is `//`, bitwise ops use

--- a/site/static/llms.txt
+++ b/site/static/llms.txt
@@ -32,6 +32,7 @@
 - [assay.alertmanager](https://assay.rs/modules/alertmanager.html): Alert management, silences, receivers
 - [assay.loki](https://assay.rs/modules/loki.html): Log push, query, labels, series
 - [assay.grafana](https://assay.rs/modules/grafana.html): Health, dashboards, datasources, annotations
+- [assay.sonarqube](https://assay.rs/modules/sonarqube.html): SonarQube quality gates, issues, hotspots, measures
 
 ## Kubernetes & GitOps
 - [assay.k8s](https://assay.rs/modules/k8s.html): 30+ K8s resource types, CRDs, readiness checks
@@ -55,10 +56,14 @@
 - [assay.velero](https://assay.rs/modules/velero.html): Velero backups, restores, schedules
 - [assay.workflow](https://assay.rs/modules/workflow.html): Native durable workflow engine — `assay serve` runs REST+SSE+dashboard; `require("assay.workflow")` registers handlers; namespace-scoped, JWT/API-key auth, dashboard whitelabel via ASSAY_WHITELABEL_* env vars
 - [assay.harbor](https://assay.rs/modules/harbor.html): Harbor registry, projects, vulnerability scanning
+- [assay.infoblox](https://assay.rs/modules/infoblox.html): Infoblox WAPI — DNS records, networks, ranges, grid status
+- [assay.servicenow](https://assay.rs/modules/servicenow.html): ServiceNow Table API + CMDB lookups
 
 ## Data & Storage
 - [assay.postgres](https://assay.rs/modules/postgres.html): PostgreSQL helpers, user management
 - [assay.s3](https://assay.rs/modules/s3.html): S3-compatible storage (AWS, R2, MinIO) with Sig V4
+- [assay.aws.ec2](https://assay.rs/modules/aws-ec2.html): AWS EC2 read queries over Sig V4 — instances, volumes, security groups
+- [assay.aws.s3](https://assay.rs/modules/aws-s3.html): AWS S3 read over Sig V4 — list buckets/objects, head object
 
 ## Feature Flags & Utilities
 - [assay.unleash](https://assay.rs/modules/unleash.html): Unleash feature flags, environments, strategies


### PR DESCRIPTION
Addresses the stale module counts flagged post-0.17.1 (part of #179).

- `45 stdlib modules` → `62 stdlib modules` (actual `.lua` count) across SKILL.md + README; the old `45 + 20 = 65` math never reconciled.
- Added `sonarqube`, `servicenow`, `infoblox`, `aws.ec2`, `aws.s3` to the curated `llms.txt` highlights (they were missing).
- The generated site (65 module pages) + the README stdlib table already carry all modules; SKILL.md's module table already has the 5 rows (added in #185). Docs-only, no crate change.