### PR TITLE
fix(workflow): heartbeat-timeout reaper requeues retryable activities; catch never-heartbeated claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to Assay are documented here.
 
+## assay-workflow 0.4.1 — 2026-07-10
+
+### Fixed
+
+- **Heartbeat-timeout reaper re-queues instead of wedging the run.** When a RUNNING activity's
+  heartbeat expired with attempts remaining, the health monitor terminally FAILED it — no requeue,
+  no `ActivityFailed` event, no dispatch wake — so the parent workflow sat RUNNING forever (and with
+  `overlap_policy: "skip"`, every subsequent fire of that schedule was skipped). The reaper now
+  re-queues with the same exponential backoff `/fail` uses; the exhausted path still terminally
+  fails the activity and the workflow.
+- **Claims that die before their first heartbeat now time out.** `get_timed_out_activities` required
+  `last_heartbeat IS NOT NULL`, so a worker that crashed between claim and first beat was invisible
+  to the reaper. The claim time (`started_at`) is now the baseline until a heartbeat arrives.
+- New `health::check_health_at(store, now)` seam so the reaper is integration-testable
+  deterministically; regression tests pin all three paths on both backends.
+
+## assay-engine 0.5.5 — 2026-07-10
+
+### Fixed
+
+- Rebuild on assay-workflow 0.4.1 — heartbeat-timeout reaper re-queues retryable activities and
+  catches never-heartbeated claims (see above).
+
 ## assay 0.17.6 — 2026-07-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,7 +309,7 @@ dependencies = [
 
 [[package]]
 name = "assay-engine"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "anyhow",
  "assay-auth",
@@ -426,7 +426,7 @@ dependencies = [
 
 [[package]]
 name = "assay-workflow"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "assay-domain",

--- a/crates/assay-engine/Cargo.toml
+++ b/crates/assay-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-engine"
-version = "0.5.4"
+version = "0.5.5"
 categories = ["asynchronous", "database", "web-programming::http-server"]
 edition = "2024"
 keywords = ["workflow", "auth", "oidc", "zanzibar", "postgres"]

--- a/crates/assay-workflow/Cargo.toml
+++ b/crates/assay-workflow/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "assay-workflow"
-version = "0.4.0"
+version = "0.4.1"
 categories = ["asynchronous", "database"]
 edition = "2024"
 keywords = ["workflow", "durable-execution", "orchestration", "task-queue"]

--- a/crates/assay-workflow/src/health.rs
+++ b/crates/assay-workflow/src/health.rs
@@ -11,7 +11,8 @@ const HEALTH_CHECK_SECS: u64 = 30;
 const WORKER_TIMEOUT_SECS: f64 = 90.0;
 
 /// Detects dead workers and releases their claimed tasks.
-/// Detects timed-out activities and marks them failed for retry.
+/// Detects timed-out activities and re-queues them for retry (terminal
+/// failure + workflow FAILED once attempts are exhausted).
 /// Runs as a background tokio task.
 pub async fn run_health_monitor<S: WorkflowStore>(store: Arc<S>) {
     let mut tick = interval(Duration::from_secs(HEALTH_CHECK_SECS));
@@ -26,8 +27,12 @@ pub async fn run_health_monitor<S: WorkflowStore>(store: Arc<S>) {
 }
 
 async fn check_health<S: WorkflowStore>(store: &S) -> Result<()> {
-    let now = timestamp_now();
+    check_health_at(store, timestamp_now()).await
+}
 
+/// One health-check pass at an injected `now` — public so integration tests
+/// can drive the reaper deterministically without waiting on wall-clock.
+pub async fn check_health_at<S: WorkflowStore>(store: &S, now: f64) -> Result<()> {
     // 1. Remove dead workers (no heartbeat within timeout)
     let cutoff = now - WORKER_TIMEOUT_SECS;
     let dead_workers = store.remove_dead_workers(cutoff).await?;
@@ -41,12 +46,16 @@ async fn check_health<S: WorkflowStore>(store: &S) -> Result<()> {
         let act_id = act.id.unwrap_or(-1);
 
         if act.attempt < act.max_attempts {
-            // Retry: mark as failed so the engine can reschedule
+            // Retry: re-queue with the same exponential backoff fail_activity
+            // uses. (Terminally completing here used to wedge the run: the
+            // activity went FAILED with no event and no needs_dispatch, so the
+            // workflow sat RUNNING forever.)
+            let backoff = act.initial_interval_secs * act.backoff_coefficient.powi(act.attempt - 1);
             store
-                .complete_activity(act_id, None, Some("heartbeat timeout"), true)
+                .requeue_activity_for_retry(act_id, act.attempt + 1, now + backoff)
                 .await?;
             warn!(
-                "Activity {} timed out (attempt {}/{}), marked for retry",
+                "Activity {} heartbeat timed out (attempt {}/{}) — re-queued with backoff",
                 act.name, act.attempt, act.max_attempts
             );
         } else {

--- a/crates/assay-workflow/src/store/postgres.rs
+++ b/crates/assay-workflow/src/store/postgres.rs
@@ -832,8 +832,7 @@ impl WorkflowStore for PostgresStore {
              FROM workflow.activities
              WHERE status = 'RUNNING'
                AND heartbeat_timeout_secs IS NOT NULL
-               AND last_heartbeat IS NOT NULL
-               AND ($1 - last_heartbeat) > heartbeat_timeout_secs",
+               AND ($1 - COALESCE(last_heartbeat, started_at)) > heartbeat_timeout_secs",
         )
         .bind(now)
         .fetch_all(&self.pool)

--- a/crates/assay-workflow/src/store/sqlite.rs
+++ b/crates/assay-workflow/src/store/sqlite.rs
@@ -885,8 +885,7 @@ impl WorkflowStore for SqliteStore {
              FROM workflow.activities
              WHERE status = 'RUNNING'
                AND heartbeat_timeout_secs IS NOT NULL
-               AND last_heartbeat IS NOT NULL
-               AND (? - last_heartbeat) > heartbeat_timeout_secs",
+               AND (? - COALESCE(last_heartbeat, started_at)) > heartbeat_timeout_secs",
         )
         .bind(now)
         .fetch_all(&self.pool)

--- a/crates/assay-workflow/tests/common/harness.rs
+++ b/crates/assay-workflow/tests/common/harness.rs
@@ -210,6 +210,11 @@ impl Harness {
         dispatch!(self, s => s.get_timed_out_activities(now).await)
     }
 
+    /// One deterministic health-monitor pass at an injected `now`.
+    pub async fn check_health_at(&self, now: f64) -> anyhow::Result<()> {
+        dispatch!(self, s => assay_workflow::health::check_health_at(s, now).await)
+    }
+
     pub async fn cancel_pending_activities(&self, workflow_id: &str) -> anyhow::Result<u64> {
         dispatch!(self, s => s.cancel_pending_activities(workflow_id).await)
     }

--- a/crates/assay-workflow/tests/smoke_backends.rs
+++ b/crates/assay-workflow/tests/smoke_backends.rs
@@ -1461,3 +1461,135 @@ async fn leader_election(#[case] backend: Backend) {
 // replaces them. Equivalent coverage lives in that crate's pg_test +
 // sqlite_test suites (append_then_read_round_trip, subscribe_receives_*,
 // etc.).
+
+// ── Heartbeat-timeout reaper regressions ─────────────────────────────────────
+//
+// The reaper used to terminally FAIL a timed-out activity even with attempts
+// remaining (no requeue, no ActivityFailed event, no needs_dispatch), leaving
+// the parent workflow RUNNING forever; and it ignored activities that died
+// before their first heartbeat (last_heartbeat NULL). Both paths are pinned
+// here via the deterministic check_health_at seam.
+
+#[rstest]
+#[cfg_attr(
+    all(feature = "backend-postgres", target_os = "linux"),
+    case::pg(Backend::Postgres)
+)]
+#[cfg_attr(feature = "backend-sqlite", case::sqlite(Backend::Sqlite))]
+#[tokio::test(flavor = "multi_thread")]
+async fn reaper_requeues_timed_out_activity_with_attempts_left(#[case] backend: Backend) {
+    let h = backend.setup().await.expect("setup");
+    let wf_id = uid("wf-reap-rq");
+    h.create_workflow(&make_workflow(&wf_id, "main", "reap-q"))
+        .await
+        .unwrap();
+    let mut act = make_activity(&wf_id, 1, "reap-q");
+    act.heartbeat_timeout_secs = Some(30.0);
+    let id = h.create_activity(&act).await.unwrap();
+    h.claim_activity("reap-q", "worker-r")
+        .await
+        .unwrap()
+        .expect("claim");
+    h.heartbeat_activity(id, None).await.unwrap();
+    let hb = h
+        .get_activity(id)
+        .await
+        .unwrap()
+        .unwrap()
+        .last_heartbeat
+        .unwrap();
+
+    h.check_health_at(hb + 60.0).await.unwrap();
+
+    let requeued = h.get_activity(id).await.unwrap().unwrap();
+    assert_eq!(
+        requeued.status, "PENDING",
+        "timed-out activity with attempts left must be re-queued, not terminally failed"
+    );
+    assert_eq!(requeued.attempt, 2);
+    assert!(requeued.claimed_by.is_none());
+    let wf = h.get_workflow(&wf_id).await.unwrap().unwrap();
+    assert_ne!(
+        wf.status, "FAILED",
+        "workflow must survive a retryable timeout"
+    );
+}
+
+#[rstest]
+#[cfg_attr(
+    all(feature = "backend-postgres", target_os = "linux"),
+    case::pg(Backend::Postgres)
+)]
+#[cfg_attr(feature = "backend-sqlite", case::sqlite(Backend::Sqlite))]
+#[tokio::test(flavor = "multi_thread")]
+async fn reaper_catches_activity_that_never_heartbeated(#[case] backend: Backend) {
+    let h = backend.setup().await.expect("setup");
+    let wf_id = uid("wf-reap-nohb");
+    h.create_workflow(&make_workflow(&wf_id, "main", "nohb-q"))
+        .await
+        .unwrap();
+    let mut act = make_activity(&wf_id, 1, "nohb-q");
+    act.heartbeat_timeout_secs = Some(30.0);
+    let id = h.create_activity(&act).await.unwrap();
+    // Claim → RUNNING with last_heartbeat NULL (worker dies before first beat).
+    h.claim_activity("nohb-q", "worker-n")
+        .await
+        .unwrap()
+        .expect("claim");
+    let started = h
+        .get_activity(id)
+        .await
+        .unwrap()
+        .unwrap()
+        .started_at
+        .expect("claim sets started_at");
+
+    let fresh = h.get_timed_out_activities(started + 1.0).await.unwrap();
+    assert!(!fresh.iter().any(|a| a.id == Some(id)));
+    let stale = h.get_timed_out_activities(started + 60.0).await.unwrap();
+    assert!(
+        stale.iter().any(|a| a.id == Some(id)),
+        "a claim that never heartbeats must still time out (started_at baseline)"
+    );
+}
+
+#[rstest]
+#[cfg_attr(
+    all(feature = "backend-postgres", target_os = "linux"),
+    case::pg(Backend::Postgres)
+)]
+#[cfg_attr(feature = "backend-sqlite", case::sqlite(Backend::Sqlite))]
+#[tokio::test(flavor = "multi_thread")]
+async fn reaper_fails_workflow_when_attempts_exhausted(#[case] backend: Backend) {
+    let h = backend.setup().await.expect("setup");
+    let wf_id = uid("wf-reap-ex");
+    h.create_workflow(&make_workflow(&wf_id, "main", "ex-q"))
+        .await
+        .unwrap();
+    let mut act = make_activity(&wf_id, 1, "ex-q");
+    act.heartbeat_timeout_secs = Some(30.0);
+    act.max_attempts = 1;
+    let id = h.create_activity(&act).await.unwrap();
+    h.claim_activity("ex-q", "worker-e")
+        .await
+        .unwrap()
+        .expect("claim");
+    h.heartbeat_activity(id, None).await.unwrap();
+    let hb = h
+        .get_activity(id)
+        .await
+        .unwrap()
+        .unwrap()
+        .last_heartbeat
+        .unwrap();
+
+    h.check_health_at(hb + 60.0).await.unwrap();
+
+    let failed = h.get_activity(id).await.unwrap().unwrap();
+    assert_eq!(failed.status, "FAILED");
+    let wf = h.get_workflow(&wf_id).await.unwrap().unwrap();
+    assert_eq!(
+        wf.status, "FAILED",
+        "exhausted timeout must terminate the workflow"
+    );
+}


### PR DESCRIPTION
Two heartbeat-timeout bugs that together wedge a workflow permanently when a worker dies mid-activity:

- **Reaper wedge**: with attempts remaining, the health monitor terminally `FAILED` the activity via raw `complete_activity` — no requeue, no `ActivityFailed` event, no dispatch wake. The parent workflow sat `RUNNING` forever, and with `overlap_policy: "skip"` every subsequent scheduled fire was skipped for good. Now re-queues with the same exponential backoff `fail_activity` uses (exhausted path unchanged: terminal fail + workflow FAILED).
- **Invisible first-beat window**: `get_timed_out_activities` required `last_heartbeat IS NOT NULL`, so a worker crash between claim and first heartbeat was never reaped. `COALESCE(last_heartbeat, started_at)` in both stores.

Adds `health::check_health_at(store, now)` so the reaper is deterministically testable; 3 regression tests × both backends.

Versions: assay-workflow 0.4.1, assay-engine 0.5.5. Full assay-workflow suite green (123 pass).