### PR TITLE
release: assay-lua 0.18.0 — assay_resume + opt-in unrestricted MCP mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to Assay are documented here.
 
-## Unreleased
+## assay 0.18.0 — 2026-07-07
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,7 +338,7 @@ dependencies = [
 
 [[package]]
 name = "assay-lua"
-version = "0.17.2"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/assay/Cargo.toml
+++ b/crates/assay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-lua"
-version = "0.17.2"
+version = "0.18.0"
 categories = ["command-line-utilities", "development-tools::testing"]
 edition = "2024"
 homepage = "https://assay.rs"


### PR DESCRIPTION
Version-driven release of the #191 features so downstream consumers (proxima) can pin them.

## What ships

- **`assay_resume` MCP tool** — the suspend→approve→resume loop now lives entirely in the MCP API. An MCP host can drive the whole gated flow over the API and interpose its own approver between run and resume.
- **`ASSAY_MCP_UNRESTRICTED`** — opt-in exposure of the third execution mode over MCP. Off by default (only `readonly` + `approval` advertised); when set, `assay_run` also offers `mode: "unrestricted"` for a host that gates access itself.

## Mechanics

Bumps `crates/assay/Cargo.toml` `assay-lua` 0.17.2 → 0.18.0 and cuts the CHANGELOG `Unreleased` heading to `0.18.0`. On merge to main the idempotent Release workflow publishes the crate (crates.io), the `assay-lua-v0.18.0` git tag, and `ghcr.io/developerinlondon/assay:0.18.0` (+ `:latest`, + `-sh` variant).

Full suite was green on #191 (361/0). No code changes here beyond the version + changelog.