### PR TITLE
feat(assay): complete the MCP execution model — 3rd mode (opt-in) + assay_resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to Assay are documented here.
 
 ### Added
 
+- **`assay_resume` MCP tool — the suspend→approve→resume loop now lives entirely in the MCP API.**
+  `assay_run(mode: "approval")` already returns a `needs_approval` envelope with a `resumeToken` when
+  a mutating operation suspends; the new `assay_resume` tool takes that token plus `approve: true|false`
+  and returns the next envelope (`ok` on completion, `needs_approval` again with a fresh token if the
+  run suspends on the next operation, or `error`). Previously resuming was only possible via the
+  `assay resume` CLI subcommand, so an MCP host had to shell out; now a host can drive the whole
+  gated flow over the API and interpose its own approver between run and resume. Internally,
+  `resume_tool_execution` is refactored to a shared `resume_tool_outcome` that returns the envelope
+  (mirroring `execute_tool_mode`), with the CLI now a thin wrapper that prints it.
 - **`ASSAY_MCP_UNRESTRICTED` — opt-in exposure of the third execution mode over MCP.** By default
   `assay mcp-serve` still advertises and accepts only `readonly` + `approval`, so every MCP client
   stays safe by default and can never fall through to unrestricted execution. When the server is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to Assay are documented here.
 
+## Unreleased
+
+### Added
+
+- **`ASSAY_MCP_UNRESTRICTED` — opt-in exposure of the third execution mode over MCP.** By default
+  `assay mcp-serve` still advertises and accepts only `readonly` + `approval`, so every MCP client
+  stays safe by default and can never fall through to unrestricted execution. When the server is
+  started with `ASSAY_MCP_UNRESTRICTED=1` (or `true`), the `assay_run` tool additionally offers and
+  accepts `mode: "unrestricted"` (the always-existing `ExecMode::Unrestricted`, previously reachable
+  only from the CLI). Intended for a host that gates access itself — resolving the caller's allowed
+  mode from its own policy before ever passing `unrestricted` — rather than trusting the model. The
+  advertised `mode` enum and the tool description track the flag, so a client only ever sees a mode
+  it can actually request.
+
 ## assay 0.17.2 — 2026-07-06
 
 ### Added

--- a/crates/assay/src/main.rs
+++ b/crates/assay/src/main.rs
@@ -1058,53 +1058,50 @@ async fn execute_tool_mode(
     }
 }
 
-async fn resume_tool_execution(
+/// Resume a suspended tool-mode run and RETURN its envelope without emitting
+/// it. Shared by the CLI `resume` command (which prints the envelope) and the
+/// MCP `assay_resume` tool (which surfaces it as tool content). `approve` is
+/// "yes" to approve the pending operation, anything else to deny it. The
+/// child's stderr is forwarded as diagnostics; its stdout is the resumed run's
+/// JSON envelope, returned here with its parsed `status`.
+async fn resume_tool_outcome(
     token: &str,
     approve: &str,
     resume_ttl: Option<u64>,
     readonly: bool,
-) -> ExitCode {
+) -> ToolModeOutcome {
+    let err_outcome = |message: String| ToolModeOutcome {
+        envelope: build_tool_error("error", message, readonly),
+        status: "error",
+    };
+
     let state_dir = match resolve_state_dir() {
         Ok(dir) => dir,
-        Err(err) => {
-            emit_tool_error("error", err, readonly);
-            return ExitCode::SUCCESS;
-        }
+        Err(err) => return err_outcome(err),
     };
 
     let state_path = state_dir.join("resume").join(format!("{token}.json"));
     if !state_path.exists() {
-        emit_tool_error("error", "invalid resume token".to_string(), readonly);
-        return ExitCode::SUCCESS;
+        return err_outcome("invalid resume token".to_string());
     }
 
     let state = match fs::read_to_string(&state_path) {
         Ok(content) => match serde_json::from_str::<ResumeState>(&content) {
             Ok(state) => state,
-            Err(err) => {
-                emit_tool_error("error", format!("parsing resume state: {err}"), readonly);
-                return ExitCode::SUCCESS;
-            }
+            Err(err) => return err_outcome(format!("parsing resume state: {err}")),
         },
-        Err(err) => {
-            emit_tool_error("error", format!("reading resume state: {err}"), readonly);
-            return ExitCode::SUCCESS;
-        }
+        Err(err) => return err_outcome(format!("reading resume state: {err}")),
     };
 
     let now = unix_timestamp_now();
     let ttl_secs = resume_ttl.unwrap_or(state.ttl_secs);
     if state.created_at.saturating_add(ttl_secs) < now {
-        emit_tool_error("error", "resume token expired".to_string(), readonly);
-        return ExitCode::SUCCESS;
+        return err_outcome("resume token expired".to_string());
     }
 
     let current_exe = match std::env::current_exe() {
         Ok(path) => path,
-        Err(err) => {
-            emit_tool_error("error", format!("locating assay binary: {err}"), readonly);
-            return ExitCode::SUCCESS;
-        }
+        Err(err) => return err_outcome(format!("locating assay binary: {err}")),
     };
 
     let mut command = Command::new(current_exe);
@@ -1154,39 +1151,49 @@ async fn resume_tool_execution(
 
     let output = match command.output() {
         Ok(output) => output,
-        Err(err) => {
-            emit_tool_error(
-                "error",
-                format!("spawning resume execution: {err}"),
-                readonly,
-            );
-            return ExitCode::SUCCESS;
-        }
+        Err(err) => return err_outcome(format!("spawning resume execution: {err}")),
     };
 
+    // The child's stderr is diagnostic (logs) — forward it. Safe on the CLI
+    // and on the MCP stdout channel alike, which only ever carries the envelope.
     if !output.stderr.is_empty() {
         eprint!("{}", String::from_utf8_lossy(&output.stderr));
     }
-    if !output.stdout.is_empty() {
-        print!("{}", String::from_utf8_lossy(&output.stdout));
-    }
 
+    let envelope = String::from_utf8_lossy(&output.stdout).into_owned();
     let resumed_status = serde_json::from_slice::<JsonValue>(&output.stdout)
         .ok()
         .and_then(|json| json.get("status").cloned())
         .and_then(|status| status.as_str().map(str::to_owned));
-    let should_cleanup =
-        output.status.success() && resumed_status.as_deref() != Some("needs_approval");
 
-    if should_cleanup && let Err(err) = fs::remove_file(&state_path) {
-        emit_tool_error(
-            "error",
-            format!("cleaning up resume state: {err}"),
-            readonly,
-        );
-        return ExitCode::SUCCESS;
+    // Drop the token once the run reaches a terminal state; a still-pending
+    // approval keeps it for the next resume. Best-effort: a cleanup hiccup
+    // must not turn a successful resume into an error.
+    let terminal = output.status.success() && resumed_status.as_deref() != Some("needs_approval");
+    if terminal {
+        let _ = fs::remove_file(&state_path);
     }
 
+    let status: &'static str = match resumed_status.as_deref() {
+        Some("ok") => "ok",
+        Some("needs_approval") => "needs_approval",
+        Some("timeout") => "timeout",
+        _ => "error",
+    };
+    ToolModeOutcome { envelope, status }
+}
+
+/// CLI `resume` command: resume a suspended run and print its envelope.
+async fn resume_tool_execution(
+    token: &str,
+    approve: &str,
+    resume_ttl: Option<u64>,
+    readonly: bool,
+) -> ExitCode {
+    let outcome = resume_tool_outcome(token, approve, resume_ttl, readonly).await;
+    if !outcome.envelope.is_empty() {
+        print!("{}", outcome.envelope);
+    }
     ExitCode::SUCCESS
 }
 
@@ -1394,10 +1401,6 @@ fn build_tool_error(status: &'static str, error_message: String, readonly: bool)
             "{{\"ok\":false,\"status\":\"error\",\"error\":\"serializing tool envelope: {e}\"}}"
         )
     })
-}
-
-fn emit_tool_error(status: &'static str, error_message: String, readonly: bool) {
-    print!("{}", build_tool_error(status, error_message, readonly));
 }
 
 fn truncate_tool_envelope(mut envelope: ToolSuccessEnvelope) -> ToolSuccessEnvelope {

--- a/crates/assay/src/mcp.rs
+++ b/crates/assay/src/mcp.rs
@@ -19,6 +19,24 @@ const SERVER_VERSION: &str = env!("CARGO_PKG_VERSION");
 const DEFAULT_PROTOCOL_VERSION: &str = "2024-11-05";
 const DEFAULT_CONTEXT_LIMIT: usize = 5;
 
+/// Opt-in gate for the third execution mode over MCP. Off by default: the
+/// server advertises and accepts only `readonly` + `approval`, so any MCP
+/// client is safe by default and can never fall through to unrestricted
+/// execution. A deployment that gates access itself — resolving the caller's
+/// allowed mode from its own policy before ever passing `unrestricted` — sets
+/// this to `1`/`true` to enable the full three-mode ladder.
+const UNRESTRICTED_ENV: &str = "ASSAY_MCP_UNRESTRICTED";
+
+fn unrestricted_allowed() -> bool {
+    matches!(
+        std::env::var(UNRESTRICTED_ENV)
+            .ok()
+            .as_deref()
+            .map(str::trim),
+        Some("1") | Some("true")
+    )
+}
+
 static CALL_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 // JSON-RPC 2.0 error codes.
@@ -108,9 +126,26 @@ fn tools_list_result() -> JsonValue {
 }
 
 fn assay_run_tool() -> JsonValue {
+    // The advertised mode ladder and its prose track whether this server was
+    // started with unrestricted execution enabled, so the client only ever
+    // sees a mode it can actually request.
+    let (modes, description, mode_description): (Vec<&str>, &str, &str) = if unrestricted_allowed()
+    {
+        (
+            vec!["readonly", "approval", "unrestricted"],
+            "Run a Lua script through the assay runtime and return the tool-mode JSON envelope (status ok | needs_approval | error). Every embedded assay module is available via require(\"assay.<module>\") alongside the builtins (http, json, fs, crypto, ...). Execution is gated by mode: 'readonly' blocks mutating builtins, 'approval' suspends each mutating operation and returns a resume token, 'unrestricted' runs everything ungated. This server was started with unrestricted execution enabled; the caller is responsible for deciding who may request it.",
+            "Execution gate. 'readonly' (default) blocks mutating builtins; 'approval' suspends each mutating operation for per-operation approval; 'unrestricted' runs everything with no gate.",
+        )
+    } else {
+        (
+            vec!["readonly", "approval"],
+            "Run a Lua script through the assay runtime and return the tool-mode JSON envelope (status ok | needs_approval | error). Every embedded assay module is available via require(\"assay.<module>\") alongside the builtins (http, json, fs, crypto, ...). Execution is always gated: 'readonly' blocks mutating builtins, 'approval' suspends each mutating operation and returns a resume token. Unrestricted execution is not exposed by this server.",
+            "Execution gate. 'readonly' (default) blocks mutating builtins; 'approval' suspends each mutating operation for per-operation approval. 'unrestricted' is not accepted.",
+        )
+    };
     json!({
         "name": "assay_run",
-        "description": "Run a Lua script through the assay runtime and return the tool-mode JSON envelope (status ok | needs_approval | error). Every embedded assay module is available via require(\"assay.<module>\") alongside the builtins (http, json, fs, crypto, ...). Execution is always gated: 'readonly' blocks mutating builtins, 'approval' suspends each mutating operation and returns a resume token. Unrestricted execution is intentionally not exposed.",
+        "description": description,
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -120,9 +155,9 @@ fn assay_run_tool() -> JsonValue {
                 },
                 "mode": {
                     "type": "string",
-                    "enum": ["readonly", "approval"],
+                    "enum": modes,
                     "default": "readonly",
-                    "description": "Execution gate. 'readonly' (default) blocks mutating builtins; 'approval' suspends each mutating operation for per-operation approval. 'unrestricted' is not accepted.",
+                    "description": mode_description,
                 },
                 "timeout_secs": {
                     "type": "number",
@@ -242,19 +277,32 @@ fn call_assay_context(arguments: &JsonValue) -> Result<JsonValue, String> {
 }
 
 /// Map the requested mode to an `ExecMode`. An absent mode defaults to
-/// read-only so a caller can never fall through to unrestricted execution;
-/// `unrestricted` (or any other value) is rejected.
+/// read-only so a caller can never fall through to a less restricted mode.
+/// `unrestricted` is accepted only when the server opted in via
+/// `ASSAY_MCP_UNRESTRICTED` (see `unrestricted_allowed`); otherwise it — and
+/// any other value — is rejected.
 fn resolve_mode(value: Option<&JsonValue>) -> Result<lua::ExecMode, String> {
+    let accepted = if unrestricted_allowed() {
+        "\"readonly\", \"approval\", or \"unrestricted\""
+    } else {
+        "\"readonly\" or \"approval\""
+    };
     match value {
         None | Some(JsonValue::Null) => Ok(lua::ExecMode::ReadOnly),
         Some(JsonValue::String(mode)) => match mode.as_str() {
             "readonly" => Ok(lua::ExecMode::ReadOnly),
             "approval" => Ok(lua::ExecMode::Approval),
+            "unrestricted" if unrestricted_allowed() => Ok(lua::ExecMode::Unrestricted),
+            "unrestricted" => Err(
+                "mode \"unrestricted\" is not enabled on this server (start it with \
+                 ASSAY_MCP_UNRESTRICTED=1 to allow it)"
+                    .to_string(),
+            ),
             other => Err(format!(
-                "mode must be \"readonly\" or \"approval\"; \"{other}\" is not accepted (unrestricted execution is never exposed)"
+                "mode must be {accepted}; \"{other}\" is not accepted"
             )),
         },
-        Some(_) => Err("mode must be a string: \"readonly\" or \"approval\"".to_string()),
+        Some(_) => Err(format!("mode must be a string: {accepted}")),
     }
 }
 

--- a/crates/assay/src/mcp.rs
+++ b/crates/assay/src/mcp.rs
@@ -122,7 +122,7 @@ fn initialize_result(params: &JsonValue) -> JsonValue {
 }
 
 fn tools_list_result() -> JsonValue {
-    json!({ "tools": [assay_run_tool(), assay_context_tool()] })
+    json!({ "tools": [assay_run_tool(), assay_resume_tool(), assay_context_tool()] })
 }
 
 fn assay_run_tool() -> JsonValue {
@@ -174,6 +174,28 @@ fn assay_run_tool() -> JsonValue {
     })
 }
 
+fn assay_resume_tool() -> JsonValue {
+    json!({
+        "name": "assay_resume",
+        "description": "Resume an assay_run that returned status 'needs_approval'. Pass the 'resumeToken' from that run's requires_approval envelope and whether to approve the pending operation. Returns the next tool-mode envelope: 'ok' when the run completes, 'needs_approval' again (with a fresh token) if it suspends on the next mutating operation, or 'error'. Denying (approve: false) fails the pending operation in the resumed run.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "token": {
+                    "type": "string",
+                    "description": "The resumeToken returned in a prior assay_run's requires_approval envelope.",
+                },
+                "approve": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Approve the pending operation (true) or deny it (false). Denying fails that operation in the resumed run.",
+                },
+            },
+            "required": ["token", "approve"],
+        },
+    })
+}
+
 fn assay_context_tool() -> JsonValue {
     json!({
         "name": "assay_context",
@@ -203,6 +225,10 @@ async fn handle_tools_call(id: JsonValue, params: JsonValue) -> JsonValue {
 
     match params.get("name").and_then(JsonValue::as_str) {
         Some("assay_run") => match call_assay_run(&arguments).await {
+            Ok(result) => success_response(id, result),
+            Err(message) => success_response(id, tool_error_content(message)),
+        },
+        Some("assay_resume") => match call_assay_resume(&arguments).await {
             Ok(result) => success_response(id, result),
             Err(message) => success_response(id, tool_error_content(message)),
         },
@@ -254,6 +280,28 @@ async fn call_assay_run(arguments: &JsonValue) -> Result<JsonValue, String> {
     if outcome.status != "needs_approval" {
         script_file.cleanup();
     }
+
+    let is_error = !matches!(outcome.status, "ok" | "needs_approval");
+    Ok(tool_text_content(outcome.envelope, is_error))
+}
+
+async fn call_assay_resume(arguments: &JsonValue) -> Result<JsonValue, String> {
+    let token = arguments
+        .get("token")
+        .and_then(JsonValue::as_str)
+        .ok_or_else(|| "assay_resume requires a 'token' string argument".to_string())?;
+
+    // Default to approving: the common case is proceeding through the gate.
+    let approve = arguments
+        .get("approve")
+        .and_then(JsonValue::as_bool)
+        .unwrap_or(true);
+    let decision = if approve { "yes" } else { "no" };
+
+    // readonly=false: an approval-mode run is what suspends, so this only ever
+    // resumes an approval token; the flag merely shapes an error envelope's
+    // `readonly` field, which is not meaningful for a resume.
+    let outcome = crate::resume_tool_outcome(token, decision, None, false).await;
 
     let is_error = !matches!(outcome.status, "ok" | "needs_approval");
     Ok(tool_text_content(outcome.envelope, is_error))

--- a/crates/assay/tests/mcp_serve.rs
+++ b/crates/assay/tests/mcp_serve.rs
@@ -15,17 +15,30 @@ struct McpServer {
 
 impl McpServer {
     fn start() -> Self {
-        let mut child = Command::new(env!("CARGO_BIN_EXE_assay"))
-            .arg("mcp-serve")
+        Self::start_with(&[])
+    }
+
+    // A server that opted in to the third mode (ASSAY_MCP_UNRESTRICTED=1).
+    fn start_unrestricted() -> Self {
+        Self::start_with(&[("ASSAY_MCP_UNRESTRICTED", "1")])
+    }
+
+    fn start_with(envs: &[(&str, &str)]) -> Self {
+        let mut cmd = Command::new(env!("CARGO_BIN_EXE_assay"));
+        cmd.arg("mcp-serve")
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::null())
-            // Per-call modes drive the gate; never inherit a process-wide one.
+            // Per-call modes drive the gate; never inherit a process-wide one,
+            // and start from a clean unrestricted-gate state each time.
             .env_remove("ASSAY_READONLY")
             .env_remove("ASSAY_APPROVAL")
             .env_remove("ASSAY_MODE")
-            .spawn()
-            .unwrap();
+            .env_remove("ASSAY_MCP_UNRESTRICTED");
+        for (k, v) in envs {
+            cmd.env(k, v);
+        }
+        let mut child = cmd.spawn().unwrap();
         let stdin = child.stdin.take().unwrap();
         let stdout = BufReader::new(child.stdout.take().unwrap());
         McpServer {
@@ -173,6 +186,58 @@ fn assay_run_rejects_unrestricted_mode() {
         text_content(result).contains("unrestricted"),
         "rejection should explain the gate: {result}"
     );
+}
+
+#[test]
+fn tools_list_offers_unrestricted_when_enabled() {
+    let mut server = McpServer::start_unrestricted();
+    server.initialize();
+
+    let resp = server.request("tools/list", json!({}));
+    let tools = resp["result"]["tools"].as_array().unwrap();
+    let run = tools.iter().find(|t| t["name"] == "assay_run").unwrap();
+    let modes = run["inputSchema"]["properties"]["mode"]["enum"]
+        .as_array()
+        .unwrap();
+    let modes: Vec<&str> = modes.iter().filter_map(Value::as_str).collect();
+    assert!(
+        modes.contains(&"unrestricted"),
+        "with ASSAY_MCP_UNRESTRICTED=1 the ladder should offer unrestricted: {modes:?}"
+    );
+    // The opt-in never drops the safer modes.
+    assert!(
+        modes.contains(&"readonly") && modes.contains(&"approval"),
+        "modes: {modes:?}"
+    );
+}
+
+#[test]
+fn assay_run_unrestricted_runs_write_op_when_enabled() {
+    let mut server = McpServer::start_unrestricted();
+    server.initialize();
+
+    let path = std::env::temp_dir().join(format!("assay-mcp-unrestricted-{}", std::process::id()));
+    let _ = std::fs::remove_file(&path);
+    let path_lua = path.to_str().unwrap().replace('\\', "\\\\");
+    let script = format!(r#"fs.write("{path_lua}", "x"); return "wrote""#);
+
+    let resp = server.call_tool(
+        "assay_run",
+        json!({ "script": script, "mode": "unrestricted" }),
+    );
+    let result = &resp["result"];
+    assert_eq!(
+        result["isError"],
+        json!(false),
+        "unrestricted mode should run the write that readonly blocks: {result}"
+    );
+    let envelope: Value = serde_json::from_str(text_content(result)).unwrap();
+    assert_eq!(envelope["status"], "ok", "envelope: {envelope}");
+    assert!(
+        path.exists(),
+        "the fs.write should have reached disk in unrestricted mode"
+    );
+    let _ = std::fs::remove_file(&path);
 }
 
 #[test]

--- a/crates/assay/tests/mcp_serve.rs
+++ b/crates/assay/tests/mcp_serve.rs
@@ -286,6 +286,86 @@ fn assay_context_returns_markdown() {
 }
 
 #[test]
+fn tools_list_includes_assay_resume() {
+    let mut server = McpServer::start();
+    server.initialize();
+
+    let resp = server.request("tools/list", json!({}));
+    let tools = resp["result"]["tools"].as_array().unwrap();
+    let names: Vec<&str> = tools.iter().filter_map(|t| t["name"].as_str()).collect();
+    assert!(
+        names.contains(&"assay_resume"),
+        "missing assay_resume: {names:?}"
+    );
+
+    let resume = tools.iter().find(|t| t["name"] == "assay_resume").unwrap();
+    let props = &resume["inputSchema"]["properties"];
+    assert!(
+        props["token"].is_object(),
+        "resume needs a token arg: {resume}"
+    );
+    assert!(
+        props["approve"].is_object(),
+        "resume needs an approve arg: {resume}"
+    );
+}
+
+#[test]
+fn approval_run_suspends_then_resume_completes_the_write() {
+    let mut server = McpServer::start();
+    server.initialize();
+
+    let path = std::env::temp_dir().join(format!("assay-mcp-approval-{}", std::process::id()));
+    let _ = std::fs::remove_file(&path);
+    let path_lua = path.to_str().unwrap().replace('\\', "\\\\");
+    let script = format!(r#"fs.write("{path_lua}", "x"); return "done""#);
+
+    // 1) approval mode → the mutating fs.write suspends and hands back a token.
+    let run = server.call_tool("assay_run", json!({ "script": script, "mode": "approval" }));
+    let envelope: Value = serde_json::from_str(text_content(&run["result"])).unwrap();
+    assert_eq!(envelope["status"], "needs_approval", "envelope: {envelope}");
+    let token = envelope["requiresApproval"]["resumeToken"]
+        .as_str()
+        .unwrap_or_else(|| panic!("no resumeToken in {envelope}"));
+    assert!(!path.exists(), "the write must not land before approval");
+
+    // 2) assay_resume approving the pending op → the run finishes, write lands.
+    let resume = server.call_tool("assay_resume", json!({ "token": token, "approve": true }));
+    let resume_result = &resume["result"];
+    assert_eq!(
+        resume_result["isError"],
+        json!(false),
+        "resume: {resume_result}"
+    );
+    let done: Value = serde_json::from_str(text_content(resume_result)).unwrap();
+    assert_eq!(done["status"], "ok", "resumed envelope: {done}");
+    assert!(path.exists(), "the approved write should have reached disk");
+
+    let _ = std::fs::remove_file(&path);
+}
+
+#[test]
+fn assay_resume_rejects_an_unknown_token() {
+    let mut server = McpServer::start();
+    server.initialize();
+
+    let resp = server.call_tool(
+        "assay_resume",
+        json!({ "token": "deadbeefdeadbeefdeadbeefdeadbeef", "approve": true }),
+    );
+    let result = &resp["result"];
+    assert_eq!(
+        result["isError"],
+        json!(true),
+        "unknown token must error: {result}"
+    );
+    assert!(
+        text_content(result).contains("invalid resume token"),
+        "should explain the bad token: {result}"
+    );
+}
+
+#[test]
 fn unknown_method_returns_json_rpc_error() {
     let mut server = McpServer::start();
     server.initialize();


### PR DESCRIPTION
Completes the assay MCP so a host can drive the **full three-mode + gated execution model** over the API, without shelling to the CLI. Two related changes:

## 1. `ASSAY_MCP_UNRESTRICTED` — opt-in exposure of the third mode

By default `assay mcp-serve` advertises/accepts only `readonly` + `approval` (safe by default — no client can fall through to unrestricted). Started with **`ASSAY_MCP_UNRESTRICTED=1`**, `assay_run` additionally offers/accepts `mode: "unrestricted"` (the always-existing `ExecMode::Unrestricted`, previously CLI-only). For a host that **gates access itself** before ever passing `unrestricted`. The advertised `mode` enum + descriptions track the flag, so a client only sees a mode it can request.

## 2. `assay_resume` — the suspend→approve→resume loop lives in the MCP API

`assay_run(mode: "approval")` already returns a `needs_approval` envelope with a `resumeToken` when a mutating op suspends. The new **`assay_resume(token, approve)`** tool returns the next envelope (`ok` on completion, `needs_approval` again with a fresh token if it suspends on the next op, or `error`). Previously resume was CLI-only (`assay resume`), forcing an MCP host to shell out; now the whole gated loop runs over the API, and the host can **interpose its own approver between run and resume**.

Internals: `resume_tool_execution` is split into a shared **`resume_tool_outcome`** that RETURNS the envelope (mirroring `execute_tool_mode`); the CLI `resume` command is now a thin wrapper that prints it. Removes the now-unused `emit_tool_error`.

## Tests

- `mcp_serve` (13 pass): default safe-by-default (unrestricted not offered/rejected); flag-on (unrestricted offered + runs a write `readonly` blocks); **full loop** (approval run suspends with a token → `assay_resume` approves → the write lands); `assay_resume` in `tools/list`; invalid-token rejection.
- CLI `approval_mode` suite still green (8 pass) — the resume refactor preserves CLI behavior.
- Full crate suite green.

## Consumer

The intended host is an agent gateway (proxima) that resolves the caller's allowed mode + approver from its own policy (Keto), gates `assay_resume` through a human approval card, and only then lets the resume proceed — exactly how it already gates `argocd app sync`.