### PR TITLE
feat: explicit approve, op-bound grants, approver audit on resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,14 @@
 
 All notable changes to Assay are documented here.
 
-## assay 0.18.0 — 2026-07-07
+## assay 0.17.5 — 2026-07-07
 
-### Changed
+### Fixed
 
 - **`assay_resume` requires an explicit `approve` decision.** The MCP tool previously defaulted an
   omitted `approve` to `true` — the authorization step for a suspended mutating operation could be
-  taken by accident. Omitting `approve` is now an invalid-arguments error, never an approval. The
-  input schema already declared the field required; the handler now enforces it. (#195)
+  taken by accident. The input schema has always declared the field required; the lenient handler
+  was the bug, and omitting `approve` is now an invalid-arguments error, never an approval. (#195)
 - **Approval grants are bound to the operation they approved.** A resume grant used to be matched
   by sequence index alone: because a resume re-runs the script from the top, a run whose control
   flow shifted between suspend and replay (e.g. a read that returned a different value the second
@@ -18,8 +18,9 @@ All notable changes to Assay are documented here.
   operation at index 0 changed since approval (approved 'http.post', got 'http.put')` — instead of
   executing an operation nobody approved. Grants travel to the re-run via the new
   `ASSAY_APPROVED_OPS` environment variable (a JSON array of `{index, op, approver?}` records) and
-  accumulate across the approval chain in the resume state. State files written by earlier
-  versions keep working; their existing grants simply carry no binding to enforce. (#196)
+  accumulate across the approval chain in the resume state. The gate is fail-closed: an approved
+  index with no op binding is refused outright, so index-only grants — including resume state
+  written by earlier versions — are never honored. (#196)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,33 @@
 
 All notable changes to Assay are documented here.
 
+## assay 0.18.0 — 2026-07-07
+
+### Changed
+
+- **`assay_resume` requires an explicit `approve` decision.** The MCP tool previously defaulted an
+  omitted `approve` to `true` — the authorization step for a suspended mutating operation could be
+  taken by accident. Omitting `approve` is now an invalid-arguments error, never an approval. The
+  input schema already declared the field required; the handler now enforces it. (#195)
+- **Approval grants are bound to the operation they approved.** A resume grant used to be matched
+  by sequence index alone: because a resume re-runs the script from the top, a run whose control
+  flow shifted between suspend and replay (e.g. a read that returned a different value the second
+  time) could spend the grant on a *different* mutating operation that landed on the same index.
+  Each grant now records the op it was issued for and the gate refuses terminally — `approval:
+  operation at index 0 changed since approval (approved 'http.post', got 'http.put')` — instead of
+  executing an operation nobody approved. Grants travel to the re-run via the new
+  `ASSAY_APPROVED_OPS` environment variable (a JSON array of `{index, op, approver?}` records) and
+  accumulate across the approval chain in the resume state. State files written by earlier
+  versions keep working; their existing grants simply carry no binding to enforce. (#196)
+
+### Added
+
+- **`approver` audit identity on resumes.** `assay_resume` (MCP) and `assay resume` (CLI,
+  `--approver`) accept an optional approver identity. It is recorded in the resume state's grant
+  records, logged with the resume decision, and echoed as a top-level `approver` field in the
+  result envelope. Intended for orchestrators that interpose a human decision between suspend and
+  resume and want the authorizer on the record. (#195)
+
 ## assay 0.17.4 — 2026-07-07
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,7 +338,7 @@ dependencies = [
 
 [[package]]
 name = "assay-lua"
-version = "0.18.0"
+version = "0.17.5"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,7 +338,7 @@ dependencies = [
 
 [[package]]
 name = "assay-lua"
-version = "0.17.4"
+version = "0.18.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/crates/assay/Cargo.toml
+++ b/crates/assay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-lua"
-version = "0.17.4"
+version = "0.18.0"
 categories = ["command-line-utilities", "development-tools::testing"]
 edition = "2024"
 homepage = "https://assay.rs"

--- a/crates/assay/Cargo.toml
+++ b/crates/assay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-lua"
-version = "0.18.0"
+version = "0.17.5"
 categories = ["command-line-utilities", "development-tools::testing"]
 edition = "2024"
 homepage = "https://assay.rs"

--- a/crates/assay/src/lua/builtins/approval.rs
+++ b/crates/assay/src/lua/builtins/approval.rs
@@ -7,7 +7,7 @@
 //! decision. A per-VM counter assigns the index and advances on every
 //! gated call, so successive resumes admit one more operation each.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -22,6 +22,9 @@ struct GateState {
     counter: AtomicU64,
     approved: HashSet<u64>,
     denied: Option<u64>,
+    /// Which operation each grant was issued for. A replay whose control
+    /// flow shifted must not spend an index's grant on a different op.
+    bindings: HashMap<u64, String>,
 }
 
 pub fn apply(lua: &Lua, config: &ApprovalConfig) -> mlua::Result<()> {
@@ -29,6 +32,11 @@ pub fn apply(lua: &Lua, config: &ApprovalConfig) -> mlua::Result<()> {
         counter: AtomicU64::new(0),
         approved: config.approved_indices.iter().copied().collect(),
         denied: config.denied_index,
+        bindings: config
+            .approved_ops
+            .iter()
+            .map(|entry| (entry.index, entry.op.clone()))
+            .collect(),
     });
     for path in BLOCKED_FUNCTIONS {
         gate_function(lua, path, &state)?;
@@ -51,6 +59,17 @@ fn gate_decision(state: &GateState, op: &str, summary: &str) -> mlua::Result<()>
         return Err(mlua::Error::runtime(format!("approval: {op} denied")));
     }
     if state.approved.contains(&index) {
+        // A grant is bound to the op it was approved for; a replay that
+        // reaches a different op at this index fails terminally rather
+        // than executing an operation nobody approved.
+        if let Some(expected) = state.bindings.get(&index)
+            && expected != op
+        {
+            return Err(mlua::Error::runtime(format!(
+                "approval: operation at index {index} changed since approval \
+                 (approved '{expected}', got '{op}')"
+            )));
+        }
         return Ok(());
     }
     Err(approval_request(op, summary, index))

--- a/crates/assay/src/lua/builtins/approval.rs
+++ b/crates/assay/src/lua/builtins/approval.rs
@@ -59,18 +59,21 @@ fn gate_decision(state: &GateState, op: &str, summary: &str) -> mlua::Result<()>
         return Err(mlua::Error::runtime(format!("approval: {op} denied")));
     }
     if state.approved.contains(&index) {
-        // A grant is bound to the op it was approved for; a replay that
-        // reaches a different op at this index fails terminally rather
-        // than executing an operation nobody approved.
-        if let Some(expected) = state.bindings.get(&index)
-            && expected != op
-        {
-            return Err(mlua::Error::runtime(format!(
+        // Every grant is bound to the op it was approved for — a grant
+        // with no binding is refused outright, and a replay that reaches
+        // a different op at this index fails terminally rather than
+        // executing an operation nobody approved.
+        return match state.bindings.get(&index) {
+            Some(expected) if expected == op => Ok(()),
+            Some(expected) => Err(mlua::Error::runtime(format!(
                 "approval: operation at index {index} changed since approval \
                  (approved '{expected}', got '{op}')"
-            )));
-        }
-        return Ok(());
+            ))),
+            None => Err(mlua::Error::runtime(format!(
+                "approval: no operation binding for approved index {index} \
+                 ('{op}') — refusing"
+            ))),
+        };
     }
     Err(approval_request(op, summary, index))
 }

--- a/crates/assay/src/lua/builtins/approval.rs
+++ b/crates/assay/src/lua/builtins/approval.rs
@@ -14,7 +14,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use mlua::{Lua, MultiValue, Table, Value};
 
 use super::gated::{BLOCKED_FUNCTIONS, BLOCKED_TABLES, is_gated_http_verb};
-use crate::lua::{APPROVAL_REQUEST_PREFIX, ApprovalConfig};
+use crate::lua::{APPROVAL_REQUEST_PREFIX, ApprovalConfig, approved_ops_from_env};
 
 const SUMMARY_CAP: usize = 200;
 
@@ -32,10 +32,12 @@ pub fn apply(lua: &Lua, config: &ApprovalConfig) -> mlua::Result<()> {
         counter: AtomicU64::new(0),
         approved: config.approved_indices.iter().copied().collect(),
         denied: config.denied_index,
-        bindings: config
-            .approved_ops
-            .iter()
-            .map(|entry| (entry.index, entry.op.clone()))
+        // Bindings arrive via ASSAY_APPROVED_OPS (crate-internal transport
+        // set by the resume machinery), keeping the public ApprovalConfig
+        // API unchanged.
+        bindings: approved_ops_from_env()
+            .into_iter()
+            .map(|entry| (entry.index, entry.op))
             .collect(),
     });
     for path in BLOCKED_FUNCTIONS {

--- a/crates/assay/src/lua/mod.rs
+++ b/crates/assay/src/lua/mod.rs
@@ -90,22 +90,33 @@ impl ExecMode {
 /// operation descriptor that was actually approved (e.g. `http.post`),
 /// and — for audit — who authorized it, when the caller supplied an
 /// identity. Serialized into resume state and the re-run environment.
+/// Crate-internal: travels via `ASSAY_APPROVED_OPS`, never the public
+/// `ApprovalConfig` API.
 #[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
-pub struct ApprovedOp {
+pub(crate) struct ApprovedOp {
     pub index: u64,
     pub op: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub approver: Option<String>,
 }
 
+/// Resolve the op bindings for this run's grants from the environment
+/// (set by the resume machinery). Empty when absent or malformed —
+/// the approval gate then refuses every index-only grant, fail-closed.
+pub(crate) fn approved_ops_from_env() -> Vec<ApprovedOp> {
+    std::env::var(APPROVED_OPS_ENV)
+        .ok()
+        .and_then(|raw| serde_json::from_str::<Vec<ApprovedOp>>(&raw).ok())
+        .unwrap_or_default()
+}
+
 /// Per-run approval state consumed by the approval gate: which operation
-/// indices are pre-approved for this run, which single index (if any)
-/// must fail terminally, and the op bindings the grants were issued for.
+/// indices are pre-approved for this run and which single index (if any)
+/// must fail terminally.
 #[derive(Clone, Debug, Default)]
 pub struct ApprovalConfig {
     pub approved_indices: Vec<u64>,
     pub denied_index: Option<u64>,
-    pub approved_ops: Vec<ApprovedOp>,
 }
 
 /// Resolve the approval set + denied index from the environment. Empty
@@ -119,14 +130,9 @@ pub fn approval_config_from_env() -> ApprovalConfig {
     let denied_index = std::env::var(DENIED_INDEX_ENV)
         .ok()
         .and_then(|raw| raw.trim().parse::<u64>().ok());
-    let approved_ops = std::env::var(APPROVED_OPS_ENV)
-        .ok()
-        .and_then(|raw| serde_json::from_str::<Vec<ApprovedOp>>(&raw).ok())
-        .unwrap_or_default();
     ApprovalConfig {
         approved_indices,
         denied_index,
-        approved_ops,
     }
 }
 

--- a/crates/assay/src/lua/mod.rs
+++ b/crates/assay/src/lua/mod.rs
@@ -49,6 +49,12 @@ pub(crate) const APPROVED_INDICES_ENV: &str = "ASSAY_APPROVED_INDICES";
 /// re-run (set by the resume machinery when a decision is `no`).
 pub(crate) const DENIED_INDEX_ENV: &str = "ASSAY_DENIED_INDEX";
 
+/// JSON array of `ApprovedOp` records for an approval-mode re-run (set by
+/// the resume machinery). Binds each approved index to the operation that
+/// was approved, so a replay whose control flow shifted cannot spend a
+/// grant on a different operation.
+pub(crate) const APPROVED_OPS_ENV: &str = "ASSAY_APPROVED_OPS";
+
 /// Prefix that marks a runtime error as an approval request. The tool-mode
 /// runner extracts the JSON payload that follows it to suspend the run.
 pub(crate) const APPROVAL_REQUEST_PREFIX: &str = "__assay_approval_request__:";
@@ -80,13 +86,26 @@ impl ExecMode {
     }
 }
 
+/// One granted approval: the operation index it was issued for, the
+/// operation descriptor that was actually approved (e.g. `http.post`),
+/// and — for audit — who authorized it, when the caller supplied an
+/// identity. Serialized into resume state and the re-run environment.
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize)]
+pub struct ApprovedOp {
+    pub index: u64,
+    pub op: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub approver: Option<String>,
+}
+
 /// Per-run approval state consumed by the approval gate: which operation
-/// indices are pre-approved for this run and which single index (if any)
-/// must fail terminally.
+/// indices are pre-approved for this run, which single index (if any)
+/// must fail terminally, and the op bindings the grants were issued for.
 #[derive(Clone, Debug, Default)]
 pub struct ApprovalConfig {
     pub approved_indices: Vec<u64>,
     pub denied_index: Option<u64>,
+    pub approved_ops: Vec<ApprovedOp>,
 }
 
 /// Resolve the approval set + denied index from the environment. Empty
@@ -100,9 +119,14 @@ pub fn approval_config_from_env() -> ApprovalConfig {
     let denied_index = std::env::var(DENIED_INDEX_ENV)
         .ok()
         .and_then(|raw| raw.trim().parse::<u64>().ok());
+    let approved_ops = std::env::var(APPROVED_OPS_ENV)
+        .ok()
+        .and_then(|raw| serde_json::from_str::<Vec<ApprovedOp>>(&raw).ok())
+        .unwrap_or_default();
     ApprovalConfig {
         approved_indices,
         denied_index,
+        approved_ops,
     }
 }
 

--- a/crates/assay/src/main.rs
+++ b/crates/assay/src/main.rs
@@ -107,6 +107,10 @@ enum Commands {
         approve: String,
         #[arg(long, default_value = "3600")]
         resume_ttl: Option<u64>,
+        /// Identity of whoever authorized this decision, recorded for
+        /// audit in the resume state and echoed in the result envelope.
+        #[arg(long)]
+        approver: Option<String>,
     },
     /// Manage workflows
     Workflow {
@@ -501,6 +505,10 @@ struct ResumeState {
     summary: Option<String>,
     #[serde(default)]
     script_args: Vec<String>,
+    /// Every grant issued so far in this run's approval chain: the index,
+    /// the op it was approved for, and (when supplied) who approved it.
+    #[serde(default)]
+    approved_ops: Vec<lua::ApprovedOp>,
 }
 
 #[tokio::main]
@@ -562,7 +570,10 @@ async fn main() -> ExitCode {
             token,
             approve,
             resume_ttl,
-        }) => resume_tool_execution(&token, &approve, resume_ttl, readonly).await,
+            approver,
+        }) => {
+            resume_tool_execution(&token, &approve, resume_ttl, readonly, approver.as_deref()).await
+        }
         Some(Commands::Workflow { global, command }) => {
             let opts = match cli::GlobalOpts::resolve(global.as_flags()) {
                 Ok(o) => o,
@@ -1029,6 +1040,7 @@ async fn execute_tool_mode(
                     request,
                     exec_mode,
                     &approval.approved_indices,
+                    &approval.approved_ops,
                     &script_args,
                 ) {
                     Ok(requires_approval) => ToolModeOutcome {
@@ -1069,6 +1081,7 @@ async fn resume_tool_outcome(
     approve: &str,
     resume_ttl: Option<u64>,
     readonly: bool,
+    approver: Option<&str>,
 ) -> ToolModeOutcome {
     let err_outcome = |message: String| ToolModeOutcome {
         envelope: build_tool_error("error", message, readonly),
@@ -1122,15 +1135,35 @@ async fn resume_tool_outcome(
         .env("ASSAY_APPROVAL_RESULT", approve)
         .env("ASSAY_STATE_DIR", &state_dir);
 
+    info!(
+        decision = approve,
+        approver = approver.unwrap_or("-"),
+        op = state.op.as_deref().unwrap_or("-"),
+        index = ?state.pending_index,
+        "resume decision"
+    );
+
     if state.mode.as_deref() == Some("approval") {
         command.env(lua::APPROVAL_ENV, "1");
         let mut approved = state.approved_indices.clone();
+        let mut approved_ops = state.approved_ops.clone();
         match approve {
             "yes" => {
-                if let Some(idx) = state.pending_index
-                    && !approved.contains(&idx)
-                {
-                    approved.push(idx);
+                if let Some(idx) = state.pending_index {
+                    if !approved.contains(&idx) {
+                        approved.push(idx);
+                    }
+                    // Bind the grant to the op it was issued for, so the
+                    // re-run cannot spend it on a different operation.
+                    if let Some(op) = state.op.clone()
+                        && !approved_ops.iter().any(|entry| entry.index == idx)
+                    {
+                        approved_ops.push(lua::ApprovedOp {
+                            index: idx,
+                            op,
+                            approver: approver.map(str::to_owned),
+                        });
+                    }
                 }
             }
             _ => {
@@ -1145,6 +1178,11 @@ async fn resume_tool_outcome(
             .collect::<Vec<_>>()
             .join(",");
         command.env(lua::APPROVED_INDICES_ENV, joined);
+        if !approved_ops.is_empty()
+            && let Ok(serialized) = serde_json::to_string(&approved_ops)
+        {
+            command.env(lua::APPROVED_OPS_ENV, serialized);
+        }
     } else if readonly {
         command.env(lua::READONLY_ENV, "1");
     }
@@ -1165,6 +1203,19 @@ async fn resume_tool_outcome(
         .ok()
         .and_then(|json| json.get("status").cloned())
         .and_then(|status| status.as_str().map(str::to_owned));
+
+    // Echo the audit identity in the envelope the caller sees. Best-effort:
+    // a non-object envelope is passed through untouched.
+    let envelope = match approver {
+        Some(who) => match serde_json::from_str::<JsonValue>(&envelope) {
+            Ok(JsonValue::Object(mut map)) => {
+                map.insert("approver".to_string(), JsonValue::String(who.to_string()));
+                serde_json::to_string(&JsonValue::Object(map)).unwrap_or(envelope)
+            }
+            _ => envelope,
+        },
+        None => envelope,
+    };
 
     // Drop the token once the run reaches a terminal state; a still-pending
     // approval keeps it for the next resume. Best-effort: a cleanup hiccup
@@ -1189,8 +1240,9 @@ async fn resume_tool_execution(
     approve: &str,
     resume_ttl: Option<u64>,
     readonly: bool,
+    approver: Option<&str>,
 ) -> ExitCode {
-    let outcome = resume_tool_outcome(token, approve, resume_ttl, readonly).await;
+    let outcome = resume_tool_outcome(token, approve, resume_ttl, readonly, approver).await;
     if !outcome.envelope.is_empty() {
         print!("{}", outcome.envelope);
     }
@@ -1273,6 +1325,7 @@ fn persist_resume_state(
     request: ApprovalRequestPayload,
     mode: lua::ExecMode,
     approved_indices: &[u64],
+    approved_ops: &[lua::ApprovedOp],
     script_args: &[String],
 ) -> Result<JsonValue, String> {
     let state_dir = resolve_state_dir()?;
@@ -1302,6 +1355,7 @@ fn persist_resume_state(
         op: request.op.clone(),
         summary: request.summary.clone(),
         script_args: script_args.to_vec(),
+        approved_ops: approved_ops.to_vec(),
     };
 
     let serialized =

--- a/crates/assay/src/main.rs
+++ b/crates/assay/src/main.rs
@@ -1040,7 +1040,7 @@ async fn execute_tool_mode(
                     request,
                     exec_mode,
                     &approval.approved_indices,
-                    &approval.approved_ops,
+                    &lua::approved_ops_from_env(),
                     &script_args,
                 ) {
                     Ok(requires_approval) => ToolModeOutcome {

--- a/crates/assay/src/mcp.rs
+++ b/crates/assay/src/mcp.rs
@@ -187,8 +187,11 @@ fn assay_resume_tool() -> JsonValue {
                 },
                 "approve": {
                     "type": "boolean",
-                    "default": true,
-                    "description": "Approve the pending operation (true) or deny it (false). Denying fails that operation in the resumed run.",
+                    "description": "Approve the pending operation (true) or deny it (false). Required — the decision must be explicit; omitting it is an error, never an approval. Denying fails that operation in the resumed run.",
+                },
+                "approver": {
+                    "type": "string",
+                    "description": "Optional identity of the human or system that authorized this decision, recorded for audit in the resume state and echoed in the result envelope.",
                 },
             },
             "required": ["token", "approve"],
@@ -291,17 +294,23 @@ async fn call_assay_resume(arguments: &JsonValue) -> Result<JsonValue, String> {
         .and_then(JsonValue::as_str)
         .ok_or_else(|| "assay_resume requires a 'token' string argument".to_string())?;
 
-    // Default to approving: the common case is proceeding through the gate.
+    // The resume IS the authorization step for a suspended mutating op —
+    // the decision must be explicit. No default: an omitted `approve` is an
+    // argument error, never an approval.
     let approve = arguments
         .get("approve")
         .and_then(JsonValue::as_bool)
-        .unwrap_or(true);
+        .ok_or_else(|| {
+            "assay_resume requires an explicit 'approve' boolean argument".to_string()
+        })?;
     let decision = if approve { "yes" } else { "no" };
+
+    let approver = arguments.get("approver").and_then(JsonValue::as_str);
 
     // readonly=false: an approval-mode run is what suspends, so this only ever
     // resumes an approval token; the flag merely shapes an error envelope's
     // `readonly` field, which is not meaningful for a resume.
-    let outcome = crate::resume_tool_outcome(token, decision, None, false).await;
+    let outcome = crate::resume_tool_outcome(token, decision, None, false, approver).await;
 
     let is_error = !matches!(outcome.status, "ok" | "needs_approval");
     Ok(tool_text_content(outcome.envelope, is_error))

--- a/crates/assay/tests/approval_mode.rs
+++ b/crates/assay/tests/approval_mode.rs
@@ -55,6 +55,7 @@ fn scrub(cmd: &mut Command) {
     for key in [
         "ASSAY_APPROVAL",
         "ASSAY_APPROVED_INDICES",
+        "ASSAY_APPROVED_OPS",
         "ASSAY_DENIED_INDEX",
         "ASSAY_READONLY",
         "ASSAY_MODE",
@@ -362,4 +363,82 @@ fn modules_reports_approval_mode() {
     assert!(out.status.success());
     let stdout = String::from_utf8_lossy(&out.stdout);
     assert!(stdout.contains("approval mode active"), "stdout: {stdout}");
+}
+
+// ── (h) grants are bound to the op they approved ───────────────────────
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn resume_grant_cannot_be_spent_on_a_different_op() {
+    // An ungated http.get steers control flow: it returns "first" once,
+    // then "second". Run 1 suspends on http.post at index 0 and the
+    // approval binds that grant to http.post. The replay's http.get now
+    // returns "second", so a different mutating op (http.put) reaches
+    // index 0 — the bound grant must refuse it rather than execute an
+    // operation nobody approved.
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/flag"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("first"))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/flag"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("second"))
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/submit"))
+        .respond_with(ResponseTemplate::new(201))
+        .mount(&server)
+        .await;
+    Mock::given(method("PUT"))
+        .and(path("/submit"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&server)
+        .await;
+
+    let dir = unique_dir("assay-approval-binding");
+    let state_dir = dir.join("state");
+    let script = write_script(
+        &dir,
+        "shifty.lua",
+        &format!(
+            r#"local flag = http.get("{uri}/flag")
+if flag.body == "first" then
+  local r = http.post("{uri}/submit", "{{}}")
+  return {{ status = r.status }}
+else
+  local r = http.put("{uri}/submit", "{{}}")
+  return {{ status = r.status }}
+end"#,
+            uri = server.uri()
+        ),
+    );
+
+    let out = run_blocking(tool_cmd(&script, &["--approval-mode"], &state_dir)).await;
+    let json = stdout_json(&out);
+    assert_eq!(json["status"], "needs_approval", "first run: {json}");
+    assert_eq!(json["requiresApproval"]["op"], "http.post");
+    let token = json["requiresApproval"]["resumeToken"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let out = run_blocking(resume_cmd(&token, "yes", &state_dir)).await;
+    let json = stdout_json(&out);
+    assert_eq!(json["status"], "error", "shifted op must not run: {json}");
+    let err = json["error"].as_str().unwrap();
+    assert!(err.contains("changed since approval"), "error: {err}");
+    assert!(
+        err.contains("http.post") && err.contains("http.put"),
+        "error names both ops: {err}"
+    );
+
+    // Neither mutation ever reached the server — only the steering GETs.
+    let hits = server.received_requests().await.unwrap();
+    assert!(
+        hits.iter().all(|r| !r.url.path().ends_with("/submit")),
+        "no mutation may reach the server"
+    );
 }

--- a/crates/assay/tests/approval_mode.rs
+++ b/crates/assay/tests/approval_mode.rs
@@ -442,3 +442,32 @@ end"#,
         "no mutation may reach the server"
     );
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn approved_index_without_op_binding_is_refused() {
+    // The gate is fail-closed: an index-only grant (no ASSAY_APPROVED_OPS
+    // binding, e.g. hand-rolled env or pre-binding resume state) must be
+    // refused, never executed.
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/submit"))
+        .respond_with(ResponseTemplate::new(201))
+        .mount(&server)
+        .await;
+
+    let dir = unique_dir("assay-approval-unbound");
+    let state_dir = dir.join("state");
+    let script = post_script(&dir, "post.lua", &server.uri());
+
+    let mut cmd = tool_cmd(&script, &["--approval-mode"], &state_dir);
+    cmd.env("ASSAY_APPROVED_INDICES", "0");
+    let out = run_blocking(cmd).await;
+    let json = stdout_json(&out);
+    assert_eq!(json["status"], "error", "unbound grant must refuse: {json}");
+    let err = json["error"].as_str().unwrap();
+    assert!(
+        err.contains("no operation binding"),
+        "error explains the refusal: {err}"
+    );
+    assert!(server.received_requests().await.unwrap().is_empty());
+}

--- a/crates/assay/tests/mcp_serve.rs
+++ b/crates/assay/tests/mcp_serve.rs
@@ -308,6 +308,15 @@ fn tools_list_includes_assay_resume() {
         props["approve"].is_object(),
         "resume needs an approve arg: {resume}"
     );
+    assert!(
+        props["approver"].is_object(),
+        "resume offers an approver audit arg: {resume}"
+    );
+    let required = resume["inputSchema"]["required"].as_array().unwrap();
+    assert!(
+        required.contains(&json!("approve")),
+        "approve must be required: {resume}"
+    );
 }
 
 #[test]
@@ -363,6 +372,60 @@ fn assay_resume_rejects_an_unknown_token() {
         text_content(result).contains("invalid resume token"),
         "should explain the bad token: {result}"
     );
+}
+
+#[test]
+fn assay_resume_requires_an_explicit_approve() {
+    let mut server = McpServer::start();
+    server.initialize();
+
+    // No `approve` at all: the decision may never be defaulted — this must
+    // fail as an argument error before the token is even looked at.
+    let resp = server.call_tool(
+        "assay_resume",
+        json!({ "token": "deadbeefdeadbeefdeadbeefdeadbeef" }),
+    );
+    let result = &resp["result"];
+    assert_eq!(
+        result["isError"],
+        json!(true),
+        "omitted approve must error: {result}"
+    );
+    assert!(
+        text_content(result).contains("explicit 'approve'"),
+        "should demand the explicit decision: {result}"
+    );
+}
+
+#[test]
+fn assay_resume_echoes_the_approver_identity() {
+    let mut server = McpServer::start();
+    server.initialize();
+
+    let path =
+        std::env::temp_dir().join(format!("assay-mcp-approval-audit-{}", std::process::id()));
+    let _ = std::fs::remove_file(&path);
+    let path_lua = path.to_str().unwrap().replace('\\', "\\\\");
+    let script = format!(r#"fs.write("{path_lua}", "x"); return "done""#);
+
+    let run = server.call_tool("assay_run", json!({ "script": script, "mode": "approval" }));
+    let envelope: Value = serde_json::from_str(text_content(&run["result"])).unwrap();
+    let token = envelope["requiresApproval"]["resumeToken"]
+        .as_str()
+        .unwrap_or_else(|| panic!("no resumeToken in {envelope}"));
+
+    let resume = server.call_tool(
+        "assay_resume",
+        json!({ "token": token, "approve": true, "approver": "alice@example.com" }),
+    );
+    let done: Value = serde_json::from_str(text_content(&resume["result"])).unwrap();
+    assert_eq!(done["status"], "ok", "resumed envelope: {done}");
+    assert_eq!(
+        done["approver"], "alice@example.com",
+        "envelope must carry the audit identity: {done}"
+    );
+
+    let _ = std::fs::remove_file(&path);
 }
 
 #[test]


### PR DESCRIPTION
## What

Hardens the approval-mode resume flow — the authorization step for suspended mutating operations. Closes #195, closes #196. Bumps to **0.17.5** (fixes + hardening + additive audit).

### Fixed
- **`assay_resume` requires an explicit `approve`.** Previously an omitted `approve` defaulted to `true`, so the authorization could be taken by accident. The schema has always declared the field required; the lenient handler was the bug. Now an invalid-arguments error.

### Changed
- **Grants are bound to the op they approved, fail-closed.** Resume re-runs the script from the top and grants were matched by sequence index alone — a replay whose control flow shifted (e.g. a read returning a different value) could spend a grant on a *different* mutating op at the same index. Each grant now records its op; the gate refuses terminally on mismatch:
  `approval: operation at index 0 changed since approval (approved 'http.post', got 'http.put')`
  and refuses outright when an approved index carries no binding, so index-only grants — including any pre-binding resume state — are never honored. Grants travel via the new `ASSAY_APPROVED_OPS` env var (JSON array of `{index, op, approver?}`) and accumulate across the approval chain.

### Added
- **`approver` audit identity** on `assay_resume` (MCP) and `assay resume --approver` (CLI): recorded in the resume state's grants, logged with the decision, echoed as a top-level `approver` field in the result envelope.

## Tests
- `resume_grant_cannot_be_spent_on_a_different_op` — e2e reproduction of the index-shift vulnerability: wiremock steers control flow between runs; the bound grant refuses the shifted op and no mutation reaches the server.
- `approved_index_without_op_binding_is_refused` — the fail-closed invariant: an index-only grant refuses with `no operation binding`, nothing executes.
- `assay_resume_requires_an_explicit_approve` — omitted `approve` errors before the token is even looked at.
- `assay_resume_echoes_the_approver_identity` — audit field round-trips through the envelope.
- Schema test extended: `approver` advertised, `approve` in `required`.

All approval_mode (10), mcp_serve (15), tool_mode (16), cli_subcommands (13) tests pass; clippy clean.