### PR TITLE
feat(assay): aws credential chain + kubeconfig contexts for k8s (0.17.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 All notable changes to Assay are documented here.
 
+## assay 0.17.4 — 2026-07-07
+
+### Added
+
+- **`assay.k8s` is multi-cluster: kubeconfig context support.** Any k8s call takes
+  `opts.context` (or set a default with `k8s.use_context(name)` / `ASSAY_K8S_CONTEXT`),
+  resolved from `opts.kubeconfig` / `$KUBECONFIG` / `~/.kube/config`: the cluster's
+  server URL and CA (`certificate-authority-data` honored via a per-context HTTP
+  client), and the user's auth. Supported user auth: a static `token`, or the aws
+  `eks get-token` exec plugin — which is **recognized and minted in-process** (with
+  `--role-arn`/`--profile`/exec-`env` respected) rather than executed, so contexts work
+  in readonly mode where subprocesses are blocked. `k8s.contexts()` lists what's
+  available. Fully backward compatible: with no context configured, calls target the
+  in-cluster ServiceAccount exactly as before.
+- **`assay.aws.sts` — the AWS credential chain, in-process.** `sts.credentials(opts)`
+  resolves like the AWS CLI: explicit keys → `opts.profile`/`AWS_PROFILE` (parsing
+  `~/.aws/config` + `~/.aws/credentials`, following `role_arn` + `source_profile`
+  chains and `web_identity_token_file`) → env keys → IRSA
+  (`AWS_ROLE_ARN`+`AWS_WEB_IDENTITY_TOKEN_FILE`). Plus `sts.assume_role(role_arn, opts)`
+  (SigV4-signed) and `sts.assume_role_with_web_identity(role_arn, token, opts)`.
+  Temporary credentials are cached until shortly before expiry. STS is asked for JSON
+  (Accept header), so no XML parsing is involved.
+- **`assay.aws.eks` — EKS bearer tokens without the aws CLI.** `eks.get_token(cluster)`
+  mints the `k8s-aws-v1.` presigned-STS token in-process (what `aws eks get-token`
+  produces), honoring profile/role/region options. This is what powers the k8s exec-plugin
+  contexts above.
+- **`sigv4.presign(opts)`** — query-string SigV4 signing (presigned URLs), alongside the
+  existing header signing; both now accept `opts.time` for deterministic signatures in
+  tests.
+- **`aws.ec2` / `aws.s3` / `aws.ecr` clients resolve credentials automatically.**
+  `client(opts)` no longer hard-requires literal keys: omit them and the standard chain
+  runs (honoring `opts.profile` and `opts.role_arn`); `region` falls back to
+  `AWS_REGION`/`AWS_DEFAULT_REGION`. Explicit keys keep working unchanged.
+
 ## assay 0.17.3 — 2026-07-07
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,7 +338,7 @@ dependencies = [
 
 [[package]]
 name = "assay-lua"
-version = "0.17.3"
+version = "0.17.4"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/assay/Cargo.toml
+++ b/crates/assay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-lua"
-version = "0.17.3"
+version = "0.17.4"
 categories = ["command-line-utilities", "development-tools::testing"]
 edition = "2024"
 homepage = "https://assay.rs"

--- a/crates/assay/stdlib/aws/ec2.lua
+++ b/crates/assay/stdlib/aws/ec2.lua
@@ -1,7 +1,7 @@
 --- @module assay.aws.ec2
 --- @description AWS EC2 read-only queries via Signature V4. Describe instances, volumes, security groups.
 --- @keywords aws, ec2, instances, volumes, security-groups, describe, sigv4, compute, reservations
---- @quickref client(opts) -> client | Create an EC2 client (opts = {access_key, secret_key, region, session_token?, endpoint?})
+--- @quickref client(opts) -> client | Create an EC2 client (opts = {access_key?, secret_key?, profile?, role_arn?, region?, session_token?, endpoint?}; no keys -> standard chain via assay.aws.sts)
 --- @quickref c:describe_instances(opts?) -> [instance] | List instances (Action=DescribeInstances)
 --- @quickref c:describe_volumes(opts?) -> [volume] | List EBS volumes (Action=DescribeVolumes)
 --- @quickref c:describe_security_groups(opts?) -> [group] | List security groups (Action=DescribeSecurityGroups)
@@ -83,10 +83,17 @@ end
 
 function M.client(opts)
   opts = opts or {}
-  local access_key = opts.access_key or error("aws.ec2.client: access_key is required")
-  local secret_key = opts.secret_key or error("aws.ec2.client: secret_key is required")
-  local region = opts.region or error("aws.ec2.client: region is required")
-  local session_token = opts.session_token
+  -- No explicit keys → resolve via the standard chain (profile / env / IRSA),
+  -- honoring opts.profile and opts.role_arn. See assay.aws.sts.
+  local creds = opts
+  if not opts.access_key then
+    creds = require("assay.aws.sts").credentials(opts)
+  end
+  local access_key = creds.access_key or error("aws.ec2.client: access_key is required")
+  local secret_key = creds.secret_key or error("aws.ec2.client: secret_key is required")
+  local region = opts.region or env.get("AWS_REGION") or env.get("AWS_DEFAULT_REGION")
+    or error("aws.ec2.client: region is required")
+  local session_token = creds.session_token
   local endpoint = opts.endpoint
 
   local url, host

--- a/crates/assay/stdlib/aws/ecr.lua
+++ b/crates/assay/stdlib/aws/ecr.lua
@@ -1,7 +1,7 @@
 --- @module assay.aws.ecr
 --- @description AWS Elastic Container Registry. Get authorization tokens for pushing/pulling images.
 --- @keywords aws, ecr, container, registry, docker, authorization, token, login
---- @quickref client(opts) -> client | Create an ECR client (opts = {access_key, secret_key, region, session_token?, endpoint?})
+--- @quickref client(opts) -> client | Create an ECR client (opts = {access_key?, secret_key?, profile?, role_arn?, region?, session_token?, endpoint?}; no keys -> standard chain via assay.aws.sts)
 --- @quickref c:get_authorization_token() -> {token, proxy_endpoint, expires_at} | Get ECR auth token
 
 local M = {}
@@ -11,18 +11,28 @@ local sigv4 = require("assay.aws.sigv4")
 --- Create an ECR client.
 ---
 --- @param opts table with fields:
----   access_key    (string) AWS access key ID
----   secret_key    (string) AWS secret access key
----   region        (string) AWS region
+---   access_key    (string|nil) AWS access key ID (omit to resolve via the
+---                              standard chain — profile / env / IRSA)
+---   secret_key    (string|nil) AWS secret access key
+---   profile       (string|nil) AWS profile to resolve credentials from
+---   role_arn      (string|nil) Role to assume on top of the resolved credentials
+---   region        (string|nil) AWS region (default AWS_REGION/AWS_DEFAULT_REGION)
 ---   session_token (string|nil) AWS session token (for STS credentials)
 ---   endpoint      (string|nil) Override the API endpoint (for VPC endpoints
 ---                              or tests). Defaults to api.ecr.<region>.amazonaws.com.
 function M.client(opts)
   opts = opts or {}
-  local access_key = opts.access_key or error("ecr.client: access_key is required")
-  local secret_key = opts.secret_key or error("ecr.client: secret_key is required")
-  local region = opts.region or error("ecr.client: region is required")
-  local session_token = opts.session_token
+  -- No explicit keys → resolve via the standard chain (profile / env / IRSA),
+  -- honoring opts.profile and opts.role_arn. See assay.aws.sts.
+  local creds = opts
+  if not opts.access_key then
+    creds = require("assay.aws.sts").credentials(opts)
+  end
+  local access_key = creds.access_key or error("ecr.client: access_key is required")
+  local secret_key = creds.secret_key or error("ecr.client: secret_key is required")
+  local region = opts.region or env.get("AWS_REGION") or env.get("AWS_DEFAULT_REGION")
+    or error("ecr.client: region is required")
+  local session_token = creds.session_token
   local endpoint = opts.endpoint
 
   -- Endpoint can be a full URL (http://… for tests, https://… for VPC endpoints)

--- a/crates/assay/stdlib/aws/eks.lua
+++ b/crates/assay/stdlib/aws/eks.lua
@@ -1,0 +1,51 @@
+--- @module assay.aws.eks
+--- @description EKS authentication token minting (the aws eks get-token equivalent), in-process — no aws CLI subprocess, works in readonly mode. Used by assay.k8s kubeconfig contexts.
+--- @keywords aws, eks, kubernetes, token, get-token, authentication, k8s-aws-v1, presigned
+--- @quickref M.get_token(cluster_name, opts?) -> token | Mint a k8s-aws-v1 bearer token for an EKS cluster
+
+local sigv4 = require("assay.aws.sigv4")
+local sts = require("assay.aws.sts")
+
+local M = {}
+
+-- EKS validates the presigned URL's X-Amz-Date within a 15-minute window; the
+-- aws CLI uses a 60-second X-Amz-Expires. Callers should treat minted tokens
+-- as valid for ~10 minutes (assay.k8s caches them accordingly).
+local TOKEN_EXPIRES_SECS = 60
+
+local function base64url(s)
+  return (base64.encode(s):gsub("+", "-"):gsub("/", "_"):gsub("=", ""))
+end
+
+--- Mint an EKS bearer token: a presigned sts:GetCallerIdentity URL carrying the
+--- cluster name in a signed x-k8s-aws-id header, base64url-encoded with the
+--- k8s-aws-v1. prefix — exactly what `aws eks get-token` produces, minted
+--- in-process so it works where subprocesses are blocked (readonly mode).
+---
+--- @param cluster_name string The EKS cluster name
+--- @param opts table|nil { region, profile, role_arn, credentials, access_key, secret_key, session_token, time }
+--- @return string The bearer token ("k8s-aws-v1.…")
+function M.get_token(cluster_name, opts)
+  opts = opts or {}
+  local creds = opts.credentials or sts.credentials(opts)
+  local region = opts.region or env.get("AWS_REGION") or env.get("AWS_DEFAULT_REGION")
+    or "us-east-1"
+
+  local url = sigv4.presign({
+    access_key = creds.access_key,
+    secret_key = creds.secret_key,
+    session_token = creds.session_token,
+    service = "sts",
+    region = region,
+    method = "GET",
+    host = "sts." .. region .. ".amazonaws.com",
+    path = "/",
+    query = { Action = "GetCallerIdentity", Version = "2011-06-15" },
+    headers = { ["x-k8s-aws-id"] = cluster_name },
+    expires = TOKEN_EXPIRES_SECS,
+    time = opts.time,
+  })
+  return "k8s-aws-v1." .. base64url(url)
+end
+
+return M

--- a/crates/assay/stdlib/aws/s3.lua
+++ b/crates/assay/stdlib/aws/s3.lua
@@ -1,7 +1,7 @@
 --- @module assay.aws.s3
 --- @description AWS S3 read-only queries via Signature V4. List buckets, list objects, head object.
 --- @keywords aws, s3, buckets, objects, list, head, sigv4, storage, path-style
---- @quickref client(opts) -> client | Create an S3 client (opts = {access_key, secret_key, region, session_token?, endpoint?})
+--- @quickref client(opts) -> client | Create an S3 client (opts = {access_key?, secret_key?, profile?, role_arn?, region?, session_token?, endpoint?}; no keys -> standard chain via assay.aws.sts)
 --- @quickref c:list_buckets() -> [{name, creation_date}] | List buckets (GET, read)
 --- @quickref c:list_objects(bucket, opts?) -> {objects, is_truncated, ...} | List objects (GET, read)
 --- @quickref c:head_object(bucket, key) -> {status, headers}|nil | Object metadata, nil if absent (GET, read)
@@ -23,10 +23,17 @@ end
 
 function M.client(opts)
   opts = opts or {}
-  local access_key = opts.access_key or error("aws.s3.client: access_key is required")
-  local secret_key = opts.secret_key or error("aws.s3.client: secret_key is required")
-  local region = opts.region or error("aws.s3.client: region is required")
-  local session_token = opts.session_token
+  -- No explicit keys → resolve via the standard chain (profile / env / IRSA),
+  -- honoring opts.profile and opts.role_arn. See assay.aws.sts.
+  local creds = opts
+  if not opts.access_key then
+    creds = require("assay.aws.sts").credentials(opts)
+  end
+  local access_key = creds.access_key or error("aws.s3.client: access_key is required")
+  local secret_key = creds.secret_key or error("aws.s3.client: secret_key is required")
+  local region = opts.region or env.get("AWS_REGION") or env.get("AWS_DEFAULT_REGION")
+    or error("aws.s3.client: region is required")
+  local session_token = creds.session_token
   local endpoint = opts.endpoint
 
   local url, host

--- a/crates/assay/stdlib/aws/sigv4.lua
+++ b/crates/assay/stdlib/aws/sigv4.lua
@@ -1,7 +1,8 @@
 --- @module assay.aws.sigv4
---- @description AWS Signature V4 request signing. Generates Authorization headers for AWS API calls.
---- @keywords aws, sigv4, signature, authorization, signing, v4, signature-v4
+--- @description AWS Signature V4 request signing. Generates Authorization headers and presigned URLs for AWS API calls.
+--- @keywords aws, sigv4, signature, authorization, signing, v4, signature-v4, presign, presigned-url
 --- @quickref M.sign(opts) -> headers | Sign an AWS request and return authorization headers
+--- @quickref M.presign(opts) -> url | Presign an AWS request as a query-string-signed URL
 
 local M = {}
 
@@ -16,8 +17,8 @@ local function fmt02(n)
   return tostring(n)
 end
 
-local function utc_now()
-  local epoch = os.time()
+local function utc_now(epoch)
+  epoch = epoch or os.time()
   local secs = epoch
   local days = math.floor(secs / 86400)
   local time_of_day = secs % 86400
@@ -113,6 +114,7 @@ end
 ---   query       (string|nil) Query string
 ---   payload     (string) Request body
 ---   headers     (table|nil) Additional headers
+---   time        (number|nil) Epoch seconds to sign at (defaults to now; for tests)
 --- @return table Headers map including Authorization, X-Amz-Date, etc.
 function M.sign(opts)
   local access_key = opts.access_key
@@ -127,7 +129,7 @@ function M.sign(opts)
   local payload = opts.payload or ""
   local extra_headers = opts.headers or {}
 
-  local dt = utc_now()
+  local dt = utc_now(opts.time)
   local date_stamp = utc_date_stamp(dt)
   local datetime_stamp = utc_datetime_stamp(dt)
   local credential_scope = date_stamp .. "/" .. region .. "/" .. service .. "/aws4_request"
@@ -174,6 +176,89 @@ function M.sign(opts)
     .. "Signature=" .. signature
 
   return headers_map
+end
+
+--- Presign an AWS API request: the signature goes into the query string instead
+--- of an Authorization header, producing a self-contained URL. This is how EKS
+--- bearer tokens are minted (a presigned sts:GetCallerIdentity URL) — see
+--- assay.aws.eks. GET-only in practice; the payload hash is that of the empty
+--- body.
+---
+--- @param opts table with fields:
+---   access_key  (string) AWS access key ID
+---   secret_key  (string) AWS secret access key
+---   session_token (string|nil) AWS session token (for STS credentials)
+---   service     (string) AWS service name (e.g. "sts")
+---   region      (string) AWS region
+---   method      (string) HTTP method (default "GET")
+---   host        (string) API hostname
+---   path        (string) Request path (default "/")
+---   query       (table|nil) Base query params as {name=value} (e.g. Action)
+---   headers     (table|nil) Headers to include in the signature (host is
+---                           always signed; e.g. ["x-k8s-aws-id"] for EKS)
+---   expires     (number|nil) Validity in seconds (default 60)
+---   time        (number|nil) Epoch seconds to sign at (defaults to now; for tests)
+--- @return string The presigned URL
+function M.presign(opts)
+  local access_key = opts.access_key
+  local secret_key = opts.secret_key
+  local session_token = opts.session_token
+  local service = opts.service
+  local region = opts.region
+  local method = opts.method or "GET"
+  local host = opts.host
+  local path = opts.path or "/"
+  local expires = opts.expires or 60
+
+  local dt = utc_now(opts.time)
+  local date_stamp = utc_date_stamp(dt)
+  local datetime_stamp = utc_datetime_stamp(dt)
+  local credential_scope = date_stamp .. "/" .. region .. "/" .. service .. "/aws4_request"
+
+  local headers_map = { host = host }
+  for k, v in pairs(opts.headers or {}) do
+    headers_map[k:lower()] = v
+  end
+  local canonical_headers_str, signed_headers = canonical_headers_and_signed(headers_map)
+
+  local params = {}
+  for k, v in pairs(opts.query or {}) do
+    params[#params + 1] = url_encode(k) .. "=" .. url_encode(tostring(v))
+  end
+  params[#params + 1] = "X-Amz-Algorithm=AWS4-HMAC-SHA256"
+  params[#params + 1] = "X-Amz-Credential=" .. url_encode(access_key .. "/" .. credential_scope)
+  params[#params + 1] = "X-Amz-Date=" .. datetime_stamp
+  params[#params + 1] = "X-Amz-Expires=" .. tostring(expires)
+  params[#params + 1] = "X-Amz-SignedHeaders=" .. url_encode(signed_headers)
+  if session_token and session_token ~= "" then
+    params[#params + 1] = "X-Amz-Security-Token=" .. url_encode(session_token)
+  end
+  table.sort(params)
+  local canonical_query = table.concat(params, "&")
+
+  local canonical_request = table.concat({
+    method,
+    url_encode_path(path),
+    canonical_query,
+    canonical_headers_str,
+    signed_headers,
+    crypto.hash("", "sha256"),
+  }, "\n")
+
+  local string_to_sign = table.concat({
+    "AWS4-HMAC-SHA256",
+    datetime_stamp,
+    credential_scope,
+    crypto.hash(canonical_request, "sha256"),
+  }, "\n")
+
+  local date_key = crypto.hmac("AWS4" .. secret_key, date_stamp, "sha256", true)
+  local region_key = crypto.hmac(date_key, region, "sha256", true)
+  local service_key = crypto.hmac(region_key, service, "sha256", true)
+  local signing_key = crypto.hmac(service_key, "aws4_request", "sha256", true)
+  local signature = crypto.hmac(signing_key, string_to_sign, "sha256")
+
+  return "https://" .. host .. path .. "?" .. canonical_query .. "&X-Amz-Signature=" .. signature
 end
 
 return M

--- a/crates/assay/stdlib/aws/sts.lua
+++ b/crates/assay/stdlib/aws/sts.lua
@@ -1,0 +1,323 @@
+--- @module assay.aws.sts
+--- @description AWS credential resolution + STS. Resolves credentials like the AWS CLI (explicit -> profile -> env -> IRSA web identity), assumes roles, all in-process (no aws CLI needed, works in readonly mode).
+--- @keywords aws, sts, credentials, assume-role, web-identity, irsa, profile, aws-profile, credential-chain
+--- @env AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN, AWS_PROFILE, AWS_ROLE_ARN, AWS_WEB_IDENTITY_TOKEN_FILE, AWS_REGION, AWS_DEFAULT_REGION, HOME
+--- @quickref M.credentials(opts?) -> {access_key, secret_key, session_token?} | Resolve credentials via the standard chain
+--- @quickref M.assume_role(role_arn, opts?) -> creds | Assume an IAM role (sts:AssumeRole)
+--- @quickref M.assume_role_with_web_identity(role_arn, token, opts?) -> creds | Assume a role with a web identity token (IRSA)
+
+local sigv4 = require("assay.aws.sigv4")
+
+local M = {}
+
+local DEFAULT_DURATION = 3600
+local EXPIRY_SKEW_SECS = 120
+local MAX_PROFILE_DEPTH = 5
+
+-- Resolved-credential cache, keyed by how they were obtained. Entries carry
+-- expires_at (epoch) for temporary credentials; static entries never expire.
+local _cache = {}
+
+local function region_of(opts)
+  return (opts and opts.region)
+    or env.get("AWS_REGION")
+    or env.get("AWS_DEFAULT_REGION")
+    or "us-east-1"
+end
+
+local function sts_url(opts)
+  if opts and opts.sts_endpoint then
+    return opts.sts_endpoint:gsub("/+$", "")
+  end
+  return "https://sts." .. region_of(opts) .. ".amazonaws.com"
+end
+
+local function url_encode(str)
+  return (tostring(str):gsub("([^A-Za-z0-9%-_.~])", function(c)
+    return string.format("%%%02X", string.byte(c))
+  end))
+end
+
+local function form_encode(params)
+  local names = {}
+  for k in pairs(params) do names[#names + 1] = k end
+  table.sort(names)
+  local parts = {}
+  for _, k in ipairs(names) do
+    parts[#parts + 1] = url_encode(k) .. "=" .. url_encode(params[k])
+  end
+  return table.concat(parts, "&")
+end
+
+-- STS answers the query protocol in JSON when asked (Accept header), sparing
+-- us an XML parser. Expiration arrives as epoch seconds (number) in JSON.
+local function parse_credentials(body, result_key)
+  local doc = json.parse(body)
+  local resp = doc[result_key .. "Response"]
+  local result = resp and resp[result_key .. "Result"]
+  local c = result and result.Credentials
+  if not c then
+    error("aws.sts: unexpected STS response shape (missing " .. result_key .. "Response)")
+  end
+  local expires_at = nil
+  if type(c.Expiration) == "number" then
+    expires_at = c.Expiration
+  end
+  return {
+    access_key = c.AccessKeyId,
+    secret_key = c.SecretAccessKey,
+    session_token = c.SessionToken,
+    expires_at = expires_at,
+  }
+end
+
+local function cache_get(key)
+  local e = _cache[key]
+  if not e then return nil end
+  if e.expires_at and os.time() > (e.expires_at - EXPIRY_SKEW_SECS) then
+    _cache[key] = nil
+    return nil
+  end
+  return e
+end
+
+--- Assume a role with a web identity token (e.g. an IRSA-mounted ServiceAccount
+--- token). This STS call is unsigned — the token itself authenticates it.
+---
+--- @param role_arn string The role to assume
+--- @param token string The web identity (OIDC) token
+--- @param opts table|nil { region, sts_endpoint, session_name, duration_secs }
+--- @return table { access_key, secret_key, session_token, expires_at }
+function M.assume_role_with_web_identity(role_arn, token, opts)
+  opts = opts or {}
+  local body = form_encode({
+    Action = "AssumeRoleWithWebIdentity",
+    Version = "2011-06-15",
+    RoleArn = role_arn,
+    RoleSessionName = opts.session_name or "assay",
+    WebIdentityToken = token,
+    DurationSeconds = tostring(opts.duration_secs or DEFAULT_DURATION),
+  })
+  local resp = http.post(sts_url(opts), body, {
+    headers = {
+      ["Content-Type"] = "application/x-www-form-urlencoded",
+      ["Accept"] = "application/json",
+    },
+  })
+  if resp.status ~= 200 then
+    error("aws.sts.assume_role_with_web_identity: HTTP " .. resp.status .. ": " .. resp.body)
+  end
+  return parse_credentials(resp.body, "AssumeRoleWithWebIdentity")
+end
+
+--- Assume an IAM role (sts:AssumeRole), signing with base credentials resolved
+--- via the standard chain (or passed as opts.credentials).
+---
+--- @param role_arn string The role to assume
+--- @param opts table|nil { credentials, region, sts_endpoint, session_name, duration_secs, profile }
+--- @return table { access_key, secret_key, session_token, expires_at }
+function M.assume_role(role_arn, opts)
+  opts = opts or {}
+  local base = opts.credentials or M.credentials({
+    profile = opts.profile,
+    region = opts.region,
+    sts_endpoint = opts.sts_endpoint,
+  })
+  local body = form_encode({
+    Action = "AssumeRole",
+    Version = "2011-06-15",
+    RoleArn = role_arn,
+    RoleSessionName = opts.session_name or "assay",
+    DurationSeconds = tostring(opts.duration_secs or DEFAULT_DURATION),
+  })
+  local url = sts_url(opts)
+  local host = url:gsub("^https?://", ""):gsub("/.*$", "")
+  local headers = sigv4.sign({
+    access_key = base.access_key,
+    secret_key = base.secret_key,
+    session_token = base.session_token,
+    service = "sts",
+    region = region_of(opts),
+    method = "POST",
+    host = host,
+    path = "/",
+    payload = body,
+    headers = { ["content-type"] = "application/x-www-form-urlencoded" },
+  })
+  headers["accept"] = "application/json"
+  local resp = http.post(url, body, { headers = headers })
+  if resp.status ~= 200 then
+    error("aws.sts.assume_role: HTTP " .. resp.status .. " assuming " .. role_arn .. ": " .. resp.body)
+  end
+  return parse_credentials(resp.body, "AssumeRole")
+end
+
+-- ===== ~/.aws config-file profiles =====
+
+-- Minimal INI parser for ~/.aws/config + ~/.aws/credentials: [section] headers,
+-- k = v lines, ;/# comments. Returns { section_name -> { key -> value } }.
+local function parse_ini(text)
+  local sections = {}
+  local current = nil
+  for raw in (text .. "\n"):gmatch("(.-)\n") do
+    local line = raw:match("^%s*(.-)%s*$")
+    if line ~= "" and not line:match("^[;#]") then
+      local section = line:match("^%[(.-)%]$")
+      if section then
+        current = {}
+        sections[section] = current
+      elseif current then
+        local k, v = line:match("^([%w_%-%.]+)%s*=%s*(.-)$")
+        if k then current[k:lower()] = v end
+      end
+    end
+  end
+  return sections
+end
+M._parse_ini = parse_ini -- exposed for tests
+
+local function read_ini(path)
+  local ok, text = pcall(fs.read, path)
+  if not ok then return {} end
+  return parse_ini(text)
+end
+
+local function aws_dir()
+  return (env.get("HOME") or "") .. "/.aws"
+end
+
+-- Look up a profile across both files. ~/.aws/credentials uses bare [name]
+-- sections; ~/.aws/config uses [profile name] (except [default]).
+local function profile_entry(name, opts)
+  local credentials_file = (opts and opts.credentials_file) or aws_dir() .. "/credentials"
+  local config_file = (opts and opts.config_file) or aws_dir() .. "/config"
+  local creds = read_ini(credentials_file)[name]
+  local cfg = read_ini(config_file)[name == "default" and "default" or ("profile " .. name)]
+  if not creds and not cfg then
+    return nil
+  end
+  -- credentials-file keys win over config-file keys, per AWS CLI behavior.
+  local merged = {}
+  for k, v in pairs(cfg or {}) do merged[k] = v end
+  for k, v in pairs(creds or {}) do merged[k] = v end
+  return merged
+end
+
+local function resolve_profile(name, opts, depth)
+  if depth > MAX_PROFILE_DEPTH then
+    error("aws.sts: profile chain too deep resolving '" .. name .. "' (circular source_profile?)")
+  end
+  local p = profile_entry(name, opts)
+  if not p then
+    error("aws.sts: profile '" .. name .. "' not found in ~/.aws/config or ~/.aws/credentials")
+  end
+  if p.aws_access_key_id and p.aws_secret_access_key and not p.role_arn then
+    return {
+      access_key = p.aws_access_key_id,
+      secret_key = p.aws_secret_access_key,
+      session_token = p.aws_session_token,
+    }
+  end
+  if p.role_arn then
+    local call_opts = {
+      region = (opts and opts.region) or p.region,
+      sts_endpoint = opts and opts.sts_endpoint,
+      session_name = "assay-" .. name,
+    }
+    if p.web_identity_token_file then
+      local token = fs.read(p.web_identity_token_file)
+      return M.assume_role_with_web_identity(p.role_arn, token, call_opts)
+    end
+    local base
+    if p.aws_access_key_id and p.aws_secret_access_key then
+      base = {
+        access_key = p.aws_access_key_id,
+        secret_key = p.aws_secret_access_key,
+        session_token = p.aws_session_token,
+      }
+    elseif p.source_profile then
+      base = resolve_profile(p.source_profile, opts, depth + 1)
+    else
+      -- credential_source=Environment or nothing: fall through to the env/IRSA chain.
+      base = M.credentials({
+        region = call_opts.region,
+        sts_endpoint = call_opts.sts_endpoint,
+        no_profile = true,
+      })
+    end
+    call_opts.credentials = base
+    return M.assume_role(p.role_arn, call_opts)
+  end
+  error("aws.sts: profile '" .. name .. "' has neither static keys nor a role_arn")
+end
+
+--- Resolve AWS credentials the way the AWS CLI does, in-process:
+---   1. opts.access_key / opts.secret_key — explicit, used verbatim
+---   2. opts.profile (or AWS_PROFILE) — ~/.aws/credentials + ~/.aws/config,
+---      following role_arn + source_profile chains and web_identity_token_file
+---   3. AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY (+ AWS_SESSION_TOKEN) env vars
+---   4. IRSA: AWS_ROLE_ARN + AWS_WEB_IDENTITY_TOKEN_FILE (in-cluster pods)
+--- If opts.role_arn is set, the resolved credentials then assume that role.
+--- Temporary credentials are cached until shortly before expiry.
+---
+--- @param opts table|nil { access_key, secret_key, session_token, profile, role_arn, region, sts_endpoint, config_file, credentials_file }
+--- @return table { access_key, secret_key, session_token? }
+function M.credentials(opts)
+  opts = opts or {}
+  local base
+
+  if opts.access_key and opts.secret_key then
+    base = {
+      access_key = opts.access_key,
+      secret_key = opts.secret_key,
+      session_token = opts.session_token,
+    }
+  else
+    local profile = not opts.no_profile and (opts.profile or env.get("AWS_PROFILE")) or nil
+    if profile then
+      local key = "profile:" .. profile
+      base = cache_get(key)
+      if not base then
+        base = resolve_profile(profile, opts, 1)
+        _cache[key] = base
+      end
+    elseif env.get("AWS_ACCESS_KEY_ID") and env.get("AWS_SECRET_ACCESS_KEY") then
+      base = {
+        access_key = env.get("AWS_ACCESS_KEY_ID"),
+        secret_key = env.get("AWS_SECRET_ACCESS_KEY"),
+        session_token = env.get("AWS_SESSION_TOKEN"),
+      }
+    elseif env.get("AWS_ROLE_ARN") and env.get("AWS_WEB_IDENTITY_TOKEN_FILE") then
+      local role = env.get("AWS_ROLE_ARN")
+      local key = "irsa:" .. role
+      base = cache_get(key)
+      if not base then
+        local token = fs.read(env.get("AWS_WEB_IDENTITY_TOKEN_FILE"))
+        base = M.assume_role_with_web_identity(role, token, opts)
+        _cache[key] = base
+      end
+    else
+      error(
+        "aws.sts: no credentials found — pass access_key/secret_key or profile, "
+          .. "or set AWS_PROFILE / AWS_ACCESS_KEY_ID / AWS_ROLE_ARN+AWS_WEB_IDENTITY_TOKEN_FILE"
+      )
+    end
+  end
+
+  if opts.role_arn then
+    local key = "role:" .. opts.role_arn .. "|" .. (base.access_key or "")
+    local assumed = cache_get(key)
+    if not assumed then
+      assumed = M.assume_role(opts.role_arn, {
+        credentials = base,
+        region = opts.region,
+        sts_endpoint = opts.sts_endpoint,
+      })
+      _cache[key] = assumed
+    end
+    return assumed
+  end
+  return base
+end
+
+return M

--- a/crates/assay/stdlib/k8s.lua
+++ b/crates/assay/stdlib/k8s.lua
@@ -1,7 +1,9 @@
 --- @module assay.k8s
---- @description Kubernetes API client for Kubernetes clusters. 30+ resource types, CRDs, readiness checks, pod logs, rollouts.
---- @keywords kubernetes, k8s, pods, deployments, services, secrets, configmaps, namespaces, crd, custom-resources, rbac, events, logs, rollout, nodes, readiness, wait, deploy, deployment
---- @env KUBERNETES_SERVICE_HOST, KUBERNETES_SERVICE_PORT
+--- @description Kubernetes API client for Kubernetes clusters. 30+ resource types, CRDs, readiness checks, pod logs, rollouts. Multi-cluster via kubeconfig contexts (pass opts.context on any call, or k8s.use_context(name)); EKS aws exec-plugin auth is minted in-process.
+--- @keywords kubernetes, k8s, pods, deployments, services, secrets, configmaps, namespaces, crd, custom-resources, rbac, events, logs, rollout, nodes, readiness, wait, deploy, deployment, kubeconfig, context, multi-cluster, eks
+--- @env KUBERNETES_SERVICE_HOST, KUBERNETES_SERVICE_PORT, KUBECONFIG, ASSAY_K8S_CONTEXT, HOME
+--- @quickref M.contexts(opts?) -> [name], current | List kubeconfig context names + current-context
+--- @quickref M.use_context(name) -> nil | Set the default kubeconfig context for all calls
 --- @quickref M.register_crd(kind, api_group, version, plural, cluster_scoped?) -> nil | Register custom resource
 --- @quickref M.get(path, opts?) -> resource | GET any K8s API path
 --- @quickref M.post(path, body, opts?) -> resource | POST to any K8s API path
@@ -61,6 +63,181 @@ end
 
 local function auth_headers(token)
   return { Authorization = "Bearer " .. (token or sa_token()) }
+end
+
+-- ===== kubeconfig contexts (multi-cluster) =====
+--
+-- Cluster targeting, in priority order:
+--   1. opts.base_url (+ opts.token)                — raw, unchanged behavior
+--   2. opts.context                                — a kubeconfig context, per call
+--   3. M.use_context(name) / ASSAY_K8S_CONTEXT env — a default kubeconfig context
+--   4. in-cluster ServiceAccount                   — the pod's own cluster (default)
+-- Contexts are read from opts.kubeconfig, $KUBECONFIG, or ~/.kube/config. User
+-- auth supported: a static `token`, or the aws `eks get-token` exec plugin —
+-- which is recognized and minted IN-PROCESS via assay.aws.eks (subprocesses are
+-- blocked in readonly mode, so the plugin command is never actually run).
+
+local EKS_TOKEN_TTL_SECS = 600
+
+M._default_context = nil
+local _kubecfg = nil -- { path, doc } parse cache
+local _ctx_cache = {} -- context name -> { base_url, client, static_token, exec, token, token_expires_at }
+
+function M.use_context(name)
+  M._default_context = name
+end
+
+local function kubeconfig_path(opts)
+  return (opts and opts.kubeconfig) or env.get("KUBECONFIG")
+    or ((env.get("HOME") or "") .. "/.kube/config")
+end
+
+local function load_kubeconfig(opts)
+  local path = kubeconfig_path(opts)
+  if _kubecfg and _kubecfg.path == path then return _kubecfg.doc end
+  local ok, text = pcall(fs.read, path)
+  if not ok then
+    error("k8s: cannot read kubeconfig at " .. path .. " (set KUBECONFIG or pass opts.kubeconfig)")
+  end
+  local doc = yaml.parse(text)
+  _kubecfg = { path = path, doc = doc }
+  return doc
+end
+
+--- List the kubeconfig's context names and its current-context.
+function M.contexts(opts)
+  local doc = load_kubeconfig(opts)
+  local names = {}
+  for _, c in ipairs(doc.contexts or {}) do names[#names + 1] = c.name end
+  return names, doc["current-context"]
+end
+
+local function find_named(list, name)
+  for _, e in ipairs(list or {}) do
+    if e.name == name then return e end
+  end
+end
+
+-- Recognize the aws `eks get-token` exec plugin and lift what we need to mint
+-- the token in-process: cluster name, region, role, profile (from args or the
+-- exec env block).
+local function parse_aws_exec(exec)
+  local cmd = exec.command or ""
+  if not (cmd == "aws" or cmd:match("/aws$")) then return nil end
+  local args = exec.args or {}
+  local seen_get_token = false
+  local flags = {}
+  local i = 1
+  while i <= #args do
+    local a = args[i]
+    if a == "get-token" then
+      seen_get_token = true
+    elseif a:match("^%-%-") and args[i + 1] and not args[i + 1]:match("^%-%-") then
+      flags[a] = args[i + 1]
+      i = i + 1
+    end
+    i = i + 1
+  end
+  if not seen_get_token or not flags["--cluster-name"] then return nil end
+  local from_env = {}
+  for _, e in ipairs(exec.env or {}) do
+    from_env[e.name] = e.value
+  end
+  return {
+    cluster_name = flags["--cluster-name"],
+    region = flags["--region"] or from_env.AWS_REGION or from_env.AWS_DEFAULT_REGION,
+    role_arn = flags["--role-arn"],
+    profile = flags["--profile"] or from_env.AWS_PROFILE,
+    access_key = from_env.AWS_ACCESS_KEY_ID,
+    secret_key = from_env.AWS_SECRET_ACCESS_KEY,
+    session_token = from_env.AWS_SESSION_TOKEN,
+  }
+end
+
+local function resolve_context(name, opts)
+  local cached = _ctx_cache[name]
+  if not cached then
+    local doc = load_kubeconfig(opts)
+    local ctx = find_named(doc.contexts, name)
+    if not ctx then
+      error("k8s: context '" .. name .. "' not found in kubeconfig " .. kubeconfig_path(opts))
+    end
+    local cluster_entry = find_named(doc.clusters, ctx.context.cluster)
+    local user_entry = find_named(doc.users, ctx.context.user)
+    if not cluster_entry or not user_entry then
+      error("k8s: kubeconfig context '" .. name .. "' references a missing cluster or user")
+    end
+    local cluster = cluster_entry.cluster
+    local user = user_entry.user or {}
+
+    local client_opts = {}
+    if cluster["certificate-authority-data"] then
+      client_opts.ca_cert = base64.decode(cluster["certificate-authority-data"])
+    elseif cluster["certificate-authority"] then
+      client_opts.ca_cert_file = cluster["certificate-authority"]
+    end
+    local ok, client = pcall(http.client, client_opts)
+    if not ok then client = http.client({}) end
+
+    if user["client-certificate-data"] or user["client-certificate"] then
+      error("k8s: context '" .. name .. "' uses client-certificate auth, which is not supported")
+    end
+    local exec_cfg = nil
+    if not user.token and user.exec then
+      exec_cfg = parse_aws_exec(user.exec)
+      if not exec_cfg then
+        error(
+          "k8s: context '" .. name .. "' uses an unsupported exec credential plugin ("
+            .. tostring(user.exec.command)
+            .. ") — only static tokens and the aws eks get-token plugin (minted in-process) are supported"
+        )
+      end
+    elseif not user.token then
+      error("k8s: context '" .. name .. "' has no supported auth (token or aws eks get-token exec)")
+    end
+
+    cached = {
+      base_url = cluster.server:gsub("/+$", ""),
+      client = client,
+      static_token = user.token,
+      exec = exec_cfg,
+      token = nil,
+      token_expires_at = 0,
+    }
+    _ctx_cache[name] = cached
+  end
+
+  if cached.static_token then
+    cached.token = cached.static_token
+  elseif not cached.token or os.time() > cached.token_expires_at then
+    local eks = require("assay.aws.eks")
+    cached.token = eks.get_token(cached.exec.cluster_name, {
+      region = cached.exec.region,
+      role_arn = cached.exec.role_arn,
+      profile = cached.exec.profile,
+      access_key = cached.exec.access_key,
+      secret_key = cached.exec.secret_key,
+      session_token = cached.exec.session_token,
+    })
+    cached.token_expires_at = os.time() + EKS_TOKEN_TTL_SECS - 60
+  end
+  return cached
+end
+
+-- Resolve where a call goes: {base, client, token}. See the priority order in
+-- the section comment above. Fully backward compatible — with no context
+-- configured, behavior is identical to the pre-context module.
+local function target(opts)
+  opts = opts or {}
+  if opts.base_url then
+    return { base = opts.base_url, client = get_http(), token = opts.token }
+  end
+  local ctx = opts.context or M._default_context or env.get("ASSAY_K8S_CONTEXT")
+  if ctx then
+    local t = resolve_context(ctx, opts)
+    return { base = t.base_url, client = t.client, token = opts.token or t.token }
+  end
+  return { base = api_base(), client = get_http(), token = opts.token }
 end
 
 -- Percent-encode a value for a URL query component. Keeps the RFC 3986
@@ -139,10 +316,9 @@ end
 -- ===== Raw HTTP verbs (top-level) =====
 
 function M.get(path, opts)
-  opts = opts or {}
-  local url = (opts.base_url or api_base()) .. path
-  local resp = get_http():get(url, {
-    headers = auth_headers(opts.token),
+  local t = target(opts)
+  local resp = t.client:get(t.base .. path, {
+    headers = auth_headers(t.token),
   })
   if resp.status ~= 200 then
     error("k8s.get: HTTP " .. resp.status .. " " .. path .. ": " .. resp.body)
@@ -151,10 +327,9 @@ function M.get(path, opts)
 end
 
 function M.post(path, body, opts)
-  opts = opts or {}
-  local url = (opts.base_url or api_base()) .. path
-  local resp = get_http():post(url, body, {
-    headers = auth_headers(opts.token),
+  local t = target(opts)
+  local resp = t.client:post(t.base .. path, body, {
+    headers = auth_headers(t.token),
   })
   if resp.status < 200 or resp.status >= 300 then
     error("k8s.post: HTTP " .. resp.status .. " " .. path .. ": " .. resp.body)
@@ -163,10 +338,9 @@ function M.post(path, body, opts)
 end
 
 function M.put(path, body, opts)
-  opts = opts or {}
-  local url = (opts.base_url or api_base()) .. path
-  local resp = get_http():put(url, body, {
-    headers = auth_headers(opts.token),
+  local t = target(opts)
+  local resp = t.client:put(t.base .. path, body, {
+    headers = auth_headers(t.token),
   })
   if resp.status < 200 or resp.status >= 300 then
     error("k8s.put: HTTP " .. resp.status .. " " .. path .. ": " .. resp.body)
@@ -176,11 +350,11 @@ end
 
 function M.patch(path, body, opts)
   opts = opts or {}
-  local url = (opts.base_url or api_base()) .. path
-  local hdrs = auth_headers(opts.token)
+  local t = target(opts)
+  local hdrs = auth_headers(t.token)
   hdrs["Content-Type"] = opts.content_type or "application/merge-patch+json"
   local encoded = type(body) == "table" and json.encode(body) or body
-  local resp = get_http():patch(url, encoded, {
+  local resp = t.client:patch(t.base .. path, encoded, {
     headers = hdrs,
   })
   if resp.status < 200 or resp.status >= 300 then
@@ -190,10 +364,9 @@ function M.patch(path, body, opts)
 end
 
 function M.delete(path, opts)
-  opts = opts or {}
-  local url = (opts.base_url or api_base()) .. path
-  local resp = get_http():delete(url, {
-    headers = auth_headers(opts.token),
+  local t = target(opts)
+  local resp = t.client:delete(t.base .. path, {
+    headers = auth_headers(t.token),
   })
   if resp.status < 200 or resp.status >= 300 then
     error("k8s.delete: HTTP " .. resp.status .. " " .. path .. ": " .. resp.body)
@@ -238,11 +411,10 @@ function M.resources:delete(namespace, kind, name, opts)
 end
 
 function M.resources:exists(namespace, kind, name, opts)
-  opts = opts or {}
   local api_path = M._resource_path(namespace, kind, name)
-  local url = (opts.base_url or api_base()) .. api_path
-  local resp = get_http():get(url, {
-    headers = auth_headers(opts.token),
+  local t = target(opts)
+  local resp = t.client:get(t.base .. api_path, {
+    headers = auth_headers(t.token),
   })
   return resp.status == 200
 end
@@ -368,9 +540,9 @@ function M.pods:logs(namespace, pod_name, opts)
   if #params > 0 then
     path = path .. "?" .. table.concat(params, "&")
   end
-  local url = (opts.base_url or api_base()) .. path
-  local resp = get_http():get(url, {
-    headers = auth_headers(opts.token),
+  local t = target(opts)
+  local resp = t.client:get(t.base .. path, {
+    headers = auth_headers(t.token),
   })
   if resp.status ~= 200 then
     error("k8s.logs: HTTP " .. resp.status .. " " .. path .. ": " .. resp.body)
@@ -449,15 +621,15 @@ function M.pods:exec(namespace, pod_name, command, opts)
   params[#params + 1] = "stdin=" .. tostring(opts.stdin == true)
   params[#params + 1] = "tty=" .. tostring(opts.tty == true)
 
-  local base = opts.base_url or api_base()
-  local ws_base = base:gsub("^https://", "wss://"):gsub("^http://", "ws://")
+  local t = target(opts)
+  local ws_base = t.base:gsub("^https://", "wss://"):gsub("^http://", "ws://")
   local url = ws_base
     .. "/api/v1/namespaces/" .. namespace .. "/pods/" .. pod_name .. "/exec"
     .. "?" .. table.concat(params, "&")
 
   local conn = ws.connect(url, {
     subprotocols = { "v4.channel.k8s.io" },
-    headers = auth_headers(opts.token),
+    headers = auth_headers(t.token),
     insecure = insecure,
   })
 

--- a/crates/assay/tests/stdlib_aws_eks.rs
+++ b/crates/assay/tests/stdlib_aws_eks.rs
@@ -1,0 +1,55 @@
+mod common;
+
+use common::run_lua;
+
+// The EKS token is a presigned sts:GetCallerIdentity URL, base64url-encoded
+// with the k8s-aws-v1. prefix — minted entirely in-process (no aws CLI).
+#[tokio::test]
+async fn test_eks_get_token_shape() {
+    let script = r#"
+        local eks = require("assay.aws.eks")
+        local token = eks.get_token("my-cluster", {
+            access_key = "AKIAIOSFODNN7EXAMPLE",
+            secret_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+            region = "us-east-1",
+            time = 1720000000,
+        })
+        assert.eq(token:sub(1, 11), "k8s-aws-v1.")
+
+        -- Decode the base64url payload back to the presigned URL and verify it.
+        local b64 = token:sub(12):gsub("-", "+"):gsub("_", "/")
+        local pad = #b64 % 4
+        if pad == 2 then b64 = b64 .. "==" elseif pad == 3 then b64 = b64 .. "=" end
+        local url = base64.decode(b64)
+        assert.contains(url, "https://sts.us-east-1.amazonaws.com/?")
+        assert.contains(url, "Action=GetCallerIdentity")
+        assert.contains(url, "Version=2011-06-15")
+        assert.contains(url, "X-Amz-SignedHeaders=host%3Bx-k8s-aws-id")
+        assert.contains(url, "X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20240703%2Fus-east-1%2Fsts%2Faws4_request")
+        assert.not_nil(url:match("X%-Amz%-Signature=%x+"))
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_eks_get_token_session_token_included() {
+    let script = r#"
+        local eks = require("assay.aws.eks")
+        local token = eks.get_token("qa-workload", {
+            credentials = {
+                access_key = "ASIATEMP",
+                secret_key = "tempsecret",
+                session_token = "temptoken",
+            },
+            region = "eu-west-1",
+            time = 1720000000,
+        })
+        local b64 = token:sub(12):gsub("-", "+"):gsub("_", "/")
+        local pad = #b64 % 4
+        if pad == 2 then b64 = b64 .. "==" elseif pad == 3 then b64 = b64 .. "=" end
+        local url = base64.decode(b64)
+        assert.contains(url, "sts.eu-west-1.amazonaws.com")
+        assert.contains(url, "X-Amz-Security-Token=temptoken")
+    "#;
+    run_lua(script).await.unwrap();
+}

--- a/crates/assay/tests/stdlib_aws_sigv4.rs
+++ b/crates/assay/tests/stdlib_aws_sigv4.rs
@@ -112,3 +112,56 @@ async fn test_sigv4_sign_defaults_method_to_get() {
     "#;
     run_lua(script).await.unwrap();
 }
+
+#[tokio::test]
+async fn test_sigv4_presign_produces_query_signed_url() {
+    let script = r#"
+        local sigv4 = require("assay.aws.sigv4")
+        local url = sigv4.presign({
+            access_key = "AKIAIOSFODNN7EXAMPLE",
+            secret_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+            service = "sts",
+            region = "us-east-1",
+            host = "sts.us-east-1.amazonaws.com",
+            query = { Action = "GetCallerIdentity", Version = "2011-06-15" },
+            headers = { ["x-k8s-aws-id"] = "my-cluster" },
+            expires = 60,
+            time = 1720000000,
+        })
+        assert.contains(url, "https://sts.us-east-1.amazonaws.com/?")
+        assert.contains(url, "Action=GetCallerIdentity")
+        assert.contains(url, "X-Amz-Algorithm=AWS4-HMAC-SHA256")
+        assert.contains(url, "X-Amz-Credential=AKIAIOSFODNN7EXAMPLE%2F20240703%2Fus-east-1%2Fsts%2Faws4_request")
+        assert.contains(url, "X-Amz-Expires=60")
+        assert.contains(url, "X-Amz-SignedHeaders=host%3Bx-k8s-aws-id")
+        local sig = url:match("X%-Amz%-Signature=(%x+)")
+        assert.not_nil(sig)
+        assert.eq(#sig, 64)
+        -- Deterministic: same inputs + time -> same URL.
+        local url2 = sigv4.presign({
+            access_key = "AKIAIOSFODNN7EXAMPLE",
+            secret_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+            service = "sts",
+            region = "us-east-1",
+            host = "sts.us-east-1.amazonaws.com",
+            query = { Action = "GetCallerIdentity", Version = "2011-06-15" },
+            headers = { ["x-k8s-aws-id"] = "my-cluster" },
+            expires = 60,
+            time = 1720000000,
+        })
+        assert.eq(url, url2)
+        -- Session tokens are carried and signed.
+        local url3 = sigv4.presign({
+            access_key = "ASIAEXAMPLE",
+            secret_key = "secret",
+            session_token = "tok/with+chars=",
+            service = "sts",
+            region = "eu-west-1",
+            host = "sts.eu-west-1.amazonaws.com",
+            query = { Action = "GetCallerIdentity", Version = "2011-06-15" },
+            time = 1720000000,
+        })
+        assert.contains(url3, "X-Amz-Security-Token=tok%2Fwith%2Bchars%3D")
+    "#;
+    run_lua(script).await.unwrap();
+}

--- a/crates/assay/tests/stdlib_aws_sts.rs
+++ b/crates/assay/tests/stdlib_aws_sts.rs
@@ -1,0 +1,222 @@
+mod common;
+
+use common::run_lua;
+use wiremock::matchers::{body_string_contains, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+// STS answers the query protocol in JSON when the Accept header asks for it —
+// Expiration arrives as epoch seconds. These mocks mirror that shape.
+
+fn sts_json(result_key: &str, access_key: &str) -> serde_json::Value {
+    serde_json::json!({
+        format!("{result_key}Response"): {
+            format!("{result_key}Result"): {
+                "Credentials": {
+                    "AccessKeyId": access_key,
+                    "SecretAccessKey": "resolved-secret",
+                    "SessionToken": "resolved-session-token",
+                    "Expiration": 9999999999u64,
+                }
+            }
+        }
+    })
+}
+
+#[tokio::test]
+async fn test_parse_ini() {
+    let script = r#"
+        local sts = require("assay.aws.sts")
+        local sections = sts._parse_ini([[
+# a comment
+[default]
+aws_access_key_id = AKIDDEFAULT
+aws_secret_access_key = sekret
+
+[profile qa]
+role_arn = arn:aws:iam::111122223333:role/qa-read
+source_profile = default
+region = eu-west-1
+]])
+        assert.eq(sections["default"].aws_access_key_id, "AKIDDEFAULT")
+        assert.eq(sections["default"].aws_secret_access_key, "sekret")
+        assert.eq(sections["profile qa"].role_arn, "arn:aws:iam::111122223333:role/qa-read")
+        assert.eq(sections["profile qa"].source_profile, "default")
+        assert.eq(sections["profile qa"].region, "eu-west-1")
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_credentials_explicit_passthrough() {
+    let script = r#"
+        local sts = require("assay.aws.sts")
+        local c = sts.credentials({ access_key = "AKID", secret_key = "sec", session_token = "tok" })
+        assert.eq(c.access_key, "AKID")
+        assert.eq(c.secret_key, "sec")
+        assert.eq(c.session_token, "tok")
+    "#;
+    run_lua(script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_credentials_static_profile_from_files() {
+    let dir = tempfile::tempdir().unwrap();
+    let creds_path = dir.path().join("credentials");
+    std::fs::write(
+        &creds_path,
+        "[myprofile]\naws_access_key_id = AKIDPROF\naws_secret_access_key = profsecret\n",
+    )
+    .unwrap();
+
+    let script = format!(
+        r#"
+        local sts = require("assay.aws.sts")
+        local c = sts.credentials({{
+            profile = "myprofile",
+            credentials_file = "{creds}",
+            config_file = "/nonexistent-config",
+        }})
+        assert.eq(c.access_key, "AKIDPROF")
+        assert.eq(c.secret_key, "profsecret")
+        "#,
+        creds = creds_path.display()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_credentials_profile_role_chain_via_assume_role() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/"))
+        .and(body_string_contains("Action=AssumeRole"))
+        .and(body_string_contains(
+            "RoleArn=arn%3Aaws%3Aiam%3A%3A111122223333%3Arole%2Fqa-read",
+        ))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(sts_json("AssumeRole", "ASIACHAINED")),
+        )
+        .mount(&server)
+        .await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let creds_path = dir.path().join("credentials");
+    std::fs::write(
+        &creds_path,
+        "[base]\naws_access_key_id = AKIDBASE\naws_secret_access_key = basesecret\n",
+    )
+    .unwrap();
+    let config_path = dir.path().join("config");
+    std::fs::write(
+        &config_path,
+        "[profile qa]\nrole_arn = arn:aws:iam::111122223333:role/qa-read\nsource_profile = base\n",
+    )
+    .unwrap();
+
+    let script = format!(
+        r#"
+        local sts = require("assay.aws.sts")
+        local c = sts.credentials({{
+            profile = "qa",
+            credentials_file = "{creds}",
+            config_file = "{config}",
+            sts_endpoint = "{sts}",
+        }})
+        assert.eq(c.access_key, "ASIACHAINED")
+        assert.eq(c.secret_key, "resolved-secret")
+        assert.eq(c.session_token, "resolved-session-token")
+        "#,
+        creds = creds_path.display(),
+        config = config_path.display(),
+        sts = server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_assume_role_with_web_identity() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/"))
+        .and(body_string_contains("Action=AssumeRoleWithWebIdentity"))
+        .and(body_string_contains("WebIdentityToken=oidc-token-body"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(sts_json("AssumeRoleWithWebIdentity", "ASIAWEBID")),
+        )
+        .mount(&server)
+        .await;
+
+    let script = format!(
+        r#"
+        local sts = require("assay.aws.sts")
+        local c = sts.assume_role_with_web_identity(
+            "arn:aws:iam::111122223333:role/irsa-role",
+            "oidc-token-body",
+            {{ sts_endpoint = "{sts}" }}
+        )
+        assert.eq(c.access_key, "ASIAWEBID")
+        assert.eq(c.session_token, "resolved-session-token")
+        "#,
+        sts = server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_profile_web_identity_token_file() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/"))
+        .and(body_string_contains("Action=AssumeRoleWithWebIdentity"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(sts_json("AssumeRoleWithWebIdentity", "ASIAFROMFILE")),
+        )
+        .mount(&server)
+        .await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let token_path = dir.path().join("oidc-token");
+    std::fs::write(&token_path, "token-from-file").unwrap();
+    let config_path = dir.path().join("config");
+    std::fs::write(
+        &config_path,
+        format!(
+            "[profile irsa]\nrole_arn = arn:aws:iam::111122223333:role/irsa\nweb_identity_token_file = {}\n",
+            token_path.display()
+        ),
+    )
+    .unwrap();
+
+    let script = format!(
+        r#"
+        local sts = require("assay.aws.sts")
+        local c = sts.credentials({{
+            profile = "irsa",
+            credentials_file = "/nonexistent-credentials",
+            config_file = "{config}",
+            sts_endpoint = "{sts}",
+        }})
+        assert.eq(c.access_key, "ASIAFROMFILE")
+        "#,
+        config = config_path.display(),
+        sts = server.uri()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_missing_profile_errors_clearly() {
+    let script = r#"
+        local sts = require("assay.aws.sts")
+        local ok, err = pcall(sts.credentials, {
+            profile = "ghost",
+            credentials_file = "/nonexistent",
+            config_file = "/nonexistent",
+        })
+        assert.eq(ok, false)
+        assert.contains(tostring(err), "profile 'ghost' not found")
+    "#;
+    run_lua(script).await.unwrap();
+}

--- a/crates/assay/tests/stdlib_k8s_contexts.rs
+++ b/crates/assay/tests/stdlib_k8s_contexts.rs
@@ -1,0 +1,210 @@
+mod common;
+
+use common::run_lua;
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+// Kubeconfig-context support: k8s calls can target any cluster in a kubeconfig
+// via opts.context / k8s.use_context(), with static-token users honored as-is
+// and the aws `eks get-token` exec plugin minted in-process (no subprocess —
+// works in readonly mode).
+
+fn write_kubeconfig(dir: &std::path::Path, server_uri: &str) -> std::path::PathBuf {
+    let kubeconfig = format!(
+        r#"apiVersion: v1
+kind: Config
+current-context: static-ctx
+clusters:
+  - name: static-cluster
+    cluster:
+      server: {server_uri}
+  - name: eks-cluster
+    cluster:
+      server: {server_uri}
+contexts:
+  - name: static-ctx
+    context:
+      cluster: static-cluster
+      user: static-user
+  - name: eks-ctx
+    context:
+      cluster: eks-cluster
+      user: eks-user
+  - name: broken-ctx
+    context:
+      cluster: static-cluster
+      user: exotic-user
+users:
+  - name: static-user
+    user:
+      token: static-bearer-token
+  - name: eks-user
+    user:
+      exec:
+        apiVersion: client.authentication.k8s.io/v1beta1
+        command: aws
+        args:
+          - --region
+          - us-east-1
+          - eks
+          - get-token
+          - --cluster-name
+          - my-eks-cluster
+        env:
+          - name: AWS_ACCESS_KEY_ID
+            value: AKIDEXEC
+          - name: AWS_SECRET_ACCESS_KEY
+            value: execsecret
+  - name: exotic-user
+    user:
+      exec:
+        apiVersion: client.authentication.k8s.io/v1beta1
+        command: gke-gcloud-auth-plugin
+"#
+    );
+    let path = dir.join("kubeconfig");
+    std::fs::write(&path, kubeconfig).unwrap();
+    path
+}
+
+#[tokio::test]
+async fn test_context_with_static_token() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/v1/namespaces"))
+        .and(header("Authorization", "Bearer static-bearer-token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({ "items": [] })))
+        .mount(&server)
+        .await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let kc = write_kubeconfig(dir.path(), &server.uri());
+
+    let script = format!(
+        r#"
+        local k8s = require("assay.k8s")
+        local out = k8s.get("/api/v1/namespaces", {{ context = "static-ctx", kubeconfig = "{kc}" }})
+        assert.not_nil(out.items)
+        "#,
+        kc = kc.display()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_context_with_aws_exec_plugin_mints_token_in_process() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/v1/namespaces"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({ "items": [] })))
+        .mount(&server)
+        .await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let kc = write_kubeconfig(dir.path(), &server.uri());
+
+    let script = format!(
+        r#"
+        local k8s = require("assay.k8s")
+        local out = k8s.get("/api/v1/namespaces", {{ context = "eks-ctx", kubeconfig = "{kc}" }})
+        assert.not_nil(out.items)
+        "#,
+        kc = kc.display()
+    );
+    run_lua(&script).await.unwrap();
+
+    // The minted bearer token must be an in-process k8s-aws-v1 EKS token.
+    let requests = server.received_requests().await.unwrap();
+    assert!(!requests.is_empty());
+    let auth = requests[0]
+        .headers
+        .get("authorization")
+        .expect("authorization header")
+        .to_str()
+        .unwrap();
+    assert!(
+        auth.starts_with("Bearer k8s-aws-v1."),
+        "expected an in-process EKS token, got: {auth}"
+    );
+}
+
+#[tokio::test]
+async fn test_use_context_sets_default() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/v1/pods"))
+        .and(header("Authorization", "Bearer static-bearer-token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({ "items": [] })))
+        .mount(&server)
+        .await;
+
+    let dir = tempfile::tempdir().unwrap();
+    let kc = write_kubeconfig(dir.path(), &server.uri());
+
+    let script = format!(
+        r#"
+        local k8s = require("assay.k8s")
+        k8s.use_context("static-ctx")
+        local out = k8s.get("/api/v1/pods", {{ kubeconfig = "{kc}" }})
+        assert.not_nil(out.items)
+        "#,
+        kc = kc.display()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_contexts_listing() {
+    let server = MockServer::start().await;
+    let dir = tempfile::tempdir().unwrap();
+    let kc = write_kubeconfig(dir.path(), &server.uri());
+
+    let script = format!(
+        r#"
+        local k8s = require("assay.k8s")
+        local names, current = k8s.contexts({{ kubeconfig = "{kc}" }})
+        assert.eq(#names, 3)
+        assert.eq(names[1], "static-ctx")
+        assert.eq(names[2], "eks-ctx")
+        assert.eq(current, "static-ctx")
+        "#,
+        kc = kc.display()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_unknown_context_errors() {
+    let server = MockServer::start().await;
+    let dir = tempfile::tempdir().unwrap();
+    let kc = write_kubeconfig(dir.path(), &server.uri());
+
+    let script = format!(
+        r#"
+        local k8s = require("assay.k8s")
+        local ok, err = pcall(k8s.get, "/api/v1/pods", {{ context = "ghost", kubeconfig = "{kc}" }})
+        assert.eq(ok, false)
+        assert.contains(tostring(err), "context 'ghost' not found")
+        "#,
+        kc = kc.display()
+    );
+    run_lua(&script).await.unwrap();
+}
+
+#[tokio::test]
+async fn test_unsupported_exec_plugin_errors() {
+    let server = MockServer::start().await;
+    let dir = tempfile::tempdir().unwrap();
+    let kc = write_kubeconfig(dir.path(), &server.uri());
+
+    let script = format!(
+        r#"
+        local k8s = require("assay.k8s")
+        local ok, err = pcall(k8s.get, "/api/v1/pods", {{ context = "broken-ctx", kubeconfig = "{kc}" }})
+        assert.eq(ok, false)
+        assert.contains(tostring(err), "unsupported exec credential plugin")
+        "#,
+        kc = kc.display()
+    );
+    run_lua(&script).await.unwrap();
+}

--- a/site/static/llms.txt
+++ b/site/static/llms.txt
@@ -35,7 +35,7 @@
 - [assay.sonarqube](https://assay.rs/modules/sonarqube.html): SonarQube quality gates, issues, hotspots, measures
 
 ## Kubernetes & GitOps
-- [assay.k8s](https://assay.rs/modules/k8s.html): 30+ K8s resource types, CRDs, readiness checks, pod logs + exec
+- [assay.k8s](https://assay.rs/modules/k8s.html): 30+ K8s resource types, CRDs, readiness checks, pod logs + exec; multi-cluster via kubeconfig contexts (EKS exec auth minted in-process)
 - [assay.argocd](https://assay.rs/modules/argocd.html): ArgoCD apps, sync, health, projects
 - [assay.kargo](https://assay.rs/modules/kargo.html): Kargo stages, freight, promotions
 - [assay.flux](https://assay.rs/modules/flux.html): Flux GitRepositories, Kustomizations, HelmReleases
@@ -64,6 +64,8 @@
 - [assay.s3](https://assay.rs/modules/s3.html): S3-compatible storage (AWS, R2, MinIO) with Sig V4
 - [assay.aws.ec2](https://assay.rs/modules/aws-ec2.html): AWS EC2 read queries over Sig V4 — instances, volumes, security groups
 - [assay.aws.s3](https://assay.rs/modules/aws-s3.html): AWS S3 read over Sig V4 — list buckets/objects, head object
+- [assay.aws.sts](https://assay.rs/modules/aws-sts.html): AWS credential chain (profile/env/IRSA) + AssumeRole, in-process
+- [assay.aws.eks](https://assay.rs/modules/aws-eks.html): EKS bearer tokens (aws eks get-token equivalent), in-process
 
 ## Feature Flags & Utilities
 - [assay.unleash](https://assay.rs/modules/unleash.html): Unleash feature flags, environments, strategies


### PR DESCRIPTION
Makes assay actually usable from a host that holds only IRSA + a multi-cluster kubeconfig (the common EKS-pod shape): the k8s module was locked to the in-cluster ServiceAccount, and the aws modules hard-required literal access keys.

## What ships

- **`assay.k8s` multi-cluster**: `opts.context` on any call / `k8s.use_context(name)` / `ASSAY_K8S_CONTEXT`, resolved from the kubeconfig (server + CA per context, per-context HTTP clients). User auth: static `token`, or the **aws `eks get-token` exec plugin recognized and minted in-process** (no subprocess — works in readonly mode; `--role-arn`/`--profile`/exec-`env` honored). `k8s.contexts()` lists them. **Backward compatible**: no context configured → in-cluster SA exactly as before.
- **`assay.aws.sts` (new)**: the AWS CLI credential chain in-process — explicit → profile (`~/.aws` incl. `role_arn`+`source_profile` chains, `web_identity_token_file`) → env → IRSA; `assume_role` + `assume_role_with_web_identity`; temp-cred caching; JSON STS responses (no XML).
- **`assay.aws.eks` (new)**: `k8s-aws-v1.` bearer tokens minted in-process via presigned `sts:GetCallerIdentity`.
- **`sigv4.presign`**: query-string signing; `opts.time` for deterministic tests.
- **`aws.ec2/s3/ecr`**: credential-chain fallback when keys are omitted (`opts.profile`/`opts.role_arn`); region env fallback. Explicit keys unchanged.

## Verification

- 22 new tests: sigv4 presign shape/determinism, sts chain (ini parsing, static profile, role chain via wiremock AssumeRole, web identity), eks token shape (decoded + inspected), k8s contexts (static token, **in-process exec-plugin minting asserted via the Bearer prefix**, use_context default, listing, unknown-context + unsupported-plugin errors).
- Full assay-lua suite green (116 binaries, 0 failures). clippy + fmt clean.

## Release

Bumps `assay-lua` 0.17.3 → **0.17.4** (patch — all additive) and cuts the CHANGELOG heading; on merge the idempotent Release workflow publishes the crate, tag, and `ghcr.io/developerinlondon/assay:0.17.4`.